### PR TITLE
Lessen attack reward

### DIFF
--- a/run.py
+++ b/run.py
@@ -337,15 +337,16 @@ class DisplayWindow:
         return model_name, action
 
     def _get_action_from_keys(self, keys):
-        A = ["A"] if keys[pygame.K_a] else []
+        a = ["A"] if keys[pygame.K_a] else []
+        b = ["B"] if keys[pygame.K_s] else []
         if keys[pygame.K_LEFT]:
-            return ['LEFT'] + A
+            return ['LEFT'] + a + b
         if keys[pygame.K_RIGHT]:
-            return ['RIGHT'] + A
+            return ['RIGHT'] + a + b
         if keys[pygame.K_UP]:
-            return ['UP'] + A
+            return ['UP'] + a + b
         if keys[pygame.K_DOWN]:
-            return ['DOWN'] + A
+            return ['DOWN'] + a + b
 
         return None
 

--- a/run.py
+++ b/run.py
@@ -143,6 +143,7 @@ class DisplayWindow:
         endings = {}
         reward_map = {}
         buttons = deque(maxlen=100)
+        next_action = None
 
         model_requested = 0
         model_name = None
@@ -191,11 +192,13 @@ class DisplayWindow:
 
             # Perform a step in the environment
             if mode in ('c', 'n'):
-                zelda_model = self._select_model(info)
-                ai, loaded_name = self._select_available_model(zelda_model, model_requested)
-                model_name = f"{zelda_model.name} ({loaded_name}) {ai.num_timesteps:,} timesteps"
+                if next_action:
+                    action = next_action
+                    model_name = "keyboard input"
+                    next_action = None
+                else:
+                    model_name, action = self._get_action_from_model(model_requested, info, obs)
 
-                action = ai.predict(obs, deterministic=False)
                 last_info = info
                 obs, _, terminated, truncated, info = env.step(action)
 
@@ -288,6 +291,11 @@ class DisplayWindow:
                         elif event.key == pygame.K_u:
                             cap_fps = not cap_fps
 
+                        elif event.key in (pygame.K_LEFT, pygame.K_RIGHT, pygame.K_UP, pygame.K_DOWN):
+                            keys = pygame.key.get_pressed()
+                            next_action = self._get_action_from_keys(keys)
+                            mode = 'n'
+
                         elif event.key == pygame.K_s:
                             if not force_save:
                                 force_save = True
@@ -319,6 +327,28 @@ class DisplayWindow:
 
         env.close()
         pygame.quit()
+
+    def _get_action_from_model(self, model_requested, info, obs):
+        zelda_model = self._select_model(info)
+        ai, loaded_name = self._select_available_model(zelda_model, model_requested)
+        model_name = f"{zelda_model.name} ({loaded_name}) {ai.num_timesteps:,} timesteps"
+
+        action = ai.predict(obs, deterministic=False)
+        return model_name, action
+
+    def _get_action_from_keys(self, keys):
+        A = ["A"] if keys[pygame.K_a] else []
+        if keys[pygame.K_LEFT]:
+            return ['LEFT'] + A
+        if keys[pygame.K_RIGHT]:
+            return ['RIGHT'] + A
+        if keys[pygame.K_UP]:
+            return ['UP'] + A
+        if keys[pygame.K_DOWN]:
+            return ['DOWN'] + A
+
+        return None
+
 
     def _select_model(self, info) -> ZeldaModelDefinition:
         acceptable_models = self.orchestrator.find_acceptable_models(info)

--- a/run.py
+++ b/run.py
@@ -629,7 +629,7 @@ class DisplayWindow:
         for y in range(tile_states.shape[0]):
             for x in range(tile_states.shape[1]):
                 if tile_states[y, x] not in \
-                        (TileState.WALKABLE.value, TileState.IMPASSABLE.value, TileState.BRICK.value):
+                        (TileState.WALKABLE.value, TileState.IMPASSABLE.value):
                     tiles.append((y, x))
 
         tiles += info['link'].tile_coordinates

--- a/run.py
+++ b/run.py
@@ -629,7 +629,7 @@ class DisplayWindow:
         for y in range(tile_states.shape[0]):
             for x in range(tile_states.shape[1]):
                 if tile_states[y, x] not in \
-                        (TileState.WALKABLE.value, TileState.IMPASSABLE.value):
+                        (TileState.WALKABLE.value, TileState.IMPASSABLE.value, TileState.BRICK.value):
                     tiles.append((y, x))
 
         tiles += info['link'].tile_coordinates

--- a/triforce/action_space.py
+++ b/triforce/action_space.py
@@ -25,18 +25,26 @@ class ZeldaActionSpace(gym.ActionWrapper):
 
         assert isinstance(env.action_space, gym.spaces.MultiBinary)
 
