### PR TITLE
Added training hints to speed up training

### DIFF
--- a/triforce/action_space.py
+++ b/triforce/action_space.py
@@ -234,6 +234,10 @@ class ZeldaActionSpace(gym.Wrapper):
         actions_possible = self.actions_allowed & link.get_available_actions(ActionKind.BEAMS in self.actions_allowed)
         assert actions_possible, "No actions available, we should have at least MOVE."
 
+        invalid = {}
+        for action, direction in state.info.get('invalid_actions', []):
+            invalid.setdefault(action, []).append(direction)
+
         mask = torch.zeros(self.total_actions, dtype=bool)
         for action in actions_possible:
             index = self.action_to_index[action]
@@ -272,6 +276,10 @@ class ZeldaActionSpace(gym.Wrapper):
                         else:
                             for direction in link.get_sword_directions_allowed():
                                 mask[index + self._direction_to_index(direction)] = True
+
+            if action in invalid:
+                for direction in invalid[action]:
+                    mask[index + self._direction_to_index(direction)] = False
 
         return mask
 

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -365,18 +365,21 @@ class GameplayCritic(ZeldaCritic):
     def set_progress(self, state_change : StateChange, rewards : StepRewards):
         """Sets the progress based on how many rooms we have seen, enemies hit, and other factors."""
 
-        rooms = [(0, 0x67),
-                 (0, 0x68),
-                 (0, 0x58),
-                 (0, 0x48),
-                 (0, 0x38),
-                 (0, 0x37),]
+        rooms = {
+            (0, 0x77) : 0,
+            (0, 0x67) : 1,
+            (0, 0x78) : 1,
+            (0, 0x68) : 2,
+            (0, 0x58) : 3,
+            (0, 0x48) : 4,
+            (0, 0x38) : 5,
+            (0, 0x37) : 6,
+        }
 
         level = state_change.state.level
         location = state_change.state.location
-        if (level, location) in rooms:
-            self._progress = max(self._progress, rooms.index((level, location)) / len(rooms))
 
+        self._progress = rooms.get((level, location), 0)
         rewards.progress = self._progress
 
 REWARD_ENTERED_CAVE = Reward("reward-entered-cave", REWARD_LARGE)

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -32,7 +32,7 @@ BEAM_ATTACK_REWARD = Reward("reward-beam-hit", REWARD_MEDIUM)
 PENALTY_CAVE_ATTACK = Penalty("penalty-attack-cave", -REWARD_MAXIMUM)
 USED_BOMB_PENALTY = Penalty("penalty-bomb-miss", -REWARD_MEDIUM)
 BOMB_HIT_REWARD = Reward("reward-bomb-hit", REWARD_SMALL)
-PENALTY_WRONG_LOCATION = Penalty("penalty-wrong-location", -REWARD_MEDIUM)
+PENALTY_WRONG_LOCATION = Penalty("penalty-wrong-location", -REWARD_MAXIMUM)
 
 def _init_equipment_rewards():
     """Initializes the equipment rewards."""

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -1,5 +1,6 @@
 """All end conditions for training."""
 
+from .objectives import ObjectiveKind, Objectives
 from .state_change_wrapper import StateChange
 from .zelda_enums import SwordKind
 
@@ -151,5 +152,17 @@ class LeftRoom(ZeldaEndCondition):
                 return False, True, "truncated-left-room"
 
             return True, False, "failure-left-room"
+
+        return False, False, None
+
+class LeftRoute(ZeldaEndCondition):
+    """End condition for leaving the current room."""
+    def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
+        prev = state_change.previous
+        state = state_change.state
+        if prev.full_location != state.full_location:
+            objectives : Objectives = state_change.previous.objectives
+            if objectives.kind == ObjectiveKind.MOVE and state.location != objectives.next_rooms:
+                return True, False, "failure-left-route"
 
         return False, False, None

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -108,7 +108,7 @@ class EnteredDungeon(ZeldaEndCondition):
 
 class LeftOverworld1Area(ZeldaEndCondition):
     """End the scenario if the agent leaves the allowable areas between the start room and dungeon 1."""
