### PR TITLE
Implement frame stacking

### DIFF
--- a/tests/ppo_test.py
+++ b/tests/ppo_test.py
@@ -153,7 +153,7 @@ def test_model_training(model_scenario, num_channels):
 
     # Make sure we can successfully use the model
     for step in range(3):
-        assert obs.shape[0] == num_channels, f"Expected {num_channels} channels, but got {obs.shape[0]}"
+        assert obs["image"].shape[0] == num_channels, f"Expected {num_channels} channels, but got {obs.shape[0]}"
         logits, value = network(obs)
         action_probs = torch.softmax(logits, dim=-1)
         action = torch.argmax(action_probs).item()  # Select the most probable action

--- a/tests/ppo_test.py
+++ b/tests/ppo_test.py
@@ -129,9 +129,9 @@ def test_ppo_training(device, num_envs):
     expected_actions = [0, 1, 2]
     assert actions_taken == expected_actions, f"Expected actions {expected_actions}, but got {actions_taken}"
 
-@pytest.mark.parametrize("num_envs", [1])
+@pytest.mark.parametrize("num_channels", [1, 3])
 @pytest.mark.parametrize("model_scenario", ["full-game start-overworld1", "overworld-sword overworld-sword"])
-def test_model_training(model_scenario, num_envs):
+def test_model_training(model_scenario, num_channels):
     model_name, scenario_name = model_scenario.split(" ")
     model_def : ModelDefinition = ModelDefinition.get(model_name)
     assert model_def is not None, f"Unknown model: {model_name}"
@@ -140,11 +140,11 @@ def test_model_training(model_scenario, num_envs):
     assert scenario_name is not None, f"Unknown scenario: {scenario_name}"
 
     def create_env():
-        return make_zelda_env(scenario_name, model_def.action_space)
+        return make_zelda_env(scenario_name, model_def.action_space, frame_stack=num_channels)
 
     progress = MagicMock()
     ppo = PPO("cpu", log_dir=None)
-    network = ppo.train(SharedNatureAgent, create_env, ppo.target_steps * 2 + 1, progress, envs=num_envs)
+    network = ppo.train(SharedNatureAgent, create_env, ppo.target_steps * 2 + 1, progress)
     assert progress.update.call_count, "PPO did not call update"
 
     env = create_env()
@@ -153,6 +153,7 @@ def test_model_training(model_scenario, num_envs):
 
     # Make sure we can successfully use the model
     for step in range(3):
+        assert obs.shape[0] == num_channels, f"Expected {num_channels} channels, but got {obs.shape[0]}"
         logits, value = network(obs)
         action_probs = torch.softmax(logits, dim=-1)
         action = torch.argmax(action_probs).item()  # Select the most probable action

--- a/train.py
+++ b/train.py
@@ -44,8 +44,10 @@ def main():
     if scenario_def is None:
         raise ValueError(f"Unknown scenario: {args.scenario}")
 
+    frame_stack = args.frame_stack if args.frame_stack > 0 else 1
+
     def create_env():
-        return make_zelda_env(scenario_def, model_def.action_space, obs_kind=args.obs_kind)
+        return make_zelda_env(scenario_def, model_def.action_space, obs_kind=args.obs_kind, frame_stack=frame_stack)
 
     device = args.device if args.device else  torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -80,6 +82,7 @@ def parse_args():
     parser.add_argument("--dynamic-lr", action='store_true', default=None, help="Use a dynamic learning rate.")
     parser.add_argument("--obs-kind", choices=['gameplay', 'viewport', 'full'], default='viewport',
                         help="The kind of observation to use.")
+    parser.add_argument("--frame-stack", type=int, default=1, help="The number of frames to stack in the observation.")
     parser.add_argument("--device", choices=['cpu', 'cuda'], default=None, help="The device to use.")
 
     parser.add_argument('model', type=str, help='The model to train.')

