### PR TITLE
Wavefront objective change

### DIFF
--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -374,6 +374,16 @@ class GameplayCritic(ZeldaCritic):
             (0, 0x48) : 4,
             (0, 0x38) : 5,
             (0, 0x37) : 6,
+            (1, 0x72) : 2,
+            (1, 0x63) : 3,
+            (1, 0x53) : 4, # here
+            (1, 0x52) : 5,
+            (1, 0x42) : 6,
+            (1, 0x43) : 7,
+            (1, 0x44) : 8,
+            (1, 0x45) : 9,
+            (1, 0x35) : 10,
+            (1, 0x36) : 11,
         }
 
         level = state_change.state.level

--- a/triforce/models.py
+++ b/triforce/models.py
@@ -338,7 +338,7 @@ class ModelDefinition(BaseModel):
             return available_models
 
         if not os.path.exists(path):
-            raise FileNotFoundError(f"Path {path} does not exist")
+            return available_models
 
         # Check if .pt
         full_path = os.path.join(path, self.name + '.pt')

--- a/triforce/objectives.py
+++ b/triforce/objectives.py
@@ -224,9 +224,17 @@ class Objectives:
                         target_location = item_to_overworld[i]
                         break
         else:
-            # Find where the triforce is
-            target_item = ZeldaItemKind(ZeldaItemKind.Triforce1.value - state.level + 1)
-            target_location = item_to_dungeon[target_item]
+            # Directional hint to avoid dead end
+            if state.full_location == (1, 0x53, False):
+                target_location = MapLocation(1, 0x52, False)
+
+            elif state.full_location == (1, 0x52, False):
+                target_location = MapLocation(1, 0x42, False)
+
+            else:
+                # Find where the triforce is
+                target_item = ZeldaItemKind(ZeldaItemKind.Triforce1.value - state.level + 1)
+                target_location = item_to_dungeon[target_item]
 
         if self._last_route[:2] == (state.level, state.location):
             return self._last_route[2]

--- a/triforce/objectives.py
+++ b/triforce/objectives.py
@@ -194,6 +194,9 @@ class Objectives:
         """Finds the route to the next objective on the game's map then returns what exit tiles the
         agent would need to take to get there and what next rooms that would lead to."""
         # pylint: disable=too-many-branches
+        if state.in_cave:
+            return state.room.exits[Direction.S], [MapLocation(state.level, state.location, False)]
+
         if state.level == 0:
             # Figure out which dungeon to go to
             if state.link.sword == SwordKind.NONE:

--- a/triforce/objectives.py
+++ b/triforce/objectives.py
@@ -1,9 +1,8 @@
 from enum import Enum
 
 import heapq
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Set
 
-from .zelda_objects import ZeldaObject
 from .zelda_game import ZeldaGame
 from .zelda_enums import BoomerangKind, Direction, MapLocation, SwordKind, TileIndex, ZeldaItemKind
 
@@ -45,18 +44,10 @@ class ObjectiveKind(Enum):
 
 class Objective:
     """The current objective for the agent."""
-    def __init__(self, kind : ObjectiveKind, targets, next_rooms : set[int] = None):
+    def __init__(self, kind : ObjectiveKind, targets : Set[TileIndex], next_rooms : Set[int]):
         self.kind : ObjectiveKind = kind
         self.next_rooms : Sequence[MapLocation] = next_rooms if next_rooms is not None else set()
-
-        self.targets : Sequence[TileIndex] = []
-        for target in targets:
-            if isinstance(target, ZeldaObject):
-                self.targets.extend(target.self_tiles)
-            elif isinstance(target, TileIndex):
-                self.targets.append(target)
-            else:
-                raise ValueError(f"Invalid target type: {type(target)}")
+        self.targets : Sequence[TileIndex] = targets
 
 CAVE_TREASURE_TILE = TileIndex(0x0f, 0x0b)
 
@@ -96,21 +87,6 @@ class Objectives:
         self._rooms : Dict[RoomMemory] = {}
         self._last_route = 0, 0, []
 
