### PR TITLE
Don't Path Through Enemies

### DIFF
--- a/run.py
+++ b/run.py
@@ -591,7 +591,7 @@ class DisplayWindow:
                 surface.blit(text_surface, text_rect)
 
     def _get_optimal_path(self, info):
-        return info['a*_path'][-1] if 'a*_path' in info else []
+        return info['a*_path'] if 'a*_path' in info else []
 
     def _find_special_tiles(self, info):
         tiles = []

--- a/run.py
+++ b/run.py
@@ -564,9 +564,9 @@ class DisplayWindow:
                 x = offset[0] + tile_x * tile_width - 8 * scale
                 y = 56 * scale + offset[1] + tile_y * tile_height
 
-                # red for DAMAGE, yellow for DANGER, blue for WALKABLE, black otherwise
+                # red for DANGER, yellow for WARNING, blue for WALKABLE, black otherwise
                 state = info['tile_states'].get((tile_y, tile_x), TileState.IMPASSABLE)
-                color = (255, 0, 0) if state == TileState.DAMAGE else (255, 255, 0) if state == TileState.DANGER else \
+                color = (255, 0, 0) if state == TileState.DANGER else (255, 255, 0) if state == TileState.WARNING else \
                     (0, 0, 255) if state == TileState.WALKABLE else (0, 0, 0)
 
                 pygame.draw.rect(surface, color, (x, y, tile_width, tile_height), 1)

--- a/run.py
+++ b/run.py
@@ -587,7 +587,7 @@ class DisplayWindow:
     def _find_special_tiles(self, info):
         tiles = []
         for index, state in info['tile_states'].items():
-            if state not in (TileState.WALKABLE, TileState.IMPASSABLE):
+            if state not in (TileState.WALKABLE, TileState.IMPASSABLE, TileState.BRICK):
                 tiles.append(index)
 
         tiles += info['link'].tile_coordinates

--- a/run.py
+++ b/run.py
@@ -533,15 +533,19 @@ class DisplayWindow:
         return result
 
     def _overlay_grid_and_text(self, surface, kind, offset, tiles, text_color, scale, info):
-        # 0 == no overlay
-        # 1 == path overlay
-        # 2 == show tiles
-        # 3 == show tiles other than walkable and impassable
-        if kind == 0:
-            return
-
-        tiles_to_show = self._get_optimal_path(info) if kind == 1 else None
-        tiles_to_show = self._find_special_tiles(info) if kind == 3 else tiles_to_show
+        match kind:
+            case 0:
+                # no overlay, just return
+                return
+            case 1:
+                # show the path overlay
+                tiles_to_show = self._get_optimal_path(info) + self._find_special_tiles(info)
+            case 2:
+                # show tiles other than walkable and impassable
+                tiles_to_show = self._find_special_tiles(info)
+            case _:
+                # show all tile codes
+                tiles_to_show = None
 
         grid_width = 32
         grid_height = 22
@@ -578,7 +582,7 @@ class DisplayWindow:
                 surface.blit(text_surface, text_rect)
 
     def _get_optimal_path(self, info):
-        return info['a*_path'][-1] if 'a*_path' in info else None
+        return info['a*_path'][-1] if 'a*_path' in info else []
 
     def _find_special_tiles(self, info):
         tiles = []
@@ -586,12 +590,7 @@ class DisplayWindow:
             if state not in (TileState.WALKABLE, TileState.IMPASSABLE):
                 tiles.append(index)
 
-        obj = info['link']
-        tiles.append(obj.tile_coordinates)
-        tiles.append((obj.tile_coordinates[0] + 1, obj.tile_coordinates[1]))
-        tiles.append((obj.tile_coordinates[0], obj.tile_coordinates[1] + 1))
-        tiles.append((obj.tile_coordinates[0] + 1, obj.tile_coordinates[1] + 1))
-
+        tiles += info['link'].tile_coordinates
         return tiles
 
 class DebugReward:

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -1,8 +1,6 @@
 """A* algorithm implementation for pathfinding.  Used to train the model how to move around the map."""
 
 import heapq
-import numpy as np
-
 from .zelda_game import TileState, Direction
 
 def heuristic(current, direction : Direction, dimensions, tile_weight : int):
@@ -42,11 +40,11 @@ def mahattan_distance(y, x, ny, nx):
     """Returns the manhattan distance between two points"""
     return abs(nx - x) + abs(ny - y)
 
-WALKABLE_TILES = np.array([TileState.WALKABLE.value,
+WALKABLE_TILES = [TileState.WALKABLE.value,
                            TileState.DANGER.value,
                            TileState.WARNING.value,
                            TileState.BRICK.value
-                           ], dtype=np.uint8)
+                           ]
 
 def get_neighbors(position, tile_weight_map):
     """Returns neighbors of position that are both valid and walkable."""

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -128,7 +128,9 @@ def a_star(link_position, tile_state_map, map_dimensions, direction):
                 if neighbor not in [item[1] for item in open_set]:
                     heapq.heappush(open_set, (f_score[neighbor], neighbor))
 
