### PR TITLE
Further reward fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Full Game (so far)",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": [],
@@ -15,7 +15,7 @@
         },
         {
             "name": "Dungeon 1",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["dungeon1"],
@@ -24,7 +24,7 @@
         },
         {
             "name": "Run Dungeon1 Beams Scenario",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["dungeon1beams"],
@@ -33,7 +33,7 @@
         },
         {
             "name": "Run Dungeon1 Sword Scenario (no beams)",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["dungeon1nobeams"],
@@ -42,7 +42,7 @@
         },
         {
             "name": "Run Dungeon1 Bombs Scenario",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["dungeon1bombs"],
@@ -51,7 +51,7 @@
         },
         {
             "name": "Run Dungeon1 Boss",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["dungeon1boss"],
@@ -60,7 +60,7 @@
         },
         {
             "name": "Run Overworld Sword Scenario",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["overworld-sword"],
@@ -69,7 +69,7 @@
         },
         {
             "name": "Run Overworld1 NO Beams",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["overworld1nobeams"],
@@ -78,7 +78,7 @@
         },
         {
             "name": "Run Overworld1 Beams",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "args": ["overworld1beams"],
@@ -87,7 +87,7 @@
         },
         {
             "name": "Training",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "train.py",
             "args": ["--iterations", "5000", "--parallel", "1"],
@@ -96,7 +96,7 @@
         },
         {
             "name": "Train Overworld",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "train.py",
             "args": ["overworld1", "--iterations", "5000", "--parallel", "1"],

--- a/tests/ending_test.py
+++ b/tests/ending_test.py
@@ -22,8 +22,7 @@ def test_dungeon_combat_end():
     assert not terminated
     assert not truncated
     assert info['beam_hits'] == 0
-    assert info['step_kills'] == 3
-    assert info['step_injuries'] == 0
+    assert info['step_hits'] == 3
     assert info['action'] == 'item'
 
     found = None

--- a/tests/hit_test.py
+++ b/tests/hit_test.py
@@ -17,7 +17,7 @@ def run( env, command):
         yield env.step(c)
 
 def test_bat_injury():
-    replay = ZeldaActionReplay("1_72e.state", render_mode="human")
+    replay = ZeldaActionReplay("1_72e.state")
     assert_no_hit(replay, 'lllllllllllllllllllld')
     _, _, terminated, truncated, info = replay.step('a')
     assert not terminated
@@ -29,8 +29,12 @@ def test_bat_injury():
     assert_no_hit(replay, 'dddddddddddddddddddddddddddddddddd')
 
 def test_stalfos_injury():
-    replay = ZeldaActionReplay("1_74w.state", render_mode="human")
+    replay = ZeldaActionReplay("1_74w.state")
     assert_no_hit(replay, 'rrddddr')
+
+    unwrapped = replay.env.unwrapped
+    unwrapped.data.set_value('hearts_and_containers', 0xff)
+
     _, _, terminated, truncated, info = replay.step('a')
     assert not terminated
     assert not truncated
@@ -47,7 +51,7 @@ def test_stalfos_injury():
     assert_no_hit(replay, 'lllllll')
 
 def test_sword_injury():
-    replay = ZeldaActionReplay("1_44e.state", render_mode="human")
+    replay = ZeldaActionReplay("1_44e.state")
 
     assert_no_hit(replay, 'llluuuullllllllllllllld')
 

--- a/tests/hit_test.py
+++ b/tests/hit_test.py
@@ -10,15 +10,44 @@ def assert_no_hit( env, command):
         assert not terminated
         assert not truncated
         assert info['beam_hits'] == 0
-        assert info['step_kills'] == 0
-        assert info['step_injuries'] == 0
+        assert info['step_hits'] == 0
 
 def run( env, command):
     for c in command:
         yield env.step(c)
 
+def test_bat_injury():
+    replay = ZeldaActionReplay("1_72e.state", render_mode="human")
+    assert_no_hit(replay, 'lllllllllllllllllllld')
+    _, _, terminated, truncated, info = replay.step('a')
+    assert not terminated
+    assert not truncated
+    assert info['beam_hits'] == 0
+    assert info['step_hits'] == 1
+    assert info['action'] == 'attack'
+    
+    assert_no_hit(replay, 'dddddddddddddddddddddddddddddddddd')
+
+def test_stalfos_injury():
+    replay = ZeldaActionReplay("1_74w.state", render_mode="human")
+    assert_no_hit(replay, 'rrddddr')
+    _, _, terminated, truncated, info = replay.step('a')
+    assert not terminated
+    assert not truncated
+    assert info['step_hits'] == 1
+    assert info['action'] == 'attack'
+    assert_no_hit(replay, 'llllr')
+
+    _, _, terminated, truncated, info = replay.step('a')
+    assert not terminated
+    assert not truncated
+    assert info['step_hits'] == 1
+    assert info['action'] == 'attack'
+    
+    assert_no_hit(replay, 'lllllll')
+
 def test_sword_injury():
-    replay = ZeldaActionReplay("1_44e.state")
+    replay = ZeldaActionReplay("1_44e.state", render_mode="human")
 
     assert_no_hit(replay, 'llluuuullllllllllllllld')
 
@@ -26,8 +55,7 @@ def test_sword_injury():
     assert not terminated
     assert not truncated
     assert info['beam_hits'] == 0
-    assert info['step_kills'] == 0
-    assert info['step_injuries'] == 2
+    assert info['step_hits'] == 2
     assert info['action'] == 'attack'
     
     assert_no_hit(replay, 'u')
@@ -44,8 +72,7 @@ def test_beam_injury():
     assert not terminated
     assert not truncated
     assert info['beam_hits'] == 1
-    assert info['step_kills'] == 0
-    assert info['step_injuries'] == 1
+    assert info['step_hits'] == 1
     assert info['action'] == 'attack'
 
     assert_no_hit(replay, "lllllll")
@@ -59,8 +86,7 @@ def test_bombs_kill():
     assert not terminated
     assert not truncated
     assert info['beam_hits'] == 0
-    assert info['step_kills'] == 3
-    assert info['step_injuries'] == 0
+    assert info['step_hits'] == 3
     assert info['action'] == 'item'
 
     assert_no_hit(replay, "uuurrrrrr")

--- a/triforce_lib/action_replay.py
+++ b/triforce_lib/action_replay.py
@@ -2,6 +2,7 @@
 
 import retro
 
+from .objective_selector import ObjectiveSelector
 from .action_space import ZeldaActionSpace
 from .zelda_wrapper import ZeldaGameWrapper
 
@@ -10,7 +11,11 @@ class ZeldaActionReplay:
         env = retro.make(game='Zelda-NES', state=savestate, inttype=retro.data.Integrations.CUSTOM_ONLY, render_mode=render_mode)
         self.data = env.data
         env = ZeldaGameWrapper(env, deterministic=True)
+        env = ObjectiveSelector(env)
         env = ZeldaActionSpace(env, 'all')
+        if wrapper:
+            env = wrapper(env)
+
         self.actions = env.actions
 
         self.buttons = {

--- a/triforce_lib/critic.py
+++ b/triforce_lib/critic.py
@@ -189,11 +189,11 @@ class ZeldaGameplayCritic(ZeldaCritic):
             rewards['reward-gained-triforce'] = self.triforce_reward
 
     def critique_attack(self, old, new, rewards):
-        if new['step_kills'] or new['step_injuries']:
+        if new['step_hits']:
             if not is_in_cave(new):
-                rewards['reward-injure-kill'] = self.injure_kill_reward
+                rewards['reward-hit'] = self.injure_kill_reward
             else:
-                rewards['penalty-injure-cave'] = self.injure_kill_reward
+                rewards['penalty-hit-cave'] = self.injure_kill_reward
         
         else:
             if new['action'] == 'attack':                

--- a/triforce_lib/custom_integrations/Zelda-NES/data.json
+++ b/triforce_lib/custom_integrations/Zelda-NES/data.json
@@ -168,6 +168,54 @@
             "address": 1653,
             "type": "=u1"
         },
+        "obj_health_1": {
+            "address": 1158,
+            "type": "=u1"
+        },
+        "obj_health_2": {
+            "address": 1159,
+            "type": "=u1"
+        },
+        "obj_health_3": {
+            "address": 1160,
+            "type": "=u1"
+        },
+        "obj_health_4": {
+            "address": 1161,
+            "type": "=u1"
+        },
+        "obj_health_5": {
+            "address": 1162,
+            "type": "=u1"
+        },
+        "obj_health_6": {
+            "address": 1163,
+            "type": "=u1"
+        },
+        "obj_health_7": {
+            "address": 1164,
+            "type": "=u1"
+        },
+        "obj_health_8": {
+            "address": 1165,
+            "type": "=u1"
+        },
+        "obj_health_9": {
+            "address": 1166,
+            "type": "=u1"
+        },
+        "obj_health_a": {
+            "address": 1167,
+            "type": "=u1"
+        },
+        "obj_health_b": {
+            "address": 1169,
+            "type": "=u1"
+        },
+        "obj_health_c": {
+            "address": 1170,
+            "type": "=u1"
+        },
         "compass": {
             "address": 1639,
             "type": "=u1"

--- a/triforce_lib/end_condition.py
+++ b/triforce_lib/end_condition.py
@@ -29,7 +29,7 @@ class ZeldaEndCondition:
 
         # check truncation
         truncated = False
-        if old['link_pos'] == new['link_pos'] and not new['step_kills'] and not new['step_injuries']:
+        if old['link_pos'] == new['link_pos'] and not new['step_hits']:
             if self._position_duration >= self.position_timeout:
                 reason = "truncated-position-timeout"
                 truncated = True

--- a/triforce_lib/scenario_dungeon1.py
+++ b/triforce_lib/scenario_dungeon1.py
@@ -68,7 +68,7 @@ class Dungeon1BossCritic(Dungeon1Critic):
         self.health_lost_penalty = -self.reward_small
 
     def set_score(self, old : typing.Dict[str, int], new : typing.Dict[str, int]):
-        self.total_damage += new['step_injuries'] + new['step_kills']
+        self.total_damage += new['step_hits']
         new['score'] = get_heart_halves(new) + self.total_damage
 
 class Dungeon1CombatEndCondition(ZeldaEndCondition):

--- a/triforce_lib/zelda_game_data.txt
+++ b/triforce_lib/zelda_game_data.txt
@@ -36,7 +36,7 @@
 
 # counted items
 0x66d rupees
-0x67d rupees_to_add            
+0x67d rupees_to_add
 0x658 bombs
 0x67C bomb_max
 0x66E keys
@@ -64,6 +64,21 @@
 0x666 letter
 0x674 regular_boomerang
 0x675 magic_boomerang
+
+# enemy health
+0x486 obj_health_1
+0x487 obj_health_2
+0x488 obj_health_3
+0x489 obj_health_4
+0x48a obj_health_5
+0x48b obj_health_6
+0x48c obj_health_7
+0x48d obj_health_8
+0x48e obj_health_9
+0x48f obj_health_a
+0x491 obj_health_b
+0x492 obj_health_c
+
             
 0x667 compass
 0x668 map

--- a/triforce_lib/zelda_wrapper.py
+++ b/triforce_lib/zelda_wrapper.py
@@ -360,10 +360,12 @@ class ZeldaGameWrapper(gym.Wrapper):
         hits = 0
 
         objects = ZeldaObjectData(unwrapped.get_ram())
+        end_health = {x: objects.get_obj_health(x) for x in objects.enumerate_enemy_ids()}
         for enemy in start_enemies:
             start = start_health.get(enemy, 0)
             end = objects.get_obj_health(enemy)
-            if end < start:
+
+            if enemy not in end_health or end < start:
                 hits += 1
 
         unwrapped.em.set_state(savestate)

--- a/triforce_lib/zelda_wrapper.py
+++ b/triforce_lib/zelda_wrapper.py
@@ -359,10 +359,6 @@ class ZeldaGameWrapper(gym.Wrapper):
         
         hits = 0
 
-        for i in range(20):
-            data.set_value('hearts_and_containers', 0xff) # make sure we don't die
-            _, _, terminated, truncated, info = unwrapped.step(act)
-
         objects = ZeldaObjectData(unwrapped.get_ram())
         for enemy in start_enemies:
             start = start_health.get(enemy, 0)


### PR DESCRIPTION
- Cleaned up beam/bomb hits by changing how enemy health works in game.  Any zero health enemies like gels, keese get raised to 1 health.  This ensures that their hits are registered in a consistent way because the game won't care that the health shouldn't be there for those enemies, it decrements the health on hit anyway.  This creates a consistent way to handle hits without so much special casing.
- Fixed tests