-    def get_current_objectives(self, prev : Optional[ZeldaGame], state : ZeldaGame) -> Objective:
-        """Get the current objectives for the agent."""
-        self._update_exits(state)
-
-        # If there are items we need nearby, get them:
-        if state.items:
-            targets = [item for item in state.items if item.distance < 200]
-            if targets:
-                return Objective(ObjectiveKind.ITEM, targets)
-
-        if state.level == 0:
-            return self._get_overworld_objectives(state)
-
-        return self._get_dungeon_objectives(prev, state)
-
     def _update_exits(self, state: ZeldaGame):
         if state.in_cave:
             return
@@ -122,42 +98,146 @@ class Objectives:
         else:
             self._rooms[state.full_location].referesh_state(state)
 
-    def _get_dungeon_objectives(self, prev : Optional[ZeldaGame], state : ZeldaGame):
+    def get_current_objectives(self, prev : Optional[ZeldaGame], state : ZeldaGame) -> Objective:
+        """Get the current objectives for the agent."""
+        self._update_exits(state)
+
+        if state.level == 0:
+            kind, tile_objectives, next_rooms = self._get_overworld_room_objective(state)
+        else:
+            kind, tile_objectives, next_rooms = self._get_dungeon_room_objective(prev, state)
+
+        if kind == ObjectiveKind.NONE:
+            kind = ObjectiveKind.MOVE
+
+        # add all items to the target tiles so wavefront lets us walk to them
+        for item in state.items:
+            for tile in item.link_overlap_tiles:
+                tile_objectives.append(tile)
+
+        # Get the route on the game's overall map of where we need to go.  If we need to fight or
+        # collect treasure, do not add the next room to the list of rooms to go to.
+        if kind not in (ObjectiveKind.FIGHT, ObjectiveKind.TREASURE):
+            exit_tiles, rooms = self._get_map_objective(state)
+            tile_objectives.extend(exit_tiles)
+            next_rooms.extend(rooms)
+
+        objective = Objective(kind, set(tile_objectives), set(next_rooms))
+        return objective
+
+    def _get_overworld_room_objective(self, state : ZeldaGame):
+        # If we are in a cave, either get the item or leave
+        tile_objectives = []
+        next_rooms = []
+        if state.in_cave:
+            item = overworld_to_item.get(state.location, None)
+            if item is None or state.link.has_item(item):
+                tile_objectives.extend(state.room.exits[Direction.S])
+                next_rooms.append(MapLocation(state.level, state.location, False))
+                return ObjectiveKind.MOVE, tile_objectives, next_rooms
+
+            # Cave equipment doesn't follow normal treasure rules
+            tile_objectives.append(CAVE_TREASURE_TILE)
+            return ObjectiveKind.TREASURE, tile_objectives, next_rooms
+
+        # If the current screen has a cave, only go inside if we need the item
+        cave_tile = state.room.cave_tile
+        if cave_tile is not None and (item := overworld_to_item.get(state.location, None)) is not None:
+
+            # Dungeon entrance
+            if isinstance(item, int):
+                if not state.link.has_triforce(item):
+                    next_rooms.append(MapLocation(item, dungeon_entrances[item], False))
+                    tile_objectives.append(cave_tile)
+                    return ObjectiveKind.CAVE, tile_objectives, next_rooms
+
+            # Overworld item cave
+            elif not state.link.has_item(item):
+                next_rooms.append(MapLocation(state.level, state.location, True))
+                tile_objectives.append(cave_tile)
+                return ObjectiveKind.CAVE, tile_objectives, next_rooms
+
+        return ObjectiveKind.NONE, tile_objectives, next_rooms
+
+    def _get_dungeon_room_objective(self, prev : Optional[ZeldaGame], state : ZeldaGame):
         # If treasure is already dropped, get it
+        kind = ObjectiveKind.NONE
+        tile_objectives = []
         treasure_tile = state.treasure_tile
         if treasure_tile is not None:
-            return Objective(ObjectiveKind.TREASURE, [treasure_tile])
+            kind = ObjectiveKind.TREASURE
+            tile_objectives.append(treasure_tile)
 
         # If we collect the treasure, mark it as taken
-        room_memory : RoomMemory = self._rooms.get(state.full_location, None)
-        if room_memory.item and prev and prev.treasure_tile is not None:
-            room_memory.item = None
+        else:
+            room_memory : RoomMemory = self._rooms.get(state.full_location, None)
+            if room_memory.item and prev and prev.treasure_tile is not None:
+                room_memory.item = None
 
