### PR TITLE
Always give aligned enemy vectors

### DIFF
--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -144,7 +144,7 @@ class ZeldaGameWrapper(gym.Wrapper):
     def _get_aligned_enemies(self, info):
         """Gets enemies that are aligned with the player."""
         active_enemies = info['active_enemies']
-        if not active_enemies or not info['beams_available']:
+        if not active_enemies:
             return []
 
         link_top_left = info['link'].tile_coordinates[0]


### PR DESCRIPTION
- Always provide aligned enemy vectors, even when we don't have sword beams.
- Allow the agent to move into alignment with enemies (when it has beams) without penalizing moving off of the optimal path.