--- a/triforce/observation_wrapper.py
+++ b/triforce/observation_wrapper.py
@@ -5,7 +5,7 @@ convert the image to grayscale.  We also stack multiple frames together to give 
 of motion over time.
 """
 
-from typing import Sequence
+from typing import List, Sequence
 import gymnasium as gym
 from gymnasium.spaces import Box, Dict
 import numpy as np
@@ -52,10 +52,12 @@ VIEWPORT_PIXELS = 128
 
 class ObservationWrapper(gym.Wrapper):
     """A wrapper that trims the HUD and converts the image to grayscale."""
-    def __init__(self, env, kind, normalize):
+    def __init__(self, env, kind, frame_stack, frame_skip, normalize):
         super().__init__(env)
         self._prev_loc = None
         self._normalize = normalize
+        self.frame_stack = frame_stack
+        self.frame_skip = frame_skip
 
         if kind in ('gameplay', 'viewport'):
             self._trim = GAMEPLAY_START_Y
@@ -75,24 +77,22 @@ class ObservationWrapper(gym.Wrapper):
 
     def reset(self, **kwargs):
         frames, state = self.env.reset(**kwargs)
-        obs = frames[-1]
         self._prev_loc = state.full_location
-        obs = self._get_observation(state, obs)
+        obs = self._get_observation(state, frames)
         return obs, state
 
     def step(self, action):
         frames, reward, terminated, truncated, state_change = self.env.step(action)
-        obs = frames[-1]
-
         if state_change.previous.full_location != state_change.state.full_location:
             self._prev_loc = state_change.previous.full_location
 
-        obs = self._get_observation(state_change.state, obs)
+        obs = self._get_observation(state_change.state, frames)
         return obs, reward, terminated, truncated, state_change
 
-    def _get_observation(self, state : ZeldaGame, frame):
+    def _get_observation(self, state : ZeldaGame, frames : List[np.ndarray]):
+        tensor = self._get_stacked_frames(frames, self.frame_stack, self.frame_skip)
         return {
-            "image" : self._get_image_observation(state, frame),
+            "image" : self._get_image_observation(state, tensor),
             "vectors" : self._get_vectors(state),
             "information" : self._get_information(state)
             }
@@ -102,7 +102,7 @@ class ObservationWrapper(gym.Wrapper):
         # we also move the last channel count to be the first dimension to avoid a VecTransposeImage wrapper
         height = self.observation_space.shape[0]
         width = self.observation_space.shape[1]
-        dim = 1
+        channels = self.frame_stack
 
         low = 0.0
         high = 1.0 if self._normalize else 255.0
@@ -115,25 +115,63 @@ class ObservationWrapper(gym.Wrapper):
         elif self._trim:
             height -= self._trim
 
-        return Box(low=low, high=high, shape=(dim, height, width), dtype=dtype)
+        return Box(low=low, high=high, shape=(channels, height, width), dtype=dtype)
 
-    def _get_image_observation(self, state: ZeldaGame, frame: np.ndarray) -> torch.Tensor:
+    def _get_stacked_frames(self, frames, count, skip):
         """
-        Convert frame to the expected PyTorch format, possibly trim,
+        Stack `count` frames from the `frames` list, skipping `skip` frames between them.
+        If there aren't enough frames, duplicate the first frame to pad the stack.
+
+        Args:
+            frames (List[np.ndarray]): List of frames as numpy arrays with shape (H, W, C).
+            count (int): Number of frames to stack.
+            skip (int): Number of frames to skip between stacked frames.
+
+        Returns:
+            torch.Tensor: Stacked frames as a tensor with shape (count, C, H, W).
+        """
+        stacked_frames = []
+
+        for i in range(count):
+            frame_index = len(frames) - 1 - i * skip
+            if frame_index >= 0:
+                stacked_frames.append(frames[frame_index])
+            else:
+                # Not enough frames, duplicate the first frame
+                stacked_frames.append(frames[0])
+
+        # Reverse the order to maintain chronological order: oldest to newest
+        stacked_frames.reverse()
+
+        # Convert frames to tensors and permute axes (C, H, W)
+        stacked_tensors = [
+            torch.as_tensor(frame, dtype=torch.float32).permute(2, 0, 1)
+            for frame in stacked_frames
+        ]
+
+        # Stack along the first dimension (stack size)
+        return torch.stack(stacked_tensors, dim=0)
+
+    def _get_image_observation(self, state: ZeldaGame, frames: torch.Tensor) -> torch.Tensor:
+        """
+        Convert a batch of frames to the expected PyTorch format, possibly trim,
         convert to grayscale, and extract a viewport around Link.
