### PR TITLE
Optimize the codebase and move from numpy -> torch where possible

### DIFF
--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -2,13 +2,13 @@
 
 from enum import Enum
 from typing import Dict
-import numpy as np
+import torch
 
 from triforce.action_space import ActionKind
 from triforce.rewards import REWARD_LARGE, REWARD_MAXIMUM, REWARD_MEDIUM, REWARD_MINIMUM, REWARD_SMALL, REWARD_TINY, \
     Penalty, Reward, StepRewards
 
-from .zelda_enums import Direction, SwordKind, ZeldaAnimationKind, AnimationState
+from .zelda_enums import SwordKind, ZeldaAnimationKind, AnimationState
 from .game_state_change import ZeldaStateChange
 
 HEALTH_LOST_PENALTY = Penalty("penalty-lost-health", -REWARD_LARGE)
@@ -227,12 +227,12 @@ class GameplayCritic(ZeldaCritic):
             if not curr.enemies:
                 rewards.add(ATTACK_NO_ENEMIES_PENALTY)
 
-            elif (active_enemies := curr.active_enemies):
-                enemy_vectors = [enemy.vector for enemy in active_enemies if abs(enemy.distance) > 0]
-                if enemy_vectors:
-                    link_vector = curr.link.direction.to_vector()
-                    dotproducts = np.sum(link_vector * enemy_vectors, axis=1)
-                    if not np.any(dotproducts > np.sqrt(2) / 2):
+            elif (active_enemies := [x for x in curr.active_enemies if x.distance > 0]):
+                enemy_vectors = torch.stack([x.vector for x in active_enemies])
+
+                if enemy_vectors is not None:
+                    dotproducts = torch.sum(curr.link.direction.vector * enemy_vectors, dim=1)
+                    if not torch.any(dotproducts > torch.sqrt(torch.tensor(2)) / 2):
                         rewards.add(ATTACK_MISS_PENALTY)
                     elif not prev.link.are_beams_available:
                         distance = active_enemies[0].distance
@@ -262,8 +262,9 @@ class GameplayCritic(ZeldaCritic):
 
         if prev != curr:
             health_change = state_change.previous.link.health - self._room_enter_health
-            reward = (np.clip(health_change, -3.0, 3.0) + 3) / 6
-            reward = np.clip(reward, REWARD_MINIMUM, REWARD_MAXIMUM)
+            # clamp the reward to [-1, 1]
+            reward = (max(min(health_change, 3.0), -3.0) + 3) / 6
+            reward = max(min(reward, REWARD_MAXIMUM), REWARD_MINIMUM)
 
             if curr in state_change.previous.objectives.next_rooms:
                 if (curr, prev) in self._correct_locations:
@@ -321,20 +322,8 @@ class GameplayCritic(ZeldaCritic):
         else:
             # We moved closer, but scale the reward by the pixels moved in case the agent finds a way to exploit
             # our reward system.
-            match curr_link.direction:
-                case Direction.N:
-                    dir_vect = np.array([0, -1], dtype=np.float32)
-                case Direction.S:
-                    dir_vect = np.array([0, 1], dtype=np.float32)
-                case Direction.E:
-                    dir_vect = np.array([1, 0], dtype=np.float32)
-                case Direction.W:
-                    dir_vect = np.array([-1, 0], dtype=np.float32)
-                case _:
-                    raise ValueError("Invalid direction")
-
-            movement = curr_link.position.numpy - prev_link.position.numpy
-            progress = np.dot(movement, dir_vect)
+            movement = curr_link.position.torch - prev_link.position.torch
+            progress = torch.dot(movement, curr_link.direction.vector).item()
             # TODO: investigate why this happens
             progress = max(progress, 0)
             rewards.add(MOVE_CLOSER_REWARD, progress / MOVEMENT_SCALE_FACTOR)

--- a/triforce/enemy.py
+++ b/triforce/enemy.py
@@ -16,10 +16,6 @@ class Enemy(ZeldaObject):
     spawn_state : int
     status : int
 
-    def mark_invulnerable(self):
-        """Marks the enemy as invulnerable."""
-        self.status |= ENEMY_INVULNERABLE
-
     @property
     def dimensions(self) -> Tuple[int, int]:
         """The dimensions of the object."""