-        # If we know there's treasure in the room not spawned, kill enemies.
-        if room_memory.item is not None:
-            if targets := self._get_enemy_targets(state.enemies):
-                return Objective(ObjectiveKind.FIGHT, targets)
+            # If we know there's treasure in the room not spawned, kill enemies.
+            if room_memory.item is not None and state.enemies:
+                kind = ObjectiveKind.FIGHT
+                if state.active_enemies:
+                    tile_objectives.extend(tile
+                                            for enemy in state.active_enemies
+                                            for tile in enemy.link_overlap_tiles)
+                elif state.enemies:
+                    tile_objectives.extend(tile
+                                            for enemy in state.enemies
+                                            for tile in enemy.link_overlap_tiles)
+                else:
+                    room_memory.item = None
 
-            room_memory.item = None
+        return kind, tile_objectives, []
 
-        # otherwise, head to the triforce piece
-        target_item = ZeldaItemKind(ZeldaItemKind.Triforce1.value - state.level + 1)
-        item_location = item_to_dungeon[target_item]
-        return self._get_route_objective(state, item_location)
+    def _get_map_objective(self, state):
+        """Finds the route to the next objective on the game's map then returns what exit tiles the
+        agent would need to take to get there and what next rooms that would lead to."""
+        # pylint: disable=too-many-branches
+        if state.level == 0:
+            # Figure out which dungeon to go to
+            if state.link.sword == SwordKind.NONE:
+                target_location = item_to_overworld[SwordKind.WOOD]
 
-    def _get_enemy_targets(self, enemies):
-        if not enemies:
-            return []
+            elif state.link.sword == SwordKind.WOOD and state.link.max_health >= 5:
+                target_location = item_to_overworld[SwordKind.WHITE]
 
-        # Enemies could still be loading in.  We either want to target just the active enemies (if there are any)
-        # or all enemies if there are none active.
-        return [ tile
-                 for enemy in enemies if enemy.is_active
-                 for tile in enemy.link_overlap_tiles
-                 ] or [tile for enemy in enemies for tile in enemy.self_tiles]
+            elif state.link.max_health >= 13:
+                target_location = item_to_overworld[SwordKind.MAGIC]
+
+            # level 2 is pretty easy, we'll allow going there first
+            elif state.link.triforce_pieces == 0:
+                dungeon2 = MapLocation(0, item_to_overworld[2], False)
+                dist = state.full_location.manhattan_distance(dungeon2)
+
+                dungeon1 = MapLocation(0, item_to_overworld[1], False)
+                if dist > state.full_location.manhattan_distance(dungeon1):
+                    # a directional hint so we don't get stuck
+                    if state.full_location.value not in (0x38, 0x37):
+                        target_location = MapLocation(0, 0x38, False)
+                    else:
+                        target_location = dungeon1
+
+            else:
+                for i in range(1, 9):
+                    if not state.link.has_triforce(i):
+                        target_location = item_to_overworld[i]
+                        break
+        else:
+            # Find where the triforce is
+            target_item = ZeldaItemKind(ZeldaItemKind.Triforce1.value - state.level + 1)
+            target_location = item_to_dungeon[target_item]
+
+        if self._last_route[:2] == (state.level, state.location):
+            return self._last_route[2]
+
+        paths = self._get_route_with_astar(state.level, state.location, target_location, state.link.keys)
+        exit_targets, next_rooms = self._get_targets_rooms_from_paths(state, paths)
+
+        return exit_targets, next_rooms
 
 
-    def _paths_to_targets(self, state, paths):
+    def _get_targets_rooms_from_paths(self, state, paths):
         next_rooms = set(x[1] for x in paths if len(x) > 1)
         directions = [state.full_location.get_direction_to(x) for x in next_rooms]
 
@@ -166,77 +246,6 @@ class Objectives:
             targets += state.room.exits[direction]
 
         return targets, next_rooms