-        buttons = env.unwrapped.buttons
+        self.button_count = env.action_space.n
+        self.buttons = env.unwrapped.buttons
 
         self._decode_discrete_action = []
         for action in self.actions:
-            arr = np.array([False] * env.action_space.n)
+            arr = np.array([False] * self.button_count)
 
             for button in action:
-                arr[buttons.index(button)] = True
+                arr[self.buttons.index(button)] = True
 
             self._decode_discrete_action.append(arr)
 
         self.action_space = gym.spaces.Discrete(num_action_space)
 
     def action(self, action):
+        if isinstance(action, list) and len(action) and isinstance(action[0], str):
+            arr = np.array([False] * self.button_count)
+            for button in action:
+                arr[self.buttons.index(button)] = True
+
+            return arr
+
         return self._decode_discrete_action[action].copy()

--- a/triforce/astar.py
+++ b/triforce/astar.py
@@ -48,6 +48,7 @@ def mahattan_distance(y, x, ny, nx):
 WALKABLE_TILES = [TileState.WALKABLE.value,
                            TileState.DANGER.value,
                            TileState.WARNING.value,
+                           TileState.BRICK.value
                            ]
 
 def is_valid_tile(coords, tile_weight_map):
@@ -111,6 +112,20 @@ def a_star(link_bottom_left_tile, tile_weight_map, direction):
     Returns:
         list: The path from the starting position to the goal position.
     """
+
+    # quick out for touching the map's edge
+    if direction == Direction.W and link_bottom_left_tile[1] <= 0:
+        return [get_tile_from_direction(link_bottom_left_tile, direction)]
+
+    if direction == Direction.E and link_bottom_left_tile[1] >= tile_weight_map.shape[1] - 1:
+        return [get_tile_from_direction(link_bottom_left_tile, direction)]
+
+    if direction == Direction.N and link_bottom_left_tile[0] <= 0:
+        return [get_tile_from_direction(link_bottom_left_tile, direction)]
+
+    if direction == Direction.S and link_bottom_left_tile[0] >= tile_weight_map.shape[0] - 1:
+        return [get_tile_from_direction(link_bottom_left_tile, direction)]
+
     came_from = {}
     open_set = []
     g_score = {}

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -419,13 +419,11 @@ class GameplayCritic(ZeldaCritic):
                     progress = new_link_pos[0] - old_link_pos[0]
                 elif target == Direction.W:
                     progress = old_link_pos[0] - new_link_pos[0]
-
-                percent = abs(progress / self.movement_scale_factor)
             else:
                 progress = self.__get_progress(movement_direction, old_link_pos, new_link_pos, target)
-                percent = abs(progress / self.movement_scale_factor)
 
             if progress > 0:
+                percent = min(abs(progress / self.movement_scale_factor), 1)
                 rewards['reward-move-closer'] = self.move_closer_reward * percent
             else:
                 rewards['penalty-move-farther'] = self.move_away_penalty

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -380,8 +380,11 @@ class GameplayCritic(ZeldaCritic):
                 target[1] += 8
 
             progress = self.__get_progress(movement_direction, old_link_pos, new_link_pos, target)
-            if progress >= self.minimum_movement_required:
-                percent = min(progress / self.movement_scale_factor, 1)
+            if progress >= 0:
+                if progress < self.minimum_movement_required:
+                    percent = 0.0
+                else:
+                    percent = min(progress / self.movement_scale_factor, 1)
             else:
                 percent = None
 

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -246,6 +246,7 @@ class GameplayCritic(ZeldaCritic):
 
     def critique_attack(self, old, new, rewards):
         """Critiques attacks made by the player. """
+        # pylint: disable=too-many-branches
         if 'beam_hits' in new and new['beam_hits']:
             rewards['reward-beam-hit'] = self.injure_kill_reward
 

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -442,10 +442,13 @@ class GameplayCritic(ZeldaCritic):
 
         projected_new_pos = old_link_pos + direction_movement
 
-        old_distance = np.linalg.norm(target - old_link_pos)
-        new_distance = np.linalg.norm(target - projected_new_pos)
+        old_distance = self.__manhattan_distance(target, old_link_pos)
+        new_distance = self.__manhattan_distance(target, projected_new_pos)
 
         return old_distance - new_distance
+
+    def __manhattan_distance(self, a, b):
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
 
     def __find_second_turn(self, path):
         turn = 0

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -368,16 +368,8 @@ class GameplayCritic(ZeldaCritic):
         movement_direction = new['link_direction']
 
         if len(old_path) >= 2:
-            # target is the top left of the 8x8 tile, if we are left or above the target, add
-            # 8 to the x or y to get to that edge of the tile.
             target_tile = self.__find_second_turn(old_path)
             target = np.array(tile_index_to_position(target_tile), dtype=np.float32)
-
-            if new_link_pos[0] < target[0]:
-                target[0] += 8
-
-            if new_link_pos[1] < target[1]:
-                target[1] += 8
 
             progress = self.__get_progress(movement_direction, old_link_pos, new_link_pos, target)
             if progress >= 0:
@@ -389,6 +381,7 @@ class GameplayCritic(ZeldaCritic):
                 percent = None
 
             overlap = set(new['link'].tile_coordinates)
+            overlap.intersection_update(old['link'].tile_coordinates) # remove tiles link was already on
             overlap.intersection_update(old_path)
             if percent is not None and overlap:
                 # Did link move into the optimal path?

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -362,6 +362,8 @@ class GameplayCritic(ZeldaCritic):
         old_path = old.get("a*_path", [])
         new_path = new.get("a*_path", [])
 
+        movement_direction = new['link_direction']
+
         if len(old_path) >= 2:
             # target is the top left of the 8x8 tile, if we are left or above the target, add
             # 8 to the x or y to get to that edge of the tile.
@@ -374,7 +376,6 @@ class GameplayCritic(ZeldaCritic):
             if new_link_pos[1] < target[1]:
                 target[1] += 8
 
-            movement_direction = new['link_direction']
             progress = self.__get_progress(movement_direction, old_link_pos, new_link_pos, target)
             if progress >= self.minimum_movement_required:
                 percent = min(progress / self.movement_scale_factor, 1)

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -237,9 +237,12 @@ class GameplayCritic(ZeldaCritic):
             new (Dict[str, int]): The new state of tnhe game.
             rewards (Dict[str, float]): The rewards obtained during gameplay.
         """