-    return reconstruct_path(start, came_from, closest_node)
+    path = reconstruct_path(start, came_from, closest_node)
+    add_direction(direction, path[-1], path)
+    return path
 
 def add_direction(target, current, path):
     """
@@ -142,15 +144,14 @@ def add_direction(target, current, path):
     Returns:
         None
     """
-    if target == Direction.N:
-        path.append((current[0] - 1, current[1]))
-    elif target == Direction.S:
-        path.append((current[0] + 1, current[1]))
-    elif target == Direction.W:
-        path.append((current[0], current[1] - 1))
-    elif target == Direction.E:
-        path.append((current[0], current[1] + 1))
-    else:
-        raise ValueError(f"Unknown direction: {target}")
+    match target:
+        case Direction.N:
+            path.append((current[0] - 1, current[1]))
+        case Direction.S:
+            path.append((current[0] + 1, current[1]))
+        case Direction.W:
+            path.append((current[0], current[1] - 1))
+        case Direction.E:
+            path.append((current[0], current[1] + 1))
 
 __all__ = ['a_star']

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -2,9 +2,9 @@
 
 import heapq
 
-from .zelda_game import WALKABLE_TILES, Direction
+from .zelda_game import TileState, Direction
 
-def heuristic(current, direction : Direction, map_width, map_height, is_exterior_dangerous):
+def heuristic(current, direction : Direction, dimensions, tile : TileState):
     """
     Calculate the heuristic value for the A* algorithm.
 
@@ -19,12 +19,9 @@ def heuristic(current, direction : Direction, map_width, map_height, is_exterior
     - The heuristic value for the given parameters.
     """
     y, x = current
+    map_height, map_width = dimensions
 
-    weight = 0
-    if is_exterior_dangerous:
-        if x in [0x04, 0x05, 0x1a, 0x1b] or y in [0x04, 0x05, 0x10, 0x11]:
-            weight = 10
-
+    weight = tile.astar_weight
     if direction == Direction.N:
         return y + weight
     if direction == Direction.S:
@@ -37,28 +34,10 @@ def heuristic(current, direction : Direction, map_width, map_height, is_exterior
     ny, nx = direction
     return abs(nx - x) + abs(ny - y) + weight
 
-def get_tile(position, tiles):
-    """
-    Retrieves the value of a tile at the given position from the tiles array.
-
-    Args:
-        position (tuple): The position of the tile in the form (y, x).
-        tiles (numpy.ndarray): The array of tiles.
-
-    Returns:
-        int: The value of the tile at the given position, or 0 if the position is out of bounds.
-    """
-    y, x = position
-    if 0 <= x < tiles.shape[1] and 0 <= y < tiles.shape[0]:
-        return tiles[y, x]
-
-    return 0
-
 # Special case dungeon bricks.  Link actually walks through them so they are walkable, but only if
 # coming from a non-brick tile.  Otherwise the A* algorithm will try to route link around the bricks
 # outside the play area.
-BRICK_TILE = 0xf6
-def get_neighbors(position, tiles):
+def get_neighbors(position, tile_states, dimensions):
     """
     Returns a list of neighboring positions that are valid for movement.
 
@@ -69,20 +48,27 @@ def get_neighbors(position, tiles):
     Returns:
         list: A list of neighboring positions that are valid for movement.
     """
-    prev_tile_is_brick = get_tile(position, tiles) == BRICK_TILE
+    prev_tile_is_brick = None
 
     y, x = position
     neighbors = []
     for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
         next_position = y + dy, x + dx
-        tile = get_tile(next_position, tiles)
+        if 0 <= x + dx < dimensions[1] and 0 <= y + dy < dimensions[0]:
+            next_position = y + dy, x + dx
+            tile = tile_states.get(next_position, TileState.IMPASSABLE)
 
-        # If the previous tile is a brick, we can't move to another brick tile
-        if prev_tile_is_brick and tile == BRICK_TILE:
-            continue
+            # If the previous tile is a brick, we can't move to another brick tile
+            if tile == TileState.BRICK:
+                if prev_tile_is_brick is None:
+                    if tile_states.get(position, TileState.IMPASSABLE) == TileState.BRICK:
+                        prev_tile_is_brick = True
 
-        if WALKABLE_TILES[tile]:
-            neighbors.append(next_position)
+
+                tile = TileState.IMPASSABLE if prev_tile_is_brick else TileState.WALKABLE
+
+            if tile.is_walkable:
+                neighbors.append((next_position, tile))
 
     return neighbors
 
@@ -106,7 +92,7 @@ def reconstruct_path(start, came_from, current):
     path.append(start)
     return path[::-1]
 
-def a_star(link_position, tiles, direction, is_exterior_dangerous):
+def a_star(link_position, tile_state_map, map_dimensions, direction):
     """
     A* algorithm implementation for pathfinding.
 
@@ -114,29 +100,29 @@ def a_star(link_position, tiles, direction, is_exterior_dangerous):
         link_position (tuple): The starting position of the link.
         tiles (numpy.ndarray): The map tiles.
         direction (Direction): The direction in which the link is moving.
-        is_exterior_dangerous (bool): Flag indicating if the exterior is dangerous.
 
     Returns:
         list: The path from the starting position to the goal position.
     """
     # pylint: disable-msg=too-many-locals
-    map_height, map_width = tiles.shape
     start = link_position
+    start_tile_state = tile_state_map.get(start, TileState.IMPASSABLE)
 
     open_set = []
     heapq.heappush(open_set, (0, start))
 
     came_from = {}
     g_score = {start: 0}
-    f_score = {start: heuristic(start, direction, map_width, map_height, is_exterior_dangerous)}
+    f_score = {start: heuristic(start, direction, map_dimensions, start_tile_state)}
 
     closest_node = start
-    closest_distance = heuristic(start, direction, map_width, map_height, is_exterior_dangerous)
+    closest_distance = heuristic(start, direction, map_dimensions, start_tile_state)
 
     while open_set:
         _, current = heapq.heappop(open_set)
+        current_tile_state = tile_state_map.get(current, TileState.IMPASSABLE)
 
-        current_distance = heuristic(current, direction, map_width, map_height, is_exterior_dangerous)
+        current_distance = heuristic(current, direction, map_dimensions, current_tile_state)
         if current_distance < closest_distance:
             closest_node = current
             closest_distance = current_distance
@@ -144,12 +130,12 @@ def a_star(link_position, tiles, direction, is_exterior_dangerous):
         if current_distance == 0:
             return reconstruct_path(start, came_from, current)
 
-        for neighbor in get_neighbors(current, tiles):
-            tentative_g_score = g_score[current] + 1  # Assuming uniform cost
+        for neighbor, tile in get_neighbors(current, tile_state_map, map_dimensions):
+            tentative_g_score = g_score[current] + tile.astar_weight
             if tentative_g_score < g_score.get(neighbor, float('inf')):
                 came_from[neighbor] = current
                 g_score[neighbor] = tentative_g_score
-                h_value = heuristic(neighbor, direction, map_width, map_height, is_exterior_dangerous)
+                h_value = heuristic(neighbor, direction, map_dimensions, tile)
                 f_score[neighbor] = tentative_g_score + h_value
                 if neighbor not in [item[1] for item in open_set]:
                     heapq.heappush(open_set, (f_score[neighbor], neighbor))

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -60,7 +60,7 @@ def get_neighbors(position, tile_states, dimensions):
 
     return neighbors
 
-def reconstruct_path(start, came_from, current):
+def reconstruct_path(start, came_from, current, target):
     """
     Reconstructs the path from the start node to the current node using the came_from dictionary.
 
@@ -78,7 +78,25 @@ def reconstruct_path(start, came_from, current):
         current = came_from[current]
 
     path.append(start)
-    return path[::-1]
+
+    last = path[0]
+    path.reverse()
+
+    match target:
+        case Direction.N:
+            path.append((last[0] - 1, last[1]))
+        case Direction.S:
+            path.append((last[0] + 1, last[1]))
+        case Direction.W:
+            path.append((last[0], last[1] - 1))
+        case Direction.E:
+            path.append((last[0], last[1] + 1))
+
+    if len(path) > 1 and path[0] == path[-1]:
+        return [path[-1]]
+
+    return path
+
 
 def a_star(link_position, tile_state_map, map_dimensions, direction):
     """
@@ -116,7 +134,7 @@ def a_star(link_position, tile_state_map, map_dimensions, direction):
             closest_distance = current_distance
 
         if current_distance == 0:
-            return reconstruct_path(start, came_from, current)
+            return reconstruct_path(start, came_from, current, direction)
 
         for neighbor, tile in get_neighbors(current, tile_state_map, map_dimensions):
             tentative_g_score = g_score[current] + tile.astar_weight
@@ -128,30 +146,4 @@ def a_star(link_position, tile_state_map, map_dimensions, direction):
                 if neighbor not in [item[1] for item in open_set]:
                     heapq.heappush(open_set, (f_score[neighbor], neighbor))
 
-    path = reconstruct_path(start, came_from, closest_node)
-    add_direction(direction, path[-1], path)
-    return path
-
-def add_direction(target, current, path):
-    """
-    Adds a new coordinate to the given path based on the target direction.
-
-    Args:
-        target (Direction): The target direction.
-        current (tuple): The current coordinate (x, y).
-        path (list): The list of coordinates representing the path.
-
-    Returns:
-        None
-    """
-    match target:
-        case Direction.N:
-            path.append((current[0] - 1, current[1]))
-        case Direction.S:
-            path.append((current[0] + 1, current[1]))
-        case Direction.W:
-            path.append((current[0], current[1] - 1))
-        case Direction.E:
-            path.append((current[0], current[1] + 1))
-
-__all__ = ['a_star']
+    return reconstruct_path(start, came_from, closest_node, direction)

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -32,7 +32,11 @@ def heuristic(current, direction : Direction, dimensions, tile : TileState):
         return map_width - x - 1 + weight
 
     ny, nx = direction
-    return abs(nx - x) + abs(ny - y) + weight
+    dist = abs(nx - x) + abs(ny - y)
+    if dist:
+        return dist + weight
+
+    return 0
 
 # Special case dungeon bricks.  Link actually walks through them so they are walkable, but only if
 # coming from a non-brick tile.  Otherwise the A* algorithm will try to route link around the bricks
@@ -78,10 +82,18 @@ def reconstruct_path(start, came_from, current, target):
         current = came_from[current]
 
     path.append(start)
-
-    last = path[0]
     path.reverse()
 
+    _append_final_direction(target, path)
+
+    if len(path) > 1 and path[0] == path[-1]:
+        path = [path[-1]]
+        _append_final_direction(target, path)
+
+    return path
+
+def _append_final_direction(target, path):
+    last = path[-1]
     match target:
         case Direction.N:
             path.append((last[0] - 1, last[1]))
@@ -91,11 +103,6 @@ def reconstruct_path(start, came_from, current, target):
             path.append((last[0], last[1] - 1))
         case Direction.E:
             path.append((last[0], last[1] + 1))
-
-    if len(path) > 1 and path[0] == path[-1]:
-        return [path[-1]]
-
-    return path
 
 
 def a_star(link_position, tile_state_map, map_dimensions, direction):

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -2,7 +2,7 @@
 
 import heapq
 
-from .zelda_game import walkable_tiles, Direction
+from .zelda_game import WALKABLE_TILES, Direction
 
 def heuristic(current, direction : Direction, map_width, map_height, is_exterior_dangerous):
     """
@@ -81,7 +81,7 @@ def get_neighbors(position, tiles):
         if prev_tile_is_brick and tile == BRICK_TILE:
             continue
 
-        if walkable_tiles[tile]:
+        if WALKABLE_TILES[tile]:
             neighbors.append(next_position)
 
     return neighbors

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -48,8 +48,6 @@ def get_neighbors(position, tile_states, dimensions):
     Returns:
         list: A list of neighboring positions that are valid for movement.
     """
-    prev_tile_is_brick = None
-
     y, x = position
     neighbors = []
     for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
@@ -57,16 +55,6 @@ def get_neighbors(position, tile_states, dimensions):
         if 0 <= x + dx < dimensions[1] and 0 <= y + dy < dimensions[0]:
             next_position = y + dy, x + dx
             tile = tile_states.get(next_position, TileState.IMPASSABLE)
-
-            # If the previous tile is a brick, we can't move to another brick tile
-            if tile == TileState.BRICK:
-                if prev_tile_is_brick is None:
-                    if tile_states.get(position, TileState.IMPASSABLE) == TileState.BRICK:
-                        prev_tile_is_brick = True
-
-
-                tile = TileState.IMPASSABLE if prev_tile_is_brick else TileState.WALKABLE
-
             if tile.is_walkable:
                 neighbors.append((next_position, tile))
 

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -253,7 +253,7 @@ class GameplayCritic(ZeldaCritic):
         """
         if new['step_hits']:
             if not is_in_cave(new):
-                rewards['reward-hit'] = self.injure_kill_reward * new['step_hits']
+                rewards['reward-hit'] = self.injure_kill_reward
             else:
                 rewards['penalty-hit-cave'] = -self.injure_kill_reward
 

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -59,14 +59,10 @@ class GameplayCritic(ZeldaCritic):
         # same room movement rewards
         self.wall_collision_penalty = -REWARD_TINY
         self.move_closer_reward = REWARD_TINY
-        self.optimal_path_reward = self.move_closer_reward
 
         self.minimum_movement_required = 1.5
         self.movement_scale_factor = 9.0
         self.move_away_penalty = -self.move_closer_reward - REWARD_MINIMUM
-
-        self.too_close_threshold = 28
-        self.enemy_too_close_penalty = -REWARD_SMALL
 
         self.warning_tile_penalty = -REWARD_TINY
         self.danger_tile_penalty = -REWARD_MEDIUM
@@ -570,7 +566,6 @@ class Dungeon1BossCritic(Dungeon1Critic):
     def clear(self):
         super().clear()
         self.total_damage = 0
-        self.too_close_threshold = 10
         self.move_closer_reward = REWARD_SMALL
         self.move_away_penalty = -REWARD_SMALL
         self.injure_kill_reward = REWARD_LARGE

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -254,20 +254,20 @@ class GameplayCritic(ZeldaCritic):
                 rewards['penalty-hit-cave'] = -self.injure_kill_reward
 
         elif new['action'] == ActionType.ATTACK:
-            if not new['enemies']:
+            if not new['active_enemies']:
                 rewards['penalty-attack-no-enemies'] = self.attack_no_enemies_penalty
 
             elif new['is_sword_frozen']:
                 rewards['penalty-attack-offscreen'] = self.attack_miss_penalty
 
-            elif new['enemies']:
-                enemy_vectors = [enemy.vector for enemy in new['enemies'] if abs(enemy.distance) > 0]
+            elif new['active_enemies']:
+                enemy_vectors = [enemy.vector for enemy in new['active_enemies'] if abs(enemy.distance) > 0]
                 if enemy_vectors:
                     dotproducts = np.sum(new['link_direction'].to_vector() * enemy_vectors, axis=1)
                     if not np.any(dotproducts > np.sqrt(2) / 2):
                         rewards['penalty-attack-miss'] = self.attack_miss_penalty
                     elif not old['has_beams']:
-                        distance = new['enemies'][0].distance
+                        distance = new['active_enemies'][0].distance
                         if distance > self.distance_threshold:
                             rewards['penalty-attack-miss'] = self.attack_miss_penalty
 
@@ -345,12 +345,12 @@ class GameplayCritic(ZeldaCritic):
             if danger_diff > 0:
                 rewards['penalty-dangerous-move'] = self.danger_tile_penalty
             elif danger_diff < 0:
-                if len(old['enemies']) == len(new['enemies']):
+                if len(old['active_enemies']) == len(new['active_enemies']):
                     rewards['reward-moved-to-safety'] = self.moved_to_safety_reward
             elif warning_diff > 0:
                 rewards['penalty-risky-move'] = self.warning_tile_penalty
             elif warning_diff < 0:
-                if len(old['enemies']) == len(new['enemies']):
+                if len(old['active_enemies']) == len(new['active_enemies']):
                     rewards['reward-moved-to-safety'] = self.moved_to_safety_reward
 
         # do we have an optimal path?

--- a/triforce/objective_selector.py
+++ b/triforce/objective_selector.py
@@ -129,7 +129,7 @@ class ObjectiveSelector(gym.Wrapper):
                 self.last_route = key, path
 
         if not path:
-            path = a_star(link_tiles, info['tile_states'], info['tiles'].shape, objective_pos_dir)
+            path = a_star(link_tiles, info['tile_states'], objective_pos_dir)
             self.last_route = key, path
 
         return path

--- a/triforce/objective_selector.py
+++ b/triforce/objective_selector.py
@@ -98,7 +98,7 @@ class ObjectiveSelector(gym.Wrapper):
                 result = self.last_route[1]
                 path = result[-1]
             else:
-                path = a_star(link_tile_index, info['tiles'], objective_pos_dir, info['are_walls_dangerous'])
+                path = a_star(link_tile_index, info['tile_states'], info['tiles'].shape, objective_pos_dir)
                 result = (link_tile_index, objective_pos_dir, path)
                 self.last_route = (key, result)
 

--- a/triforce/objective_selector.py
+++ b/triforce/objective_selector.py
@@ -1,8 +1,8 @@
 import gymnasium as gym
 import numpy as np
 
-from .zelda_game import Direction, get_link_tile_index, is_in_cave, position_to_tile_index, tile_index_to_position, \
-    is_health_full, ZeldaItem
+from .zelda_game import Direction, is_in_cave, position_to_tile_index, tile_index_to_position, is_health_full, \
+                        ZeldaItem
 from .astar import a_star
 
 def get_location_from_direction(location, direction):
@@ -88,18 +88,18 @@ class ObjectiveSelector(gym.Wrapper):
 
         # find the optimal route to the objective
         if objective_pos_dir is not None:
-            link_tile_index = get_link_tile_index(info)
+            link_tiles = info['link'].tile_coordinates
 
             if not isinstance(objective_pos_dir, Direction):
                 objective_pos_dir = position_to_tile_index(*objective_pos_dir)
 
-            key = (info['level'], info['location'], link_tile_index, objective_pos_dir)
+            key = (info['level'], info['location'], link_tiles, objective_pos_dir)
             if self.last_route[0] == key:
                 result = self.last_route[1]
                 path = result[-1]
             else:
-                path = a_star(link_tile_index, info['tile_states'], info['tiles'].shape, objective_pos_dir)
-                result = (link_tile_index, objective_pos_dir, path)
+                path = a_star(link_tiles, info['tile_states'], info['tiles'].shape, objective_pos_dir)
+                result = (link_tiles, objective_pos_dir, path)
                 self.last_route = (key, result)
 
             info['a*_path'] = result

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -453,7 +453,7 @@ class ZeldaObjectData:
             elif 1 <= obj_id <= 0x48:
                 enemy_kind = id_map.get(obj_id, obj_id)
                 status = obj_status[i]
-                print(f'i: {i}, status: {status} pos:{pos} obj_id: {obj_id}')
+
                 enemy = ZeldaObject(enemy_kind, pos, distance, vector, self.get_obj_health(i), status)
                 enemies.append(enemy)
 

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -151,7 +151,7 @@ class TileState(Enum):
             case TileState.WALKABLE:
                 return 1
             case TileState.BRICK:
-                return 1
+                return 5
             case TileState.DAMAGE:
                 return 50
             case TileState.DANGER:
@@ -162,7 +162,7 @@ class TileState(Enum):
     @property
     def is_walkable(self):
         """Returns True if the tile is walkable."""
-        return self in (TileState.WALKABLE, TileState.DAMAGE, TileState.DANGER)
+        return self in (TileState.WALKABLE, TileState.DAMAGE, TileState.DANGER, TileState.BRICK)
 
     @staticmethod
     def create_map(tiles, enemies, projectiles):

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -138,8 +138,8 @@ class TileState(Enum):
     IMPASSABLE = 0
     WALKABLE = 1
     BRICK = 2  # dungeon bricks
-    DAMAGE = 3  # enemy or projectile
-    DANGER = 4  # tiles next to enemy, or the walls in a wallmaster room
+    WARNING = 3  # tiles next to enemy, or the walls in a wallmaster room
+    DANGER = 4  # enemy or projectile
 
     @ property
     def astar_weight(self):
@@ -152,9 +152,9 @@ class TileState(Enum):
                 return 1
             case TileState.BRICK:
                 return 5
-            case TileState.DAMAGE:
-                return 50
             case TileState.DANGER:
+                return 50
+            case TileState.WARNING:
                 return 25
             case _:
                 raise ValueError(f"Unknown TileState: {self}")
@@ -162,7 +162,7 @@ class TileState(Enum):
     @property
     def is_walkable(self):
         """Returns True if the tile is walkable."""
-        return self in (TileState.WALKABLE, TileState.DAMAGE, TileState.DANGER, TileState.BRICK)
+        return self in (TileState.WALKABLE, TileState.DANGER, TileState.WARNING, TileState.BRICK)
 
     @staticmethod
     def create_map(tiles, enemies, projectiles):
@@ -190,14 +190,14 @@ class TileState(Enum):
     def _add_wallmaster_tiles(result):
         x = 4
         while x < 28:
-            result[(4, x)] = TileState.DANGER
-            result[(17, x)] = TileState.DANGER
+            result[(4, x)] = TileState.WARNING
+            result[(17, x)] = TileState.WARNING
             x += 1
 
         y = 4
         while y < 18:
-            result[(y, 4)] = TileState.DANGER
-            result[(y, 27)] = TileState.DANGER
+            result[(y, 4)] = TileState.WARNING
+            result[(y, 27)] = TileState.WARNING
             y += 1
 
     @staticmethod
@@ -208,12 +208,12 @@ class TileState(Enum):
         max_x = max(coord[1] for coord in coords)
 
         for coord in coords:
-            result[coord] = TileState.DAMAGE
+            result[coord] = TileState.DANGER
 
         for ny in range(min_y - 1, max_y + 2):
             for nx in range(min_x - 1, max_x + 2):
                 if (ny, nx) not in result:
-                    result[(ny, nx)] = TileState.DANGER
+                    result[(ny, nx)] = TileState.WARNING
 
 def position_to_tile_index(x, y):
     """Converts a screen position to a tile index."""

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -189,25 +189,16 @@ class TileState(Enum):
     @staticmethod
     def _add_wallmaster_tiles(result):
         x = 4
-        y = 4
-
         while x < 28:
-            result[(y, x)] = TileState.DANGER
+            result[(4, x)] = TileState.DANGER
+            result[(17, x)] = TileState.DANGER
             x += 1
 
-        x -= 1
+        y = 4
         while y < 18:
-            result[(y, x)] = TileState.DANGER
+            result[(y, 4)] = TileState.DANGER
+            result[(y, 27)] = TileState.DANGER
             y += 1
-
-        y -= 1
-        while x > 4:
-            result[(y, x)] = TileState.DANGER
-            x -= 1
-
-        while y > 4:
-            result[(y, x)] = TileState.DANGER
-            y -= 1
 
     @staticmethod
     def _add_enemy_or_projectile(result, coords):

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -339,6 +339,7 @@ class ZeldaObjectData:
 
     def get_all_objects(self, link_pos : np.ndarray) -> tuple:
         """A slightly optimized method to get all objects in the game state, sorted by distance."""
+        # pylint: disable=too-many-locals
 
         enemies = []
         items = []

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -296,13 +296,8 @@ class ZeldaSoundsPulse1(Enum):
     SetBomb : int = 0x20
     HeartWarning : int = 0x40
 
-id_map = {}
-for __c in ZeldaEnemy:
-    id_map[__c.value] = __c
-
-item_map = {}
-for item in ZeldaItem:
-    item_map[item.value] = item
+ID_MAP = {x.value: x for x in ZeldaEnemy}
+ITEM_MAP = {x.value: x for x in ZeldaItem}
 
 class ZeldaObject:
     """Structured data for a single object.  ZeldaObjects are enemies, items, and projectiles."""
@@ -437,12 +432,12 @@ class ZeldaObjectData:
 
             if obj_id == ZeldaEnemy.Item.value:
                 obj_id = obj_status[i]
-                obj_id = item_map.get(obj_id, obj_id)
+                obj_id = ITEM_MAP.get(obj_id, obj_id)
                 items.append(ZeldaObject(obj_id, pos, distance, vector, None, None))
 
             # enemies
             elif 1 <= obj_id <= 0x48:
-                enemy_kind = id_map.get(obj_id, obj_id)
+                enemy_kind = ID_MAP.get(obj_id, obj_id)
                 status = obj_status[i]
 
                 enemy = ZeldaObject(enemy_kind, pos, distance, vector, self.get_obj_health(i), status)

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -122,7 +122,7 @@ def init_walkable_tiles():
     tiles += list(range(0x98, 0x9b+1))  # dungeon locked door north
     tiles += list(range(0xa4, 0xa7+1))  # dungeon locked door east
 
-    return set(tiles)
+    return tiles
 
 WALKABLE_TILES = init_walkable_tiles()
 BRICK_TILE = 0xf6
@@ -136,6 +136,11 @@ def tiles_to_weights(tiles) -> None:
     tiles[walkable_mask] = TileState.WALKABLE.value
 
     tiles[~brick_mask & ~walkable_mask] = TileState.IMPASSABLE.value
+
+def is_room_loaded(tiles):
+    """Returns True if the room is loaded."""
+    any_walkable = np.isin(tiles, WALKABLE_TILES).any()
+    return any_walkable
 
 class TileState(Enum):
     """The state of a tile."""
@@ -408,4 +413,5 @@ __all__ = [
     ZeldaEnemy.__name__,
     AnimationState.__name__,
     tiles_to_weights.__name__,
+    is_room_loaded.__name__,
     ]

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -219,10 +219,6 @@ def position_to_tile_index(x, y):
     """Converts a screen position to a tile index."""
     return (int((y - GAMEPLAY_START_Y) // 8), int(x // 8))
 
-def get_link_tile_index(info):
-    """Returns the tile index of link's position."""
-    return position_to_tile_index(info['link_x'], info['link_y'])
-
 def tile_index_to_position(tile_index):
     """Converts a tile index to a screen position."""
     return (tile_index[1] * 8, tile_index[0] * 8 + GAMEPLAY_START_Y)
@@ -475,7 +471,6 @@ __all__ = [
     'TileState',
     'position_to_tile_index',
     'tile_index_to_position',
-    'get_link_tile_index',
     'is_sword_frozen',
     'is_health_full',
     ZeldaSoundsPulse1.__name__,

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -256,10 +256,10 @@ class ZeldaObject:
     @property
     def is_active(self) -> bool:
         """Returns True if the object is active."""
-        if self.id != ZeldaEnemy.WallMaster:
-            return True
+        if not self.health:
+            return False
 
-        return self.status == 1
+        return self.id != ZeldaEnemy.WallMaster or self.status == 1
 
 class ZeldaObjectData:
     """
@@ -369,10 +369,11 @@ class ZeldaObjectData:
 
             # enemies
             elif 1 <= obj_id <= 0x48:
+                health = self.get_obj_health(i)
                 enemy_kind = ID_MAP.get(obj_id, obj_id)
                 status = obj_status[i]
 
-                enemy = ZeldaObject(enemy_kind, pos, distance, vector, self.get_obj_health(i), status)
+                enemy = ZeldaObject(enemy_kind, pos, distance, vector, health, status)
                 enemies.append(enemy)
 
             elif self.is_projectile(obj_id):

--- a/triforce/zelda_vector_features.py
+++ b/triforce/zelda_vector_features.py
@@ -40,7 +40,7 @@ class ZeldaVectorFeatures(gym.Wrapper):
             return result
 
         result[0] = info['objective_vector']
-        result[1] = self._get_first_vector([x for x in info['enemies'] if self._should_point_at_enemy(info, x)])
+        result[1] = self._get_first_vector(info['active_enemies'])
         result[2] = self._get_first_vector(info['projectiles'])
         result[3] = self._get_first_vector(info['items'])
 
@@ -48,15 +48,11 @@ class ZeldaVectorFeatures(gym.Wrapper):
         return np.array(result, dtype=np.float32)
 
     def _should_point_at_enemy(self, info, enemy):
-        if enemy.id == ZeldaEnemy.WallMaster:
-            dist = np.linalg.norm(np.array(info['link_pos'], dtype=np.float32) - enemy.position)
-            return dist < 30
-
         # Don't point at Zora if the sword isn't powerful enough to kill it in one hit
         if enemy.id == ZeldaEnemy.Zora and info['sword'] <= 1:
             return False
 
-        return True
+        return enemy.is_active
 
     def _get_first_vector(self, entries):
         return entries[0].vector if entries else np.zeros(2, dtype=np.float32)
@@ -64,7 +60,7 @@ class ZeldaVectorFeatures(gym.Wrapper):
     def _get_features(self, info):
         result = np.zeros(2, dtype=np.float32)
 
-        result[0] = 1.0 if 'enemies' in info and info['enemies'] else 0.0
+        result[0] = 1.0 if 'active_enemies' in info and info['active_enemies'] else 0.0
 
         if 'has_beams' in info:
             result[1] = 1.0 if info['has_beams'] else 0.0

--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -13,7 +13,7 @@ import gymnasium as gym
 import numpy as np
 
 from .zelda_game_data import zelda_game_data
-from .zelda_game import AnimationState, Direction, TileState, ZeldaEnemy, get_bomb_state, has_beams, is_in_cave, is_link_stunned, \
+from .zelda_game import AnimationState, Direction, TileState, get_bomb_state, has_beams, is_in_cave, is_link_stunned, \
                         is_mode_death, get_beam_state, is_mode_scrolling, ZeldaObjectData, is_sword_frozen
 from .model_parameters import LOCATION_CHANGE_COOLDOWN, MOVEMENT_FRAMES, RESET_DELAY_MAX_FRAMES, ATTACK_COOLDOWN, \
                                 ITEM_COOLDOWN, CAVE_COOLDOWN, RANDOM_DELAY_MAX_FRAMES

--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -108,7 +108,6 @@ class ZeldaGameWrapper(gym.Wrapper):
         info['tiles'] = tiles
         info['tile_states'] = TileState.create_map(tiles, info['enemies'], info['projectiles'])
 
-        info['are_walls_dangerous'] = any(x.id == ZeldaEnemy.WallMaster for x in info['enemies'])
         info['has_beams'] = has_beams(info) and get_beam_state(info) == AnimationState.INACTIVE
 
         location = self._get_full_location(info)

--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -57,6 +57,7 @@ class ZeldaGameWrapper(gym.Wrapper):
         self._last_info = None
         self._room_maps = {}
         self._rooms_with_locks = set()
+        self._rooms_with_locks.add((1, 0x35, False))
 
     def reset(self, **kwargs):
         obs, info = super().reset(**kwargs)
@@ -161,6 +162,9 @@ class ZeldaGameWrapper(gym.Wrapper):
             curr_keys = info['keys']
             last_keys = self._last_info.get('keys', curr_keys)
             if curr_keys < last_keys:
+                self._room_maps.pop(index, None)
+
+            if len(self._last_info['enemies']) != len(info['enemies']):
                 self._room_maps.pop(index, None)
 
         if index not in self._room_maps:

--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .zelda_game_data import zelda_game_data
 from .zelda_game import AnimationState, Direction, TileState, ZeldaEnemy, get_bomb_state, has_beams, is_in_cave, \
-                        is_link_stunned, is_mode_death, get_beam_state, is_mode_scrolling, ZeldaObjectData, \
+                        is_link_stunned, is_mode_death, get_beam_state, is_mode_scrolling, ZeldaObjectData, is_room_loaded, \
                         is_sword_frozen, get_heart_halves, tiles_to_weights
 from .model_parameters import LOCATION_CHANGE_COOLDOWN, MOVEMENT_FRAMES, RESET_DELAY_MAX_FRAMES, ATTACK_COOLDOWN, \
                                 ITEM_COOLDOWN, CAVE_COOLDOWN, RANDOM_DELAY_MAX_FRAMES
@@ -167,7 +167,8 @@ class ZeldaGameWrapper(gym.Wrapper):
             tiles = ram[map_offset:map_offset+map_len]
             tiles = tiles.reshape((32, 22)).T
 
-            self._room_maps[index] = tiles
+            if is_room_loaded(tiles):
+                self._room_maps[index] = tiles
         else:
             tiles = self._room_maps[index]
 

--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -112,6 +112,7 @@ class ZeldaGameWrapper(gym.Wrapper):
 
         # add information about enemies, items, and projectiles
         info['enemies'], info['items'], info['projectiles'] = objects.get_all_objects(link_pos)
+        info['active_enemies'] = [x for x in info['enemies'] if x.is_active]
 
         # add the tile layout of the room
         self._create_tile_maps(info, ram, link)


### PR DESCRIPTION
- Rework getting/saving tile data.  Once we have a clean copy of the tiles of a room, they don't change unless a door is unlocked.
- Refactor a* path to take in a list of start locations since link is a 2x2 set of tiles.
- Store tiles as weights to improve a* efficiency.
- Reuse parts of the a* path when link moves towards the path.  This cut the amount of time spent in a* in half.
- Better detect when the agent is following the optimal path.
- Add weight to enemies and projectiles so that the a* algorithm will try to path around them.  Even if they are the destination.
- Improve WallMaster handling.
- We now penalize moving into the "space" of enemies (the enemy's tiles and 1 tile around), regardless of the path rewards.  This means the model will stop being rewarded for stepping into an enemies square instead of just attacking.
- Only reward once for hitting enemies (don't multiply by enemies hit).  This ensures that the model isn't rewarded for taking damage while hitting two enemies.  Any damage taken is still bad.