-
-    def _get_overworld_objectives(self, state : ZeldaGame):
-        # If we are in a cave, either get the item or leave
-        if state.in_cave:
-            return self._get_cave_objective(state)
-
-        # If the current screen has a cave, only go inside if we need the item
-        cave_tile = state.room.cave_tile
-        if cave_tile is not None and (item := overworld_to_item.get(state.location, None)) is not None:
-            if isinstance(item, int):
-                if not state.link.has_triforce(item):
-                    next_rooms = [MapLocation(item, dungeon_entrances[item], False)]
-                    return Objective(ObjectiveKind.CAVE, [cave_tile], next_rooms)
-
-            elif not state.link.has_item(item):
-                next_rooms = [MapLocation(state.level, state.location, True)]
-                return Objective(ObjectiveKind.CAVE, [cave_tile], next_rooms)
-
-        # Otherwise look for the next dungeon to go into.
-        return self._get_route_to_dungeon_objective(state)
-
-    def _get_route_to_dungeon_objective(self, state : ZeldaGame):
-        if state.link.sword == SwordKind.NONE:
-            target = item_to_overworld[SwordKind.WOOD]
-
-        elif state.link.sword == SwordKind.WOOD and state.link.max_health >= 5:
-            target = item_to_overworld[SwordKind.WHITE]
-
-        elif state.link.max_health >= 13:
-            target = item_to_overworld[SwordKind.MAGIC]
-
-        # level 2 is pretty easy, we'll allow going there first
-        elif state.link.triforce_pieces == 0:
-            dungeon2 = MapLocation(0, item_to_overworld[2], False)
-            dist = state.full_location.manhattan_distance(dungeon2)
-
-            dungeon1 = MapLocation(0, item_to_overworld[1], False)
-            if dist > state.full_location.manhattan_distance(dungeon1):
-                # a directional hint so we don't get stuck
-                target = MapLocation(0, 0x38, False) if state.full_location.value not in (0x38, 0x37) else dungeon1
-
-        else:
-            for i in range(1, 9):
-                if not state.link.has_triforce(i):
-                    target = item_to_overworld[i]
-                    break
-
-        # we now have a location to move to
-        return self._get_route_objective(state, target)
-
-    def _get_route_objective(self, state, target):
-        if self._last_route[:2] == (state.level, state.location):
-            return self._last_route[2]
-
-        paths = self._get_route_with_astar(state.level, state.location, target, state.link.keys)
-        targets, next_rooms = self._paths_to_targets(state, paths)
-
-        result = Objective(ObjectiveKind.MOVE, targets, next_rooms)
-        self._last_route = state.level, state.location, result
-        return result
-
-    def _get_cave_objective(self, state : ZeldaGame):
-        assert state.in_cave
-
-        item = overworld_to_item.get(state.location, None)
-        if item is None or state.link.has_item(item):
-            target_room = MapLocation(state.level, state.location, False)
-            return Objective(ObjectiveKind.MOVE, state.room.exits[Direction.S], set([target_room]))
-
-        # Cave equipment doesn't follow normal treasure rules
-        return Objective(ObjectiveKind.TREASURE, [CAVE_TREASURE_TILE])
 
     def _enumerate_attached_rooms(self, location, key_count):
         # if we have memory of the room, use that

--- a/triforce/training_hints.py
+++ b/triforce/training_hints.py
@@ -1,6 +1,4 @@
 import gymnasium as gym
-
-from .objectives import ObjectiveKind
 from .zelda_enums import ActionKind, Direction
 from .zelda_game import ZeldaGame
 
@@ -35,6 +33,21 @@ class TrainingHintWrapper(gym.Wrapper):
                 self._check_room_direction(state, info, Direction.N)
             elif link.tile.y == 0x14:
                 self._check_room_direction(state, info, Direction.S)
+
+        if state.level != 0:
+            if link.tile.x <= 0x03 or link.tile.x >= 0x1c:
+                invalid = info.setdefault('invalid_actions', [])
+
+                for action in (ActionKind.MOVE, ActionKind.SWORD, ActionKind.BEAMS):
+                    invalid.append((action, Direction.N))
+                    invalid.append((action, Direction.S))
+
+            if link.tile.y <= 0x03 or link.tile.y >= 0x12:
+                invalid = info.setdefault('invalid_actions', [])
+
+                for action in (ActionKind.MOVE, ActionKind.SWORD, ActionKind.BEAMS):
+                    invalid.append((action, Direction.W))
+                    invalid.append((action, Direction.E))
 
     def _check_room_direction(self, state, info, direction):
         next_room = state.full_location.get_location_in_direction(direction)