-        arrow_deflected = ZeldaSoundsPulse1.ArrowDeflected.value
-        if new['sound_pulse_1'] & arrow_deflected and (old['sound_pulse_1'] & arrow_deflected) != arrow_deflected:
+        if self._is_deflecting(old, new):
             rewards['reward-block'] = self.block_projectile_reward
+
+    def _is_deflecting(self, old, new):
+        arrow_deflected = ZeldaSoundsPulse1.ArrowDeflected.value
+        return new['sound_pulse_1'] & arrow_deflected and (old['sound_pulse_1'] & arrow_deflected) != arrow_deflected
 
     def critique_attack(self, old, new, rewards):
         """Critiques attacks made by the player. """
@@ -340,7 +343,7 @@ class GameplayCritic(ZeldaCritic):
         if new['took_damage']:
             return
 
-        if not old['took_damage']:
+        if not old['took_damage'] and not self._is_deflecting(old, new):
             warning_diff = new['link_warning_tiles'] - old['link_warning_tiles']
             danger_diff = new['link_danger_tiles'] - old['link_danger_tiles']
 

--- a/triforce/objective_selector.py
+++ b/triforce/objective_selector.py
@@ -43,8 +43,6 @@ def find_cave_onscreen(info):
     closest_cave = cave_positions[np.argmin(cave_distances)]
     return closest_cave
 
