### PR TITLE
Movement fixes

### DIFF
--- a/triforce_lib/critics.py
+++ b/triforce_lib/critics.py
@@ -317,6 +317,22 @@ class GameplayCritic(ZeldaCritic):
                                 rewards['penalty-move-farther'] = self.move_away_penalty
                             elif is_movement and len(new_path) < len(old_path) and diff > 0:
                                 rewards['reward-move-closer'] = self.move_closer_reward * percent
+                
+                else:
+                    # if A* couldn't find a path, we should still reward the agent for moving closer
+                    # to the objective.  This should be rare, and often happens when an enem moves
+                    # into a wall.  (Bosses or wallmasters.)
+
+                    target = new['objective_position']
+                    old_distance = np.linalg.norm(target - np.array(old['link_pos'], dtype=np.float32))
+                    new_distance = np.linalg.norm(target - np.array(new['link_pos'], dtype=np.float32))
+                    dist = new_distance - old_distance
+                    percent = abs(dist / self.movement_scale_factor)
+
+                    if dist < 0:
+                        rewards['reward-move-closer'] = self.move_closer_reward * percent
+                    else:
+                        rewards['penalty-move-farther'] = self.move_away_penalty * percent
 
     def find_first_turn(self, path):
         direction = self.get_direction(path[0], path[1])

--- a/triforce_lib/critics.py
+++ b/triforce_lib/critics.py
@@ -304,7 +304,7 @@ class GameplayCritic(ZeldaCritic):
                             elif is_movement and len(new_path) < len(old_path) and diff > 0:
                                 rewards['reward-move-closer'] = self.move_closer_reward * percent
                             else:
-                                rewards['useless-move-penalty'] = self.useless_move_penalty
+                                rewards['penalty-useless-move'] = self.useless_move_penalty
 
                         else:
                             # The objective moved.  We might have selected a new objective, or we are

--- a/triforce_lib/triforce.json
+++ b/triforce_lib/triforce.json
@@ -5,10 +5,11 @@
             "name" : "overworld-sword",
             "path" : "overworld-sword",
             "action_space" : "move-only",
-            "priority" : 0,
+            "priority" : 2,
             "levels" : 0,
+            "rooms" : ["0x77"],
             "requires_enemies" : false,
-            "equipment_required" : ["nosword"],
+            "equipment_required" : [],
 
             "training_scenario" : "overworld-sword",
             "iterations" : 1000000

--- a/triforce_lib/zelda_game.py
+++ b/triforce_lib/zelda_game.py
@@ -104,14 +104,6 @@ def init_walkable_tiles():
     return result
 
 walkable_tiles = init_walkable_tiles()
-def is_tile_walkable(last_tile, tile):
-    # Special case dungeon bricks.  Link actually walks through them so they are walkable, but only if
-    # coming from a non-brick tile.  Otherwise the A* algorithm will try to route link around the bricks
-    # outside the play area.
-    if last_tile == tile == 0xf6:
-        return False
-    
-    return walkable_tiles[tile]
 
 def position_to_tile_index(x, y):
     return (int((y - gameplay_start_y) // 8), int(x // 8))
@@ -239,7 +231,6 @@ __all__ = [
     'get_heart_halves',
     'get_heart_containers',
     'has_beams',
-    'is_tile_walkable',
     'walkable_tiles',
     'position_to_tile_index',
     'tile_index_to_position',

--- a/triforce_lib/zeldaml.py
+++ b/triforce_lib/zeldaml.py
@@ -129,7 +129,7 @@ class ZeldaML:
                 print()
                 print(f"Training model: {model_info.name}")
                 print(f"Scenario:       {model_info.training_scenario}")
-                print(f"Path:           {model_path}")
+                print(f"Path:           {model_dir}")
                 model = self._create_model(env, log_path)
                 callback = LogRewardCallback(model.save, model_dir)
                 model.learn(iterations, progress_bar=progress_bar, callback=callback)


### PR DESCRIPTION
- Reward based on moving towards the "first turn" of the A* route instead of the end result.
- Make checking walkable tiles a little faster.
- Use the overworld-sword model for all of the first room.