--- a/triforce/training_hints.py
+++ b/triforce/training_hints.py
@@ -26,8 +26,7 @@ class TrainingHintWrapper(gym.Wrapper):
         if state.full_location == (0, 0x38) and link.tile.y < 0xa:
             info.setdefault('invalid_actions', []).append((ActionKind.MOVE, Direction.N))
 
-        # TODO: always have the next room in objectives
-        if not state.full_location.in_cave and state.objectives.kind != ObjectiveKind.ITEM:
+        if not state.full_location.in_cave:
             if link.tile.x == 0:
                 self._check_room_direction(state, info, Direction.W)
             elif link.tile.x == 0x1e:

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -54,7 +54,8 @@
             "per_reset":
             {
                 "bombs" : 3,
-                "max_health" : 3
+                "max_health" : 2,
+                "health" : 3
             }
         },
         {

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -25,7 +25,7 @@
             "iterations" : 2000000,
             "scenario_selector" : "round-robin",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftRoute", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
+            "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
             "start": ["0_77"],
             "use_hints" : true,
             "per_room":

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -10,6 +10,14 @@
             "rooms" : ["0x77"]
         },
         {
+            "name" : "dungeon1",
+            "neural_net" : "SharedNatureAgent",
+            "action_space" : ["MOVE", "SWORD"],
+            "priority" : 0,
+            "levels" : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "rooms" : ["0x77"]
+        },
+        {
             "name" : "overworld-sword",
             "neural_net" : "SharedNatureAgent",
             "action_space" : ["MOVE"],
@@ -28,14 +36,25 @@
             "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
             "start": ["0_77"],
             "use_hints" : true,
-            "per_room":
-            {
-                "health" : "max_health"
-            },
             "per_reset":
             {
                 "bombs" : 3,
                 "sword" : 1
+            }
+        },
+        {
+            "name": "start-dungeon1",
+            "description": "The dungeon 1.",
+            "iterations" : 2000000,
+            "scenario_selector" : "round-robin",
+            "critic": "GameplayCritic",
+            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout"],
+            "start": ["1_74w"],
+            "use_hints" : true,
+            "per_reset":
+            {
+                "bombs" : 3,
+                "max_health" : 3
             }
         },
         {

--- a/zui/model_selector.py
+++ b/zui/model_selector.py
@@ -19,7 +19,7 @@ class ModelSelector:
         self._loaded_models["untrained"] = (network, "untrained")
 
         self._curr_index = self._find_best_model()
-        self._curr = self._loaded_models[self._curr_index]
+        self._curr = self._loaded_models[self._curr_index if self._curr_index is not None else "untrained"]
 
     @property
     def model_name(self):


### PR DESCRIPTION
This pull request includes several changes to the `run.py` file and some updates to the `triforce` module. The most important changes include adding a new `clear` method, updating the `close` method to conditionally write, and modifying the `DisplayWindow` class to handle frame stacking. Additionally, there are updates to the objectives handling in `triforce/objectives.py`.

Changes to `run.py`:

* Added a `clear` method to the `Recording` class to clear the buffer without writing it out.
* Updated the `close` method to accept a `write` parameter to conditionally write the buffer before closing.
* Modified the `DisplayWindow` class to include a `frame_stack` parameter and updated the `show` method to pass this parameter to the environment. [[1]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L96-R107) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L145-R152)
* Added a `manual_reset` flag in the `show` method to handle manual resets during the game. [[1]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R179) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L199-R210) [[3]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R306) [[4]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L338-R350) [[5]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L353-R365)
* Updated the `_show_observation` method to render the last image in the observation stack.

Changes to `triforce` module:

* Added new progress mappings in `triforce/critics.py`.
* Modified `find_available_models` in `triforce/models.py` to return an empty list if the path does not exist, instead of raising an error.
* Refactored objectives handling in `triforce/objectives.py` to simplify the logic and improve the clarity of the objective determination process. [[1]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L4-L6) [[2]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L48-R50) [[3]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L99-L113) [[4]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L125-R209) [[5]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L208-R259)
* Cleaned up imports in `triforce/training_hints.py` and removed unnecessary checks. [[1]](diffhunk://#diff-c294e508448bf86896e16b6942e13930abf5679c7ee4a6fff14accad17e93c88L2-L3) [[2]](diffhunk://#diff-c294e508448bf86896e16b6942e13930abf5679c7ee4a6fff14accad17e93c88L29-R27)