-ADJACENT_TILES = [(-1, 0), (-1, 1), (2, 0),  (2, 1), (0, -1), (1, -1), (0, 2),  (1, 2)]
-
 class ObjectiveSelector(gym.Wrapper):
     """
     A wrapper that selects objectives for the agent to pursue.  This is used to help the agent decide what to do.
@@ -121,23 +119,14 @@ class ObjectiveSelector(gym.Wrapper):
         path = None
         if self.last_route[0] == key:
             potential_path = self.last_route[1]
-            if potential_path:
-                link_y, link_x = link_tiles[0]
-                adjacent = [(link_y + adj[0], link_x + adj[1]) for adj in ADJACENT_TILES]
-                for i, element in enumerate(potential_path):
-                    if element in link_tiles:
-                        path = potential_path[i+1:]
-                    elif element in adjacent:
-                        if i > 0:
-                            path = potential_path[i:]
-                        else:
-                            path = potential_path
-                            break
+            if potential_path and link_tiles[0] in potential_path:
+                i = potential_path.index(link_tiles[0])
+                path = potential_path[i:]
             if path:
                 self.last_route = key, path
 
         if not path:
-            path = a_star(link_tiles, info['tile_states'], objective_pos_dir)
+            path = a_star(link_tiles[0], info['tile_states'], objective_pos_dir)
             self.last_route = key, path
 
         return path

--- a/triforce/objective_selector.py
+++ b/triforce/objective_selector.py
@@ -114,19 +114,20 @@ class ObjectiveSelector(gym.Wrapper):
 
     def _get_a_star_path(self, info, objective_pos_dir):
         link_tiles = info['link'].tile_coordinates
+        bottom_left_tile = link_tiles[0][0] + 1, link_tiles[0][1]
 
         key = (info['level'], info['location'], objective_pos_dir)
         path = None
         if self.last_route[0] == key:
             potential_path = self.last_route[1]
-            if potential_path and link_tiles[0] in potential_path:
-                i = potential_path.index(link_tiles[0])
-                path = potential_path[i:]
+            if potential_path and bottom_left_tile in potential_path:
+                i = potential_path.index(bottom_left_tile)
+                path = potential_path[i+1:]
             if path:
                 self.last_route = key, path
 
         if not path:
-            path = a_star(link_tiles[0], info['tile_states'], objective_pos_dir)
+            path = a_star(bottom_left_tile, info['tile_states'], objective_pos_dir)
             self.last_route = key, path
 
         return path

--- a/triforce/objective_selector.py
+++ b/triforce/objective_selector.py
@@ -101,10 +101,9 @@ class ObjectiveSelector(gym.Wrapper):
 
         # find the optimal route to the objective
         if objective_pos_dir is not None:
-            if not isinstance(objective_pos_dir, Direction):
-                objective_pos_dir = position_to_tile_index(*objective_pos_dir)
-
-            path = self._get_a_star_path(info, objective_pos_dir)
+            a_star_tile = objective_pos_dir if isinstance(objective_pos_dir, Direction) \
+                                            else position_to_tile_index(*objective_pos_dir)
+            path = self._get_a_star_path(info, a_star_tile)
 
             info['a*_path'] = path
 

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -117,7 +117,7 @@ def is_sword_frozen(state):
 
 def init_walkable_tiles():
     """Returns a lookup table of whether particular tile codes are walkable."""
-    tiles = [0x26, 0x24, 0x8d, 0x91, 0xac, 0xad, 0xcc, 0xd2, 0xd5, 0x68, 0x6f, 0x82, 0x78, 0x7d, 0x87]
+    tiles = [0x26, 0x24, 0x8d, 0x91, 0xac, 0xad, 0xcc, 0xd2, 0xd5, 0x68, 0x6f, 0x82, 0x78, 0x7d, 0x87, 0xf6]
     tiles += list(range(0x74, 0x77+1))  # dungeon floor tiles
     tiles += list(range(0x98, 0x9b+1))  # dungeon locked door north
     tiles += list(range(0xa4, 0xa7+1))  # dungeon locked door east
@@ -125,17 +125,12 @@ def init_walkable_tiles():
     return tiles
 
 WALKABLE_TILES = init_walkable_tiles()
-BRICK_TILE = 0xf6
 
 def tiles_to_weights(tiles) -> None:
     """Converts the tiles from RAM to a set of weights for the A* algorithm."""
-    brick_mask = tiles == BRICK_TILE
-    tiles[brick_mask] = TileState.BRICK.value
-
     walkable_mask = np.isin(tiles, WALKABLE_TILES)
     tiles[walkable_mask] = TileState.WALKABLE.value
-
-    tiles[~brick_mask & ~walkable_mask] = TileState.IMPASSABLE.value
+    tiles[~walkable_mask] = TileState.IMPASSABLE.value
 
 def is_room_loaded(tiles):
     """Returns True if the room is loaded."""
@@ -146,7 +141,6 @@ class TileState(Enum):
     """The state of a tile."""
     IMPASSABLE = 100
     WALKABLE = 1
-    BRICK = 5       # dungeon bricks
     WARNING = 25    # tiles next to enemy, or the walls in a wallmaster room
     DANGER = 50     # enemy or projectile
 

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -146,9 +146,9 @@ class TileState(Enum):
     """The state of a tile."""
     IMPASSABLE = 100
     WALKABLE = 1
-    BRICK = 2      # dungeon bricks
-    WARNING = 3    # tiles next to enemy, or the walls in a wallmaster room
-    DANGER = 4     # enemy or projectile
+    WARNING = 2    # tiles next to enemy, or the walls in a wallmaster room
+    DANGER = 3     # enemy or projectile
+    BRICK = 4      # dungeon bricks
 
 def position_to_tile_index(x, y):
     """Converts a screen position to a tile index."""


### PR DESCRIPTION
- Added a way to control game from keyboard to test critics.
- Now consider all of Link's tiles when pathfinding to avoid the pathfinding algorithm punishing the agent for not taking impossible moves.
- Track room progress via the manhattan distance of just the direction pressed on the dpad.  (This avoids penalizing/rewarding for the amount of distance link is snapped to the grid in the perpendicular direction to where the agent moved.)
- Don't reward/penalize "dangerous" tiles when link deflects an attack.
- Lower kill rewards when in a room where killing isn't the goal.  Still reward highly for beam kills far away, since that makes it likelier to get through the room without taking damage.