-    overworld_dungeon1_walk_rooms = set([0x78, 0x67, 0x68, 0x58, 0x48, 0x38, 0x37])
+    overworld_dungeon1_walk_rooms = set([0x77, 0x78, 0x67, 0x68, 0x58, 0x48, 0x38, 0x37])
 
     def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
         state = state_change.state

--- a/triforce/scenario_wrapper.py
+++ b/triforce/scenario_wrapper.py
@@ -27,6 +27,7 @@ class TrainingScenarioDefinition(BaseModel):
     reward_overrides : Optional[Dict[str, Union[int, float, None]]] = {}
     end_conditions : List[str]
     start : List[str]
+    use_hints : Optional[bool] = False
     per_reset : Optional[Dict[str, int | str]] = {}
     per_frame : Optional[Dict[str, int | str]] = {}
     per_room : Optional[Dict[str, int | str]] = {}

--- a/triforce/state_change_wrapper.py
+++ b/triforce/state_change_wrapper.py
@@ -274,6 +274,9 @@ class StateChangeWrapper(gym.Wrapper):
             for name, value in self.per_reset:
                 self._set_value(curr, name, value)
 
+            for name, value in self.per_room:
+                self._set_value(curr, name, value)
+
         elif prev.full_location != curr.full_location:
             for name, value in self.per_room:
                 self._set_value(curr, name, value)

--- a/triforce/training_hints.py
+++ b/triforce/training_hints.py
@@ -1,6 +1,6 @@
-from typing import Optional
 import gymnasium as gym
 
+from .objectives import ObjectiveKind
 from .zelda_enums import ActionKind, Direction
 from .zelda_game import ZeldaGame
 
@@ -26,7 +26,8 @@ class TrainingHintWrapper(gym.Wrapper):
         if state.full_location == (0, 0x38) and link.tile.y < 0xa:
             info.setdefault('invalid_actions', []).append((ActionKind.MOVE, Direction.N))
 
-        if not state.full_location.in_cave:
+        # TODO: always have the next room in objectives
+        if not state.full_location.in_cave and state.objectives.kind != ObjectiveKind.ITEM:
             if link.tile.x == 0:
                 self._check_room_direction(state, info, Direction.W)
             elif link.tile.x == 0x1e:

--- a/triforce/training_hints.py
+++ b/triforce/training_hints.py
@@ -1,0 +1,29 @@
+import gymnasium as gym
+
+from .zelda_enums import ActionKind, Direction
+from .zelda_game import ZeldaGame
+
+class TrainingHintWrapper(gym.Wrapper):
+    """Training hints for early stages of training a model."""
+
+    def reset(self, **kwargs):
+        """Resets the environment."""
+        obs, state = self.env.reset(**kwargs)
+        self._disable_actions(None, state)
+        return obs, state
+
+    def step(self, action, **kwargs):
+        """Steps the environment."""
+        obs, reward, terminated, truncated, state_change = self.env.step(action, **kwargs)
+        self._disable_actions(state_change.previous, state_change.state)
+        return obs, reward, terminated, truncated, state_change
+
+    def _disable_actions(self, prev : ZeldaGame, state : ZeldaGame):
+        info = state.info
+        if state.full_location == (0, 0x38) and state.link.tile.y < 0xa:
+            info.setdefault('invalid_actions', []).append((ActionKind.MOVE, Direction.N))
+
+
+        if prev is not None and prev.full_location != state.full_location:
+            direction = state.full_location.get_direction_to(prev.full_location)
+            info.setdefault('invalid_actions', []).append((ActionKind.MOVE, direction))

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -30,12 +30,12 @@
             "use_hints" : true,
             "per_room":
             {
-                "health" : "max_health",
-                "sword" : 1
+                "health" : "max_health"
             },
             "per_reset":
             {
-                "bombs" : 3
+                "bombs" : 3,
+                "sword" : 1
             }
         },
         {

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -25,7 +25,7 @@
             "iterations" : 2000000,
             "scenario_selector" : "round-robin",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
+            "end_conditions": ["LeftRoute", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
             "start": ["0_77"],
             "use_hints" : true,
             "per_room":

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -26,10 +26,12 @@
             "scenario_selector" : "round-robin",
             "critic": "GameplayCritic",
             "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
-            "start": ["0_67s"],
+            "start": ["0_77"],
+            "use_hints" : true,
             "per_room":
             {
-                "health" : "max_health"
+                "health" : "max_health",
+                "sword" : 1
             },
             "per_reset":
             {

--- a/triforce/zelda_enums.py
+++ b/triforce/zelda_enums.py
@@ -336,6 +336,15 @@ class MapLocation(Coordinates):
         self.in_cave = in_cave
 
     def __eq__(self, other) -> bool:
+        if isinstance(other, tuple):
+            match len(other):
+                case 2:
+                    return self.level == other[0] and self.value == other[1]
+                case 3:
+                    return self.level == other[0] and self.value == other[1] and self.in_cave == other[2]
+                case _:
+                    raise ValueError("Invalid tuple length.")
+
         return super().__eq__(other) and self.level == other.level and self.in_cave == other.in_cave
 
     def __hash__(self):


### PR DESCRIPTION
This pull request introduces several changes to the `triforce` module, focusing on enhancing the action masking logic, refining penalties and rewards, updating end conditions, and adding support for training hints. Below is a summary of the most important changes:

### Enhancements to Action Masking:

* [`triforce/action_space.py`](diffhunk://#diff-91dfe18526c4f51067c04dae9b4e85386a775dbae653aa2d891dfea4541dc593R237-R240): Added logic to handle invalid actions by incorporating them into the action mask, ensuring that certain actions are disabled based on the game state. [[1]](diffhunk://#diff-91dfe18526c4f51067c04dae9b4e85386a775dbae653aa2d891dfea4541dc593R237-R240) [[2]](diffhunk://#diff-91dfe18526c4f51067c04dae9b4e85386a775dbae653aa2d891dfea4541dc593R280-R283)

### Updates to Penalties and Rewards:

* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL35-R35): Adjusted the `PENALTY_WRONG_LOCATION` to use `REWARD_MAXIMUM` instead of `REWARD_MEDIUM` and revised the progress calculation to use a dictionary for room progress tracking. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL35-R35) [[2]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL368-R382)

### Modifications to End Conditions:

* [`triforce/end_conditions.py`](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L111-R112): Added a new end condition `LeftRoute` to handle scenarios where the agent leaves the current room and updated the `overworld_dungeon1_walk_rooms` set. [[1]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L111-R112) [[2]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041R157-R168)

### Support for Training Hints:

* [`triforce/training_hints.py`](diffhunk://#diff-c294e508448bf86896e16b6942e13930abf5679c7ee4a6fff14accad17e93c88R1-R43): Introduced a new `TrainingHintWrapper` class to provide training hints during the early stages of model training, disabling certain actions based on the game state.

### Configuration and Environment Setup:

* [`triforce/scenario_wrapper.py`](diffhunk://#diff-fa08e750dba921e14ee50bbc4ba0e171cfbb46128e8ca58c8ad244c19603a449R30): Added a `use_hints` option to the `TrainingScenarioDefinition` class to enable or disable training hints.
* [`triforce/zelda_env.py`](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R5): Modified the `make_zelda_env` function to accept additional keyword arguments and conditionally apply the `TrainingHintWrapper` based on the `use_hints` setting. [[1]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R5) [[2]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28L13-R14) [[3]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R25-R29) [[4]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R41-R44)

These changes collectively enhance the functionality and flexibility of the `triforce` module, improving the action masking logic, refining the reward and penalty system, and adding support for training hints to guide the model during training.