@@ -58,8 +54,3 @@ class Enemy(ZeldaObject):
     def is_stunned(self) -> bool:
         """Returns True if the enemy is stunned."""
         return self.stun_timer > 0
-
-    @property
-    def is_invulnerable(self) -> bool:
-        """Returns True if the enemy is invulnerable and cannot take damage."""
-        return not self.is_active or self.status & ENEMY_INVULNERABLE == ENEMY_INVULNERABLE

--- a/triforce/game_state_change.py
+++ b/triforce/game_state_change.py
@@ -171,7 +171,7 @@ class ZeldaStateChange:
             if terminated or truncated:
                 break
 
-            curr = ZeldaGame(curr, env, info, curr.frames + 1)
+            curr = ZeldaGame(env, info, curr.frames + 1)
 
         # Check if we hit any enemies and store those into our damage counters and the discount of future hits
         self._compare_health_status(start, curr, self.__dict__)

--- a/triforce/game_state_change.py
+++ b/triforce/game_state_change.py
@@ -3,6 +3,7 @@
 from typing import Dict, List, Optional
 
 import numpy as np
+import torch
 
 from .action_space import ActionTaken
 from .zelda_enums import AnimationState, ZeldaItemKind, ZeldaAnimationKind
@@ -15,7 +16,7 @@ class ZeldaStateChange:
         self.frames : List[np.ndarray] = frames
         self.previous : ZeldaGame = prev
         self.state : ZeldaGame = curr
-        self.action_mask : Optional[np.ndarray] = None
+        self.action_mask : Optional[torch.Tensor] = None
         self.actions_available = None
 
         self.health_lost = (max(0, prev.link.health - curr.link.health + health_changed) \

--- a/triforce/link.py
+++ b/triforce/link.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from functools import cached_property
 
-import numpy as np
+import torch
 from .zelda_enums import ActionKind, AnimationState, ArrowKind, BoomerangKind, CandleKind, Direction, PotionKind, \
     RingKind, SelectedEquipmentKind, SwordKind, TileIndex, ZeldaAnimationKind, SoundKind
 from .zelda_objects import ZeldaObject
@@ -299,10 +299,10 @@ class Link(ZeldaObject):
         self.game.magic_shield = value
 
     # Dungeon items
-    @property
+    @cached_property
     def triforce_pieces(self) -> int:
         """The number of triforce pieces link has (does not include Triforce of Power in level 9)."""
-        return np.binary_repr(self.game.triforce).count('1')
+        return torch.popcount(torch.tensor(self.game.triforce, dtype=torch.uint8)).item()
 
     @property
     def triforce_of_power(self) -> bool:

--- a/triforce/link.py
+++ b/triforce/link.py
@@ -1,5 +1,6 @@
 
 from dataclasses import dataclass
+from functools import cached_property
 
 import numpy as np
 from .zelda_enums import ActionKind, AnimationState, ArrowKind, BoomerangKind, CandleKind, Direction, PotionKind, \
@@ -28,7 +29,7 @@ class Link(ZeldaObject):
     direction : Direction
     status : int
 
-    @property
+    @cached_property
     def link_overlap_tiles(self):
         """The tiles that the object overlaps with link's top-left tile."""
         x_dim, y_dim = self.dimensions

--- a/triforce/link.py
+++ b/triforce/link.py
@@ -2,7 +2,6 @@
 from dataclasses import dataclass
 from functools import cached_property
 
-import torch
 from .zelda_enums import ActionKind, AnimationState, ArrowKind, BoomerangKind, CandleKind, Direction, PotionKind, \
     RingKind, SelectedEquipmentKind, SwordKind, TileIndex, ZeldaAnimationKind, SoundKind
 from .zelda_objects import ZeldaObject
@@ -302,7 +301,13 @@ class Link(ZeldaObject):
     @cached_property
     def triforce_pieces(self) -> int:
         """The number of triforce pieces link has (does not include Triforce of Power in level 9)."""
-        return torch.popcount(torch.tensor(self.game.triforce, dtype=torch.uint8)).item()
+        triforce = self.game.triforce
+        count = 0
+        while triforce:
+            count += triforce & 1
+            triforce >>= 1
+
+        return count
 
     @property
     def triforce_of_power(self) -> bool:

--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -79,6 +79,8 @@ class PPO:
 
         env = create_env()
         network = create_network(network, env.observation_space, env.action_space)
+        if (load_path := kwargs.get('load_path', None)) is not None:
+            network.load(load_path)
 
         envs = kwargs.get('envs', 1)
 

--- a/triforce/observation_wrapper.py
+++ b/triforce/observation_wrapper.py
@@ -218,7 +218,7 @@ class ObservationWrapper(gym.Wrapper):
             if obj.distance <= 1e-5:
                 result[i] = torch.tensor([0, 0, -1], dtype=torch.float32)
             else:
-                result[i, :2] = torch.from_numpy(obj.vector[:2])
+                result[i, :2] = obj.vector[:2]
                 result[i, 2] = obj.distance / DISTANCE_SCALE
 
         return result

--- a/triforce/room.py
+++ b/triforce/room.py
@@ -1,7 +1,7 @@
 # This file contains the Room class, which represents a single room in the game.""
 from collections import OrderedDict
 from typing import Sequence, Tuple
-import numpy as np
+import torch
 
 from .wavefront import Wavefront
 from .zelda_objects import ZeldaObject
@@ -34,8 +34,8 @@ def init_half_walkable_tiles():
             0xaf, 0xb9, 0xbb, 0xad, 0xb1, 0xdd, 0xde, 0xd9, 0xdb, 0xdf, 0xd1, 0xdc, 0xd0, 0xda
             ]
 