+
+        Args:
+            state (ZeldaGame): Current game state containing Link's position.
+            frames (torch.Tensor): Batch of frames with shape (N, C, H, W).
+
+        Returns:
+            torch.Tensor: Processed batch of frames with shape (N, 1, viewport_size, viewport_size).
         """
-
         if self._normalize:
-            frame = torch.as_tensor(frame, dtype=torch.float32) / 255.0
-        else:
-            frame = torch.as_tensor(frame, dtype=torch.float32)
-
-        frame = frame.permute(2, 0, 1)
+            frames = frames / 255.0
 
         if self._trim:
-            frame = frame[:, self._trim:, :]
+            frames = frames[:, :, self._trim:, :]
 
-        frame = (frame * GRAYSCALE_WEIGHTS.view(-1, 1, 1)).sum(dim=0, keepdim=True)
+        # Convert to grayscale using the weights
+        frames = (frames * GRAYSCALE_WEIGHTS.view(1, -1, 1, 1)).sum(dim=1, keepdim=False)
 
         if self._viewport_size:
             x = state.link.position.x
@@ -141,7 +179,7 @@ class ObservationWrapper(gym.Wrapper):
             half_vp = self._viewport_size // 2
 
             # Current height and width (after trimming)
-            h, w = frame.shape[-2], frame.shape[-1]
+            h, w = frames.shape[-2], frames.shape[-1]
 
             # Compute necessary padding
             top_pad = max(0, half_vp - y)
@@ -151,25 +189,26 @@ class ObservationWrapper(gym.Wrapper):
 
             # Pad using replicate if Link is near an edge
             if top_pad > 0 or bottom_pad > 0 or left_pad > 0 or right_pad > 0:
-                frame = F.pad(frame, (left_pad, right_pad, top_pad, bottom_pad), mode='replicate')
+                frames = F.pad(frames, (left_pad, right_pad, top_pad, bottom_pad), mode='replicate')
 
             # Adjust coordinates after padding
             y += top_pad
             x += left_pad
 
-            # Crop out the viewport
-            frame = frame[...,  # keep channel as-is
-                          y - half_vp : y + half_vp,
-                          x - half_vp : x + half_vp]
+            # Crop out the viewport for each frame in the batch
+            frames = frames[:,  # keep batch dimension as-is
+                            y - half_vp : y + half_vp,
+                            x - half_vp : x + half_vp]
 
-        # 6) If not normalizing, clamp to [0, 255] and cast to byte
         if not self._normalize:
-            frame = frame.clamp_(0, 255).byte()
+            frames = frames.clamp_(0, 255).byte()
 
-        if frame.shape[-2] != self._viewport_size or frame.shape[-1] != self._viewport_size:
-            frame = self._reshape(frame)
+        # Ensure all frames have the expected viewport size
+        if frames.shape[-2] != self._viewport_size or frames.shape[-1] != self._viewport_size:
+            frames = self._reshape(frames)
 
-        return frame
+        return frames
+
 
     def _reshape(self, frame: torch.Tensor) -> torch.Tensor:
         """

