### PR TITLE
Center the model's view on Link

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ stable_baselines3
 stable-baselines3[extra]
 matplotlib
 pytest
+opencv-python
+Pillow

--- a/triforce.py
+++ b/triforce.py
@@ -21,6 +21,7 @@ def parse_args():
     parser.add_argument("--load", help="Load a specific saved model.")
     parser.add_argument("--debug-scenario", action='store_true', help="Debug the scenario by printing out rewards.")
     parser.add_argument("--ent-coef", type=float, default=0.00, help="Entropy coefficient for the PPO algorithm.")
+    parser.add_argument("--obs-kind", choices=['gameplay', 'viewport', 'full'], default='viewport', help="The kind of observation to use.")
 
     try:
         args = parser.parse_args()
@@ -44,7 +45,7 @@ def main():
     render_mode = 'human' if args.action == 'test' or args.action == 'evaluate' or args.render else None
     record = args.action == 'record'
     debug_scenario = args.debug_scenario or args.action == 'evaluate'
-    zelda_ml = ZeldaML(base_dir, args.scenario, args.frame_stack, args.color, args.parallel, record=record, render_mode=render_mode, verbose=args.verbose, debug_scenario=debug_scenario, ent_coef=args.ent_coef, device="cuda")
+    zelda_ml = ZeldaML(base_dir, args.scenario, args.frame_stack, args.color, args.parallel, record=record, render_mode=render_mode, verbose=args.verbose, debug_scenario=debug_scenario, ent_coef=args.ent_coef, device="cuda", obs_kind=args.obs_kind)
 
     if args.load:
         zelda_ml.load(args.load)

--- a/triforce_lib/zelda_observation_wrapper.py
+++ b/triforce_lib/zelda_observation_wrapper.py
@@ -53,10 +53,10 @@ class ZeldaObservationWrapper(gym.Wrapper):
             self.observation_space = gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
 
         if self.viewport_size:
-            shape = self.env.observation_space.shape
+            shape = self.observation_space.shape
             new_shape = (self.viewport_size, self.viewport_size, shape[2])
             self.observation_space = gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
-            
+
         elif self.trim:
             shape = self.observation_space.shape
             new_shape = (shape[0] - self.trim, shape[1], shape[2])

--- a/triforce_lib/zelda_observation_wrapper.py
+++ b/triforce_lib/zelda_observation_wrapper.py
@@ -29,17 +29,21 @@ class FrameCaptureWrapper(gym.Wrapper):
         return observation, reward, terminated, truncated, info
 
 class ZeldaObservationWrapper(gym.Wrapper):
-    def __init__(self, env, frames, count, grayscale, gameplay_only):
+    def __init__(self, env, frames, n_frames, grayscale, kind):
         super().__init__(env)
         self.env = env
         self.frames = frames
-        self.n_stack = count
+        self.n_frames = n_frames
         self.observation_space = self.env.observation_space
         self.grayscale = grayscale
-        if gameplay_only:
+
+        if kind == 'gameplay' or kind == 'viewport':
             self.trim = gameplay_start_y
         else:
             self.trim = 0
+
+        if kind == 'viewport':
+            self.viewport_size = 64
 
         # modify the observation space to match the new shape
         # we also move the last channel count to be the first dimension to avoid a VecTransposeImage wrapper
@@ -48,61 +52,70 @@ class ZeldaObservationWrapper(gym.Wrapper):
             new_shape = (shape[0], shape[1], 1)
             self.observation_space = gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
 
-        if self.trim:
+        if self.viewport_size:
+            shape = self.env.observation_space.shape
+            new_shape = (self.viewport_size, self.viewport_size, shape[2])
+            self.observation_space = gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
+            
+        elif self.trim:
             shape = self.observation_space.shape
             new_shape = (shape[0] - self.trim, shape[1], shape[2])
             self.observation_space = gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
-
-        if count > 1:
+        
+        if n_frames > 1:
             shape = self.observation_space.shape
             # add a dimension for the number of frames we stack, so that the new shape is (h, w, ch, frames)
-            new_shape = (shape[0], shape[1], shape[2], count)
+            new_shape = (shape[0], shape[1], shape[2], n_frames)
             self.observation_space = gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
-
 
     def reset(self, **kwargs):
         _, info = self.env.reset(**kwargs)
-        return self._get_observation(), info
+        return self._get_observation(info), info
 
     def step(self, action):
         _, reward, terminated, truncated, info = self.env.step(action)
-        return self._get_observation(), reward, terminated, truncated, info
+        return self._get_observation(info), reward, terminated, truncated, info
 
-    def _get_observation(self):
+    def _get_observation(self, info):
         # Some Zelda enemies flash in and out every other frame, so we need to capture a sequence
         # of frames in a way that will capture the enemy in both states.  We also don't really want
         # to just use the last three frames, as that doesn't give a good sense of motion.  So we will
         # use some from the past, being sure to not always pick odd or even frames.
 
