### PR TITLE
Closing distance rewards

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "type": "python",
             "request": "launch",
             "program": "triforce.py",
-            "args": ["train", "dungeon1stalfos", "4096", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "2"],
+            "args": ["train", "dungeon1stalfos", "4096", "--render", "--debug-scenario","--verbose", "2"],
             "console": "integratedTerminal",
             "justMyCode": false
         },
@@ -27,7 +27,7 @@
             "type": "python",
             "request": "launch",
             "program": "triforce.py",
-            "args": ["train", "dungeon1combat", "4096", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "2"],
+            "args": ["train", "dungeon1combat", "4096", "--render", "--debug-scenario","--verbose", "2"],
             "console": "integratedTerminal",
             "justMyCode": false
         },
@@ -36,7 +36,7 @@
             "type": "python",
             "request": "launch",
             "program": "triforce.py",
-            "args": ["train", "gauntlet", "4096", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "2"],
+            "args": ["train", "gauntlet", "4096", "--render", "--debug-scenario","--verbose", "2"],
             "console": "integratedTerminal",
             "justMyCode": false
         },
@@ -45,7 +45,7 @@
             "type": "python",
             "request": "launch",
             "program": "triforce.py",
-            "args": ["evaluate", "gauntlet", "10", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "2"],
+            "args": ["evaluate", "gauntlet", "10", "--render", "--debug-scenario","--verbose", "2"],
             "console": "integratedTerminal",
             "justMyCode": false
         },
@@ -54,7 +54,7 @@
             "type": "python",
             "request": "launch",
             "program": "triforce.py",
-            "args": ["train", "dungeon1", "4096", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "1"],
+            "args": ["train", "dungeon1", "4096", "--render", "--debug-scenario","--verbose", "1"],
             "console": "integratedTerminal",
             "justMyCode": false
         },
@@ -63,7 +63,7 @@
             "type": "python",
             "request": "launch",
             "program": "triforce.py",