--- a/triforce/zelda_env.py
+++ b/triforce/zelda_env.py
@@ -11,7 +11,8 @@ from .scenario_wrapper import ScenarioWrapper, TrainingScenarioDefinition
 from .rewards import EpisodeRewardTracker
 
 def make_zelda_env(scenario : TrainingScenarioDefinition, action_space : str, *,
-                   obs_kind = 'viewport', render_mode = None, translation=True):
+                   obs_kind = 'viewport', render_mode = None, translation=True,
+                   frame_stack=1):
     """
     Creates a Zelda retro environment for the given scenario.
     Args:
@@ -37,7 +38,7 @@ def make_zelda_env(scenario : TrainingScenarioDefinition, action_space : str, *,
     env = ZeldaActionSpace(env, action_space)
 
     # Converts our list of frames into a standard observation space.
-    env = ObservationWrapper(env, obs_kind, normalize=True)
+    env = ObservationWrapper(env, obs_kind, frame_stack, frame_skip=2, normalize=True)
 
     # Process the scenario. This is where we define the end conditions and rewards for the scenario.
     # Replaces the float reward with a StepRewards object.

--- a/triforce/zelda_game.py
+++ b/triforce/zelda_game.py
@@ -278,9 +278,9 @@ class ZeldaGame:
         return item
 
     def _build_enemy(self, tables, index, obj_id):
-        health = tables.read("obj_health")[index] >> 4
+        health = int(tables.read("obj_health")[index] >> 4)
         status = tables.read("obj_status")[index]
-        stun_timer = tables.read("obj_stun_timer")[index]
+        stun_timer = int(tables.read("obj_stun_timer")[index])
         spawn_state = tables.read("obj_spawn_state")[index]
         pos = self._read_position(tables, index)
         direction = self._read_direction(tables, index)
@@ -292,8 +292,8 @@ class ZeldaGame:
         return Projectile(self, index, obj_id, self._read_position(tables, index))
 
     def _read_position(self, tables, index):
-        x = tables.read('obj_pos_x')[index]
-        y = tables.read('obj_pos_y')[index]
+        x = int(tables.read('obj_pos_x')[index])
+        y = int(tables.read('obj_pos_y')[index])
         return Position(x, y)
 
     def _read_direction(self, tables, index):


### PR DESCRIPTION
This pull request introduces changes to enhance the frame stacking functionality and improve the observation handling in the `triforce` environment. The most important changes include adding support for frame stacking in the environment creation functions, updating the observation wrapper to handle stacked frames, and modifying test cases to accommodate these changes.

Enhancements to frame stacking:

* [`train.py`](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R47-R50): Added a `--frame-stack` argument to specify the number of frames to stack in the observation and updated the `create_env` function to use this parameter. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R47-R50) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R85)
* [`triforce/zelda_env.py`](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28L14-R15): Updated the `make_zelda_env` function to accept a `frame_stack` parameter and pass it to the `ObservationWrapper`. [[1]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28L14-R15) [[2]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28L40-R41)

Updates to observation handling:

* [`triforce/observation_wrapper.py`](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL8-R8): Modified the `ObservationWrapper` to handle frame stacking and updated related methods to process stacked frames. [[1]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL8-R8) [[2]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL55-R60) [[3]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL78-R95) [[4]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL105-R105) [[5]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL118-R182) [[6]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL154-L172)

Test case modifications:

* [`tests/ppo_test.py`](diffhunk://#diff-8ff65cc26fefebc60719af71bbad72bbb2ec0dea4894af7a8aeabcc254fd9824L132-R134): Updated test cases to use `num_channels` instead of `num_envs` and added assertions to verify the number of channels in observations. [[1]](diffhunk://#diff-8ff65cc26fefebc60719af71bbad72bbb2ec0dea4894af7a8aeabcc254fd9824L132-R134) [[2]](diffhunk://#diff-8ff65cc26fefebc60719af71bbad72bbb2ec0dea4894af7a8aeabcc254fd9824L143-R147) [[3]](diffhunk://#diff-8ff65cc26fefebc60719af71bbad72bbb2ec0dea4894af7a8aeabcc254fd9824R156)