-        if self.n_stack > 1:
+        if self.n_frames > 1:
             stacked = []
             sequence = [1, 6, 15]
-            for i in range(self.n_stack):
+            for i in range(self.n_frames):
                 position = sequence[i]
                 frame = self.frames[-position]
-
-                if self.trim:
-                    frame = frame[self.trim:, :, :]
-
-                if self.grayscale:
-                    frame = np.dot(frame[..., :3], [0.299, 0.587, 0.114]).astype(np.uint8)
-                    # add the channel back to the frame so the shape is (height, width, 1)
-                    frame = np.expand_dims(frame, axis=-1)
-
+                frame = self.trim_normalize_grayscale(info, frame)
                 stacked.append(frame)
 
-            if self.n_stack > 1:
+            if self.n_frames > 1:
                 stacked_images = np.stack(stacked, axis=-1)
             return stacked_images
         else:
             frame = self.frames[-1]
-
-            if self.trim:
-                frame = frame[self.trim:, :, :]
-
-            if self.grayscale:
-                frame = np.dot(frame[..., :3], [0.299, 0.587, 0.114]).astype(np.uint8)
-                # add the channel back to the frame so the shape is (height, width, 1)
-                frame = np.expand_dims(frame, axis=-1)
-
+            frame = self.trim_normalize_grayscale(info, frame)
             return frame
+
+    def trim_normalize_grayscale(self, info, frame):
+        if self.trim or self.viewport_size:
+            frame = frame[self.trim:, :, :]
+
+        if self.viewport_size:
+            if 'link_pos' in info:
+                x, y = info.get('link_pos')
+                y -= self.trim
+            else:
+                x, y = 0, 0
+
+            half_vp = self.viewport_size // 2
+            padded_frame = np.pad(frame, ((half_vp, half_vp), (half_vp, half_vp), (0, 0)), mode='edge')
+            center_x, center_y = y + half_vp, x + half_vp
+            frame = padded_frame[center_x - half_vp:center_x + half_vp, center_y - half_vp:center_y + half_vp]
+
+        if self.grayscale:
+            frame = np.dot(frame[..., :3], [0.299, 0.587, 0.114]).astype(np.uint8)
+            frame = np.expand_dims(frame, axis=-1)
+        return frame

--- a/triforce_lib/zelda_observation_wrapper.py
+++ b/triforce_lib/zelda_observation_wrapper.py
@@ -100,7 +100,7 @@ class ZeldaObservationWrapper(gym.Wrapper):
             return frame
 
     def trim_normalize_grayscale(self, info, frame):
-        if self.trim or self.viewport_size:
+        if self.trim:
             frame = frame[self.trim:, :, :]
 
         if self.viewport_size:

--- a/triforce_lib/zeldaml.py
+++ b/triforce_lib/zeldaml.py
@@ -6,8 +6,6 @@ import numpy as np
 from stable_baselines3 import PPO, A2C
 from stable_baselines3.common.evaluation import evaluate_policy
 from stable_baselines3.common.callbacks import BaseCallback
-from stable_baselines3.common.results_plotter import load_results, ts2xy
-from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.vec_env import SubprocVecEnv
 
@@ -46,6 +44,12 @@ class ZeldaML:
             del kwargs['ent_coef']
         else:
             self.ent_coef = 0.0
+
+        if 'obs_kind' in kwargs:
+            obs_kind = kwargs['obs_kind']
+            del kwargs['obs_kind']
+        else:
+            obs_kind = 'viewport'
 
         if not isinstance(frame_stack, int) or frame_stack < 2:
             frame_stack = 1
@@ -87,8 +91,8 @@ class ZeldaML:
             env = ZeldaGameWrapper(env)
             
             # Frame stack and convert to grayscale if requested
-            env = ZeldaObservationWrapper(env, captured_frames, self.frame_stack, not self.color, gameplay_only=True)
-            
+            env = ZeldaObservationWrapper(env, captured_frames, self.frame_stack, not self.color, kind=obs_kind)
+
             # Reduce the action space to only the actions we want the model to take (no need for A+B for example,
             # since that doesn't make any sense in Zelda)
             env = ZeldaAttackOnlyActionSpace(env)


### PR DESCRIPTION
Previous versions of this lib tried to get an ML model to play the game by looking at the screen.  This change allows you to set `--obs-kind viewport` which gives link a small 64x64 pixel window to see the game through.  This allows the model to actually learn what link looks like easier and where enemies are positioned relative to him, without having to find that on screen.

Additionally, I've removed the (currently) unnecessary features that were present and replaced them with a list of normalized vectors, pointing (in order) to the closest enemies.  That should let the model be able to react appropriately to its immediate surroundings while still knowing where it needs to go.