-WALKABLE_TILES = init_walkable_tiles()
-HALF_WALKABLE_TILES = init_half_walkable_tiles()
+WALKABLE_TILES = torch.tensor(init_walkable_tiles(), dtype=torch.uint8)
+HALF_WALKABLE_TILES = torch.tensor(init_half_walkable_tiles(), dtype=torch.uint8)
 BRICK_TILE = 0xf6
 
 class Room:
@@ -51,7 +51,7 @@ class Room:
         """Gets or creates a room."""
         # pylint: disable=too-many-locals
 
-        walkable_tiles = np.zeros(((tiles.shape[0] + 1, tiles.shape[1] + 1)), dtype=bool)
+        walkable_tiles = torch.zeros(((tiles.shape[0] + 1, tiles.shape[1] + 1)), dtype=bool)
         for x in range(-1, tiles.shape[0]):
             for y in range(-1, tiles.shape[1]):
                 # top left
@@ -101,10 +101,10 @@ class Room:
 
         return result
 
-    def __init__(self, location, tiles : np.ndarray, walkable : np.ndarray):
+    def __init__(self, location, tiles : torch.Tensor, walkable : torch.Tensor):
         self.full_location = location
-        self.tiles : np.ndarray = tiles
-        self.walkable : np.ndarray = walkable
+        self.tiles : torch.Tensor = tiles
+        self.walkable : torch.Tensor = walkable
         self.exits = self._get_exit_tiles()
         self.cave_tile = self._get_cave_coordinates()
         self._wf_lru = OrderedDict()
@@ -146,7 +146,7 @@ class Room:
     @property
     def is_loaded(self):
         """Returns True if the room is loaded."""
-        any_walkable = np.isin(self.tiles, WALKABLE_TILES).any()
+        any_walkable = torch.isin(self.tiles, WALKABLE_TILES).any()
         return any_walkable
 
     def _get_exit_tiles(self):

--- a/triforce/simulate_critic.py
+++ b/triforce/simulate_critic.py
@@ -13,8 +13,8 @@ def simulate_critique(env, action, scenario : ZeldaScenario, old : Dict, new : D
 
     rewards = {}
     critic.clear()
-    prev = ZeldaGame(None, env, old, 0)
-    state = ZeldaGame(prev, env, new, 0)
+    prev = ZeldaGame(env, old, 0)
+    state = ZeldaGame(env, new, 0)
     change = ZeldaStateChange(env, prev, state, action, [], {}, 0)
     critic.critique_gameplay(change, rewards)
 

--- a/triforce/zelda_enums.py
+++ b/triforce/zelda_enums.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-import numpy as np
+import torch
 
 # the y coordinate where the gameplay window starts (above this line is the HUD)
 GAMEPLAY_START_Y = 56
@@ -220,13 +220,13 @@ class Direction(Enum):
         """Returns the vector for the direction."""
         match self:
             case Direction.E:
-                return np.array([1, 0])
+                return torch.tensor([1, 0], dtype=torch.float32)
             case Direction.W:
-                return np.array([-1, 0])
+                return torch.tensor([-1, 0], dtype=torch.float32)
             case Direction.S:
-                return np.array([0, 1])
+                return torch.tensor([0, 1], dtype=torch.float32)
             case Direction.N:
-                return np.array([0, -1])
+                return torch.tensor([0, -1], dtype=torch.float32)
             case _:
                 raise ValueError(f"Unhandled Direction: {self}")
 
@@ -283,11 +283,6 @@ class Coordinates:
         if not isinstance(other, Coordinates):
             return NotImplemented
         return (self.x, self.y) < (other.x, other.y)
-
-    @property
-    def numpy(self):
-        """Returns the position as a numpy array."""
-        return np.array([self.x, self.y], dtype=np.float32)
 
     def __add__(self, other):
         if isinstance(other, Coordinates):

--- a/triforce/zelda_enums.py
+++ b/triforce/zelda_enums.py
@@ -1,6 +1,7 @@
 """Various enumerations of equipment, item, and enemy types in the game."""
 
 from enum import Enum
+from functools import cached_property
 
 import torch
 
@@ -216,7 +217,8 @@ class Direction(Enum):
             case _:
                 return Direction.NONE
 
-    def to_vector(self):
+    @cached_property
+    def vector(self):
         """Returns the vector for the direction."""
         match self:
             case Direction.E:
@@ -297,6 +299,11 @@ class Coordinates:
         if isinstance(other, tuple) and len(other) == 2:
             return Coordinates(self.x - other[0], self.y - other[1])
         raise TypeError("Can only subtract Coordinates or a tuple of length 2.")
+
+    @property
+    def torch(self):
+        """Converts the coordinates to a torch tensor."""
+        return torch.tensor([self.x, self.y], dtype=torch.float32)
 
 class Position(Coordinates):
     """A position in the game world."""

--- a/triforce/zelda_enums.py
+++ b/triforce/zelda_enums.py
@@ -1,7 +1,6 @@
 """Various enumerations of equipment, item, and enemy types in the game."""
 
 from enum import Enum
-from numbers import Integral
 
 import numpy as np
 
@@ -237,17 +236,8 @@ ITEM_MAP = {x.value: x for x in ZeldaItemKind}
 class Coordinates:
     """Base class of coordinates in the game world."""
     def __init__(self, x: int, y: int):
-        if isinstance(x, Integral):
-            x = int(x)
-
-        if isinstance(y, Integral):
-            y = int(y)
-
-        if not isinstance(x, int) or not isinstance(y, int):
-            raise TypeError("Both elements must be integers.")
-
-        self._x = x
-        self._y = y
+        self._x = int(x)
+        self._y = int(y)
 
     @property
     def x(self) -> int:

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import List, Optional
 
 import gymnasium as gym
+import torch
 
 from .room import Room
 from .zelda_objects import Item, Projectile
@@ -224,7 +225,7 @@ class ZeldaGame:
         map_offset, map_len = zelda_game_data.tables['tile_layout']
         tiles = self.ram[map_offset:map_offset+map_len]
         tiles = tiles.reshape((32, 22)).T.swapaxes(0, 1)
-        return tiles
+        return torch.from_numpy(tiles)
 
     @property
     def game_over(self):

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -37,8 +37,9 @@ class ObjectTables:
 
 class ZeldaGame:
     """The current state of a zelda game."""
-    __active = None
+    # pylint: disable=too-many-public-methods
 
+    __active = None
     _env : gym.Env
     info : dict
     frames : int

--- a/triforce/zelda_objects.py
+++ b/triforce/zelda_objects.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Set, Tuple
 
-import numpy as np
+import torch
 
 from .zelda_enums import TileIndex, ZeldaEnemyKind, ZeldaItemKind, ZeldaProjectileId, Position
 
@@ -58,7 +58,7 @@ class ZeldaObject:
     @cached_property
     def distance(self) -> float:
         """The distance from link to the object."""
-        value = np.linalg.norm(self.vector_from_link)
+        value = torch.norm(self.vector_from_link)
         if abs(value) < 1e-5:
             return 0
 
@@ -69,14 +69,14 @@ class ZeldaObject:
         """The normalized direction vector from link to the object."""
         distance = self.distance
         if distance == 0:
-            return np.array([0, 0], dtype=np.float32)
+            return torch.tensor([0, 0], dtype=torch.float32)
 
         return self.vector_from_link / distance
 
     @cached_property
     def vector_from_link(self):
         """The (un-normalized) vector from link to the object."""
-        return self.position.numpy - self.game.link.position.numpy
+        return torch.tensor(self.position - self.game.link.position, dtype=torch.float32)
 
 @dataclass
 class Projectile(ZeldaObject):

--- a/triforce/zelda_objects.py
+++ b/triforce/zelda_objects.py
@@ -59,7 +59,7 @@ class ZeldaObject:
     def distance(self) -> float:
         """The distance from link to the object."""
         value = np.linalg.norm(self.vector_from_link)
-        if np.isclose(value, 0, atol=1e-5):
+        if abs(value) < 1e-5:
             return 0
 
         return value

--- a/triforce/zelda_objects.py
+++ b/triforce/zelda_objects.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Tuple
+from functools import cached_property
+from typing import Set, Tuple
 
 import numpy as np
 
@@ -26,35 +27,36 @@ class ZeldaObject:
         """The dimensions of the object."""
         return 2, 2
 
-    @property
-    def tile(self):
+    @cached_property
+    def tile(self) -> TileIndex:
         """The x, y coordinates of the top-left tile in this object."""
         return self.position.tile_index
 
-    @property
-    def link_overlap_tiles(self):
+    @cached_property
+    def link_overlap_tiles(self) -> Set[TileIndex]:
         """The tiles that the object overlaps with link's top-left tile."""
-        result = []
+        result = set()
         x_dim, y_dim = self.dimensions
         for x in range(-1, x_dim):
             for y in range(-1, y_dim):
-                result.append(TileIndex(self.tile[0] + x, self.tile[1] + y))
+                result.add(TileIndex(self.tile[0] + x, self.tile[1] + y))
 
         return result
 
-    @property
-    def self_tiles(self):
+
+    @cached_property
+    def self_tiles(self) -> Set[TileIndex]:
         """The tiles that the object occupies."""
-        result = []
+        result = set()
         x_dim, y_dim = self.dimensions
         for x in range(x_dim):
             for y in range(y_dim):
-                result.append(TileIndex(self.tile[0] + x, self.tile[1] + y))
+                result.add(TileIndex(self.tile[0] + x, self.tile[1] + y))
 
         return result
 
-    @property
-    def distance(self):
+    @cached_property
+    def distance(self) -> float:
         """The distance from link to the object."""
         value = np.linalg.norm(self.vector_from_link)
         if np.isclose(value, 0, atol=1e-5):
@@ -62,7 +64,7 @@ class ZeldaObject:
 
         return value
 
-    @property
+    @cached_property
     def vector(self):
         """The normalized direction vector from link to the object."""
         distance = self.distance
@@ -71,15 +73,10 @@ class ZeldaObject:
 
         return self.vector_from_link / distance
 
-    @property
+    @cached_property
     def vector_from_link(self):
         """The (un-normalized) vector from link to the object."""
-        vector = self.__dict__.get('_vector', None)
-        if vector is None:
-            vector = self.position.numpy - self.game.link.position.numpy
-            self.__dict__['_vector']  = vector
-
-        return vector
+        return self.position.numpy - self.game.link.position.numpy
 
 @dataclass
 class Projectile(ZeldaObject):

--- a/triforce/zelda_wrapper.py
+++ b/triforce/zelda_wrapper.py
@@ -101,9 +101,7 @@ class ZeldaGameWrapper(gym.Wrapper):
 
     def _create_and_set_state(self, info):
         prev = self._prev_state
-        state = ZeldaGame(prev, self, info, self._total_frames)
-        state.activate()
-
+        state = ZeldaGame(self, info, self._total_frames)
         self._prev_state = state
         return prev, state
 


### PR DESCRIPTION
This pull request focuses on transitioning the codebase from using NumPy to PyTorch for tensor operations and improving the training functionality. The most important changes include importing PyTorch, updating various tensor operations, and adding functionality to load models during training.

### Transition to PyTorch:
* [`train.py`](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R12): Imported PyTorch and updated the device handling to use PyTorch's `torch.device`. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R12) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R35-R36)
* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL5-R11): Replaced NumPy operations with equivalent PyTorch operations for vector calculations and reward clamping. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL5-R11) [[2]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL230-R235) [[3]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL265-R267) [[4]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL324-R326) [[5]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL348-L363)
* [`triforce/ml_ppo.py`](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012L4): Updated tensor operations and random shuffling to use PyTorch. [[1]](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012L4) [[2]](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012R81-R82) [[3]](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012L260-R264) [[4]](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012L327-R331) [[5]](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012L339-R340)
* [`triforce/observation_wrapper.py`](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL221-R221): Changed tensor creation to use PyTorch directly.
* [`triforce/rewards.py`](diffhunk://#diff-a39384e6e7dae626ffb6ad6219ff58a9fdd5368c59babe08115a06d605e204b3L5): Replaced NumPy's `clip` and `mean` functions with equivalent PyTorch operations. [[1]](diffhunk://#diff-a39384e6e7dae626ffb6ad6219ff58a9fdd5368c59babe08115a06d605e204b3L5) [[2]](diffhunk://#diff-a39384e6e7dae626ffb6ad6219ff58a9fdd5368c59babe08115a06d605e204b3L118-R122) [[3]](diffhunk://#diff-a39384e6e7dae626ffb6ad6219ff58a9fdd5368c59babe08115a06d605e204b3L230-R240)

### Additional functionality:
* [`train.py`](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R72): Added an argument to load a pre-trained model for continued training. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R72) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L43-R48)
* [`triforce/ml_ppo.py`](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012R81-R82): Implemented functionality to load a model if a load path is provided.

### Code simplification and cleanup:
* [`triforce/enemy.py`](diffhunk://#diff-9899ee8f7d59e33006956035c7443159f9cba59643e0bfccd73bcb46f1803aa3L19-L22): Removed the `mark_invulnerable` method and `is_invulnerable` property as they were unused. [[1]](diffhunk://#diff-9899ee8f7d59e33006956035c7443159f9cba59643e0bfccd73bcb46f1803aa3L19-L22) [[2]](diffhunk://#diff-9899ee8f7d59e33006956035c7443159f9cba59643e0bfccd73bcb46f1803aa3L61-L65)
* [`triforce/link.py`](diffhunk://#diff-cf3329d14e9dcb45a3f9e14cf3e0c71b5a3b0602cddd36690704c52f536fd437R3-L4): Replaced `@property` with `@cached_property` for `link_overlap_tiles` and `triforce_pieces` to improve performance. [[1]](diffhunk://#diff-cf3329d14e9dcb45a3f9e14cf3e0c71b5a3b0602cddd36690704c52f536fd437R3-L4) [[2]](diffhunk://#diff-cf3329d14e9dcb45a3f9e14cf3e0c71b5a3b0602cddd36690704c52f536fd437L31-R31) [[3]](diffhunk://#diff-cf3329d14e9dcb45a3f9e14cf3e0c71b5a3b0602cddd36690704c52f536fd437L301-R310)
* [`triforce/game_state_change.py`](diffhunk://#diff-56e1f2e6b526f77d6b8acbc8e46fe1b7961a69cd8ed73dcdffef6d6908965e38R6): Removed unnecessary import and updated the `ZeldaGame` instantiation. [[1]](diffhunk://#diff-56e1f2e6b526f77d6b8acbc8e46fe1b7961a69cd8ed73dcdffef6d6908965e38R6) [[2]](diffhunk://#diff-56e1f2e6b526f77d6b8acbc8e46fe1b7961a69cd8ed73dcdffef6d6908965e38L18-R19) [[3]](diffhunk://#diff-56e1f2e6b526f77d6b8acbc8e46fe1b7961a69cd8ed73dcdffef6d6908965e38L174-R175)
* [`triforce/room.py`](diffhunk://#diff-a6d0e611488edff89ba5e921cbfb70b95bc90c5637c232c1ec69c677b6d3dedcL4-R4): Converted walkable tiles to use PyTorch tensors. [[1]](diffhunk://#diff-a6d0e611488edff89ba5e921cbfb70b95bc90c5637c232c1ec69c677b6d3dedcL4-R4) [[2]](diffhunk://#diff-a6d0e611488edff89ba5e921cbfb70b95bc90c5637c232c1ec69c677b6d3dedcL37-R38) [[3]](diffhunk://#diff-a6d0e611488edff89ba5e921cbfb70b95bc90c5637c232c1ec69c677b6d3dedcL54-R54)