-            "args": ["evaluate", "dungeon1", "10", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "2"],
+            "args": ["evaluate", "dungeon1", "10", "--render", "--debug-scenario","--verbose", "2"],
             "console": "integratedTerminal",
             "justMyCode": false
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
             "justMyCode": false
         },
         {
+            "name": "Scenario: Dungeon 1 Stalfos Training",
+            "type": "python",
+            "request": "launch",
+            "program": "triforce.py",
+            "args": ["train", "dungeon1stalfos", "4096", "--render", "--debug-scenario", "--algorithm", "ppo", "--verbose", "2"],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
             "name": "Scenario: Dungeon 1 Combat Training",
             "type": "python",
             "request": "launch",

--- a/tests/ending_test.py
+++ b/tests/ending_test.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from triforce_lib import ZeldaGameplayCritic
+from triforce_lib.scenario_dungeon_combat import ZeldaDungeonCombatEndCondition
+from utilities import CriticWrapper, RewardRecorder
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from triforce_lib import ZeldaActionReplay
+
+def test_dungeon_combat_end():
+    recorder = RewardRecorder()
+
+    def wrapper(env):
+        return CriticWrapper(env, end_conditions=[ZeldaDungeonCombatEndCondition(recorder)])
+
+    replay = ZeldaActionReplay("1_44e.state", wrapper)
+    
+    replay.run_steps('llluuuullllllllllllllld')
+
+    _, _, terminated, truncated, info = replay.step('b')
+    assert not terminated
+    assert not truncated
+    assert info['beam_hits'] == 0
+    assert info['step_kills'] == 3
+    assert info['step_injuries'] == 0
+    assert info['action'] == 'item'
+
+    found = None
+    for i in range(100):
+        _, _, terminated, truncated, info = replay.step('r')
+        if terminated:
+            found = i
+            break
+    
+    assert found is not None

--- a/tests/hit_test.py
+++ b/tests/hit_test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 

--- a/tests/reward_test.py
+++ b/tests/reward_test.py
@@ -1,0 +1,81 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from triforce_lib import ZeldaGameplayCritic
+from utilities import CriticWrapper, RewardRecorder
+from triforce_lib import ZeldaActionReplay
+
+def test_wall_collision():
+    recorder = RewardRecorder()
+
+    def wrapper(env):
+        return CriticWrapper(env, critics=[ZeldaGameplayCritic(recorder)])
+
+    actions = ZeldaActionReplay("1_44e.state", wrapper)
+
+    # move under a block
+    actions.run_steps('llllll')
+    recorder.rewards.clear()
+
+    # step up to the block, we shouldn't get penalized here even though we don't fully move
+    actions.step('u')
+    
+    assert not [x for x in recorder.rewards if x[0] == 'penalty-wall-collision']
+
+    recorder.rewards.clear()
+
+    # now we are against a block, we should get penalized for moving up and not changing position
+    actions.step('u')
+
+    collisions = [x for x in recorder.rewards if x[0] == 'penalty-wall-collision']
+    assert len(collisions) == 1
+    source, reward = collisions[0]
+    assert source == 'penalty-wall-collision'
+    assert reward < 0
+
+
+def test_close_distance():
+    recorder = RewardRecorder()
+
+    def wrapper(env):
+        return CriticWrapper(env, critics=[ZeldaGameplayCritic(recorder)])
+
+    actions = ZeldaActionReplay("1_44e.state", wrapper)
+
+    # move under a block
+    actions.run_steps('ll')
+    assert len(recorder.rewards) == 1
+    name, reward = recorder.rewards[0]
+    assert name == "reward-close-distance"
+    assert reward > 0
+
+    recorder.rewards.clear()
+    actions.run_steps('r')
+    assert len(recorder.rewards) == 0
+
+def test_position():
+    # note the position may change for the other axis as link snaps to the grid
+    actions = ZeldaActionReplay("1_44e.state")
+    prev = actions.step('l')[-1]
+    assert prev['link_pos'] == (prev['link_x'], prev['link_y'])
+
+    curr = actions.step('l')[-1]
+    assert curr['link_pos'] == (curr['link_x'], curr['link_y'])
+    assert prev['link_x'] > curr['link_x']
+
+    prev = curr
+    curr = actions.step('u')[-1]
+    assert curr['link_pos'] == (curr['link_x'], curr['link_y'])
+    assert prev['link_y'] > curr['link_y']
+
+    prev = curr
+    curr = actions.step('d')[-1]
+    assert curr['link_pos'] == (curr['link_x'], curr['link_y'])
+    assert prev['link_y'] < curr['link_y']
+
+    prev = curr
+    curr = actions.step('r')[-1]
+    assert curr['link_pos'] == (curr['link_x'], curr['link_y'])
+    assert prev['link_x'] < curr['link_x']

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,0 +1,50 @@
+import gymnasium as gym
+
+class RewardRecorder:
+    def __init__(self):
+        self.rewards = []
+        self.ends = []
+
+    def report_reward(self, source, reward):
+        self.rewards.append((source, reward))
+
+    def report_ending(self, kind):
+        self.ends.append(kind)
+
+
+class CriticWrapper(gym.Wrapper):
+    """Wraps the environment to actually call our critics and end conditions."""
+    def __init__(self, env, critics=None, end_conditions=None):
+        super().__init__(env)
+
+        assert critics or end_conditions
+
+        self.critics = critics or []
+        self.end_conditions = end_conditions or []
+        self._last = None
+
+    def reset(self, **kwargs):
+        state = super().reset(**kwargs)
+
+        for c in self.critics:
+            c.clear()
+
+        for ec in self.end_conditions:
+            ec.clear()
+
+        self._last = None
+        return state
+    
+    def step(self, act):
+        obs, rewards, terminated, truncated, state = self.env.step(act)
+
+        if self._last is not None:
+            for c in self.critics:
+                rewards += c.critique_gameplay(self._last, state)
+
+            end = [x.is_scenario_ended(self._last, state) for x in self.end_conditions]
+            terminated = terminated or any((x[0] for x in end))
+            truncated = truncated or any((x[1] for x in end))
+
+        self._last = state
+        return obs, rewards, terminated, truncated, state

--- a/triforce.py
+++ b/triforce.py
@@ -13,7 +13,6 @@ def parse_args():
     parser.add_argument("iterations", type=int, help="Number of iterations to run.")
 
     parser.add_argument("--verbose", type=int, default=0, help="Verbosity.")
-    parser.add_argument("--algorithm", type=str, default="ppo", choices=['ppo', 'a2c'], help="The algorithm to use.")
     parser.add_argument("--render", action='store_true', help="Render the environment.")
     parser.add_argument("--color", action='store_true', help="Record the environment.")
     parser.add_argument("--frame-stack", type=int, default=3, help="Number of frames to stack in the observation.")
@@ -44,7 +43,7 @@ def main():
     render_mode = 'human' if args.action == 'test' or args.action == 'evaluate' or args.render else None
     record = args.action == 'record'
     debug_scenario = args.debug_scenario or args.action == 'evaluate'
-    zelda_ml = ZeldaML(base_dir, args.scenario, args.algorithm, args.frame_stack, args.color, record=record, render_mode=render_mode, verbose=args.verbose, debug_scenario=debug_scenario, ent_coef=args.ent_coef)
+    zelda_ml = ZeldaML(base_dir, args.scenario, args.frame_stack, args.color, record=record, render_mode=render_mode, verbose=args.verbose, debug_scenario=debug_scenario, ent_coef=args.ent_coef)
 
     if args.load:
         zelda_ml.load(args.load)

--- a/triforce_lib/__init__.py
+++ b/triforce_lib/__init__.py
@@ -12,4 +12,12 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 retro.data.Integrations.add_custom_path(os.path.join(script_dir, 'custom_integrations'))
 
 # define the model surface area
-__all__ = [ ZeldaML.__name__, ZeldaScenario.__name__, ZeldaCritic.__name__, ZeldaEndCondition.__name__, ZeldaGameplayCritic.__name__, ZeldaEndCondition.__name__, ZeldaActionReplay.__name__]
+__all__ = [
+    ZeldaML.__name__,
+    ZeldaScenario.__name__,
+    ZeldaCritic.__name__,
+    ZeldaEndCondition.__name__,
+    ZeldaGameplayCritic.__name__,
+    ZeldaEndCondition.__name__,
+    ZeldaActionReplay.__name__
+    ]

--- a/triforce_lib/action_replay.py
+++ b/triforce_lib/action_replay.py
@@ -6,10 +6,12 @@ from .action_space import ZeldaActionSpace
 from .zelda_wrapper import ZeldaGameWrapper
 
 class ZeldaActionReplay:
-    def __init__(self, savestate, render_mode=None):
+    def __init__(self, savestate, wrapper=None, render_mode=None):
         env = retro.make(game='Zelda-NES', state=savestate, inttype=retro.data.Integrations.CUSTOM_ONLY, render_mode=render_mode)
         env = ZeldaGameWrapper(env, deterministic=True)
         env = ZeldaActionSpace(env)
+        if wrapper:
+            env = wrapper(env)
 
         self.map = {}
 

--- a/triforce_lib/action_replay.py
+++ b/triforce_lib/action_replay.py
@@ -2,14 +2,14 @@
 
 import retro
 
-from .action_space import ZeldaActionSpace
+from .action_space import ZeldaAttackOnlyActionSpace
 from .zelda_wrapper import ZeldaGameWrapper
 
 class ZeldaActionReplay:
     def __init__(self, savestate, wrapper=None, render_mode=None):
         env = retro.make(game='Zelda-NES', state=savestate, inttype=retro.data.Integrations.CUSTOM_ONLY, render_mode=render_mode)
         env = ZeldaGameWrapper(env, deterministic=True)
-        env = ZeldaActionSpace(env)
+        env = ZeldaAttackOnlyActionSpace(env)
         if wrapper:
             env = wrapper(env)
 

--- a/triforce_lib/action_space.py
+++ b/triforce_lib/action_space.py
@@ -1,12 +1,11 @@
 import gymnasium as gym
 import numpy as np
 
-class ZeldaActionSpace(gym.ActionWrapper):
+class ZeldaAttackOnlyActionSpace(gym.ActionWrapper):
     def __init__(self, env):
         super().__init__(env)
 
-        # currently do not allow the model to turn and act at the same time
-        self.actions = [['LEFT'], ['RIGHT'], ['UP'], ['DOWN'], ['A'], ['B']]
+        self.actions = [['LEFT'], ['RIGHT'], ['UP'], ['DOWN'], ['LEFT', 'A'], ['RIGHT', 'A'], ['UP', 'A'], ['DOWN', 'A']]
 
         assert isinstance(env.action_space, gym.spaces.MultiBinary)
 

--- a/triforce_lib/scenarios.json
+++ b/triforce_lib/scenarios.json
@@ -19,6 +19,21 @@
             "data" : {}
         },
         {
+            "name": "dungeon1stalfos",
+            "description": "Dungeon 1 Stalfos trainer",
+            "critics": ["ZeldaDungeonCombatCritic"],
+            "end_conditions": ["ZeldaDungeonCombatEndCondition"],
+            "level" : 1,
+            "start": ["1_74"],
+            "data":
+            {
+                "bombs" : 0,
+                "keys" : 0,
+                "hearts_and_containers" : 252,
+                "partial_hearts" : 254
+            }
+        },
+        {
             "name": "dungeon1combat",
             "description": "Dungeon 1 combat trainer",
             "critics": ["ZeldaDungeonCombatCritic"],

--- a/triforce_lib/zelda_wrapper.py
+++ b/triforce_lib/zelda_wrapper.py
@@ -71,6 +71,7 @@ class ZeldaGameWrapper(gym.Wrapper):
     
     def _reset_state(self):
         self._location = None
+        self._link_last_pos = None
         self._beams_already_active = False
         self._prev_enemies = None
         self._prev_health = None
@@ -103,6 +104,10 @@ class ZeldaGameWrapper(gym.Wrapper):
         
         location = (info['level'], info['location'])
         new_location = self._location != location
+        info['new_location'] = new_location
+
+        info['new_position'] = not new_location and self._link_last_pos is not None and self._link_last_pos != objects.link_pos
+        self._link_last_pos = objects.link_pos
 
         # only check beams and other state if we are in the same room:
         if new_location:

--- a/triforce_lib/zelda_wrapper.py
+++ b/triforce_lib/zelda_wrapper.py
@@ -245,7 +245,7 @@ class ZeldaGameWrapper(gym.Wrapper):
         return obs,terminated,truncated,info,rew
     
     def action_is_movement(self, act):
-        return any(act[4:8])
+        return any(act[4:8]) and not self.action_is_attack(act) and not self.action_is_item(act)
 
     def action_is_item(self, act):
         return act[0]

--- a/triforce_lib/zelda_wrapper.py
+++ b/triforce_lib/zelda_wrapper.py
@@ -39,7 +39,6 @@ class ZeldaObjectData:
             return None
         return self.obj_health[obj] >> 4
         
-
     def is_enemy(self, obj_id : int):
         return 1 <= obj_id <= 0x48
     
@@ -49,6 +48,7 @@ class ZeldaObjectData:
             if self.is_enemy(self.get_object_id(i)):
                 yield i
 
+    @property
     def enemy_count(self):
         return sum(1 for i in range(1, 0xb) if self.is_enemy(self.get_object_id(i)))
 
@@ -87,6 +87,7 @@ class ZeldaGameWrapper(gym.Wrapper):
 
         info['objects'] = objects
         info['beam_hits'] = 0
+        info['link_pos'] = objects.link_pos
 
         curr_enemy_health = None
         step_kills = 0

--- a/triforce_lib/zelda_wrapper.py
+++ b/triforce_lib/zelda_wrapper.py
@@ -14,7 +14,6 @@ from .zelda_game import get_bomb_state, is_mode_death, get_beam_state, is_mode_s
 
 class ZeldaObjectData:
     def __init__(self, ram):
-
         for table, (offset, size) in zelda_game_data.tables.items():
             self.__dict__[table] = ram[offset:offset+size]
 
@@ -82,6 +81,15 @@ class ZeldaGameWrapper(gym.Wrapper):
         # take the first step
         obs, rewards, terminated, truncated, info = self.act_and_wait(act)
 
+        if self.action_is_movement(act):
+            info['action'] = 'movement'
+
+        elif self.action_is_attack(act):
+            info['action'] = 'attack'
+
+        elif self.action_is_item(act):
+            info['action'] = 'item'
+            
         unwrapped = self.env.unwrapped
         objects = ZeldaObjectData(unwrapped.get_ram())
 
@@ -197,17 +205,14 @@ class ZeldaGameWrapper(gym.Wrapper):
             if self.action_is_movement(act):
                 obs, terminated, truncated, info, rew = self.skip(act, movement_cooldown)
                 rewards += rew
-                info['action'] = 'movement'
 
             elif self.action_is_attack(act):
                 obs, terminated, truncated, info, rew = self.skip(act, attack_cooldown)
                 rewards += rew
-                info['action'] = 'attack'
 
             elif self.action_is_item(act):
                 obs, terminated, truncated, info, rew = self.skip(act, item_cooldown)
                 rewards += rew
-                info['action'] = 'item'
 
             else:
                 raise Exception("Unknown action type")

--- a/triforce_lib/zeldaml.py
+++ b/triforce_lib/zeldaml.py
@@ -18,16 +18,15 @@ from .scenario import ZeldaScenario
 
 class ZeldaML:
     """The model and algorithm used to train the agent"""
-    def __init__(self, model_dir, scenario, algorithm, frame_stack, color, **kwargs):
+    def __init__(self, model_dir, scenario, frame_stack, color, **kwargs):
         """
         arguments:
             model_dir -- the directory to save the model
-            algorithm -- the algorithm to use (ppo, a2c, etc)
             color -- whether to use color or not (False = grayscale)
             frame_stack -- number of frames to stack in the observation
             kwargs -- additional arguments to pass to the environment creation, such as render_mode, etc
         """
-        algorithm = algorithm.lower()
+        algorithm = "ppo"
         
         if 'verbose' in kwargs:
             self.verbose = kwargs['verbose']

--- a/triforce_lib/zeldaml.py
+++ b/triforce_lib/zeldaml.py
@@ -11,7 +11,7 @@ from stable_baselines3.common.monitor import Monitor
 
 from .reward_reporter import RewardReporter
 from .zelda_wrapper import ZeldaGameWrapper
-from .action_space import ZeldaActionSpace
+from .action_space import ZeldaAttackOnlyActionSpace
 from .zelda_observation_wrapper import FrameCaptureWrapper, ZeldaObservationWrapper
 from .zelda_game_features import ZeldaGameFeatures
 from .scenario import ZeldaScenario
@@ -84,7 +84,7 @@ class ZeldaML:
         
         # Reduce the action space to only the actions we want the model to take (no need for A+B for example,
         # since that doesn't make any sense in Zelda)
-        env = ZeldaActionSpace(env)
+        env = ZeldaAttackOnlyActionSpace(env)
 
         # extract features from the game for the model, like whether link has beams or has keys and expose these as observations
         env = ZeldaGameFeatures(env)


### PR DESCRIPTION
- Added Stalfos scenario
- Removed --algorithm
- Changed action space to allow for picking a direction with an attack
- Updated rewards so that we properly detect “wall collisions” (ie moving into a wall but not going anywhere)
- Updated rewards so that we reward when link moves towards enemies (the reward is multiplied by the percentage of enemies he moves closer to)
- Removed “tile discovery” reward
- Fixed an issue where we didn’t properly end scenarios when enemy_count reached 0