### PR TITLE
Implement training circuits

### DIFF
--- a/tests/ppo_test.py
+++ b/tests/ppo_test.py
@@ -99,7 +99,7 @@ def test_ppo_training(device, num_envs):
     if num_envs == 1:
         kwargs['target_steps'] = 128
 
-    ppo = PPO(device, log_dir=None, **kwargs)
+    ppo = PPO(log_dir=None, device=device, **kwargs)
 
     # Train PPO for enough iterations to allow learning.  There's no magic here, this just seems
     # to be enough iterations for this environment to learn.
@@ -143,7 +143,7 @@ def test_model_training(model_scenario, num_channels):
         return make_zelda_env(scenario_name, model_def.action_space, frame_stack=num_channels)
 
     progress = MagicMock()
-    ppo = PPO("cpu", log_dir=None)
+    ppo = PPO(log_dir=None, device="cpu")
     network = ppo.train(SharedNatureAgent, create_env, ppo.target_steps * 2 + 1, progress)
     assert progress.update.call_count, "PPO did not call update"
 

--- a/train.py
+++ b/train.py
@@ -80,9 +80,7 @@ def parse_args():
     parser.add_argument("--verbose", type=int, default=0, help="Verbosity.")
     parser.add_argument("--ent-coef", type=float, default=0.001, help="Entropy coefficient for the PPO algorithm.")
     parser.add_argument("--dynamic-lr", action='store_true', default=None, help="Use a dynamic learning rate.")
-    parser.add_argument("--obs-kind", choices=['gameplay', 'viewport', 'full'], default='viewport',
-                        help="The kind of observation to use.")
-    parser.add_argument("--frame-stack", type=int, default=3, help="The number of frames to stack in the observation.")
+    parser.add_argument("--frame-stack", type=int, default=None, help="The number of frames to stack.")
     parser.add_argument("--device", choices=['cpu', 'cuda'], default=None, help="The device to use.")
 
     parser.add_argument('model', type=str, help='The model to train.')

--- a/train.py
+++ b/train.py
@@ -113,8 +113,12 @@ def main():
             del kwargs['exit_criteria']
             del kwargs['exit_threshold']
 
+
+        kwargs['model_name'] = model_def.name + '-' + scenario_def.name
         model = train_once(ppo, scenario_def, model_def, model_directory, iterations, **kwargs)
         kwargs['model'] = model
+
+    model.save(f"{model_directory}/{model_name}.pt")
 
 def parse_args():
     """Parse command line arguments."""

--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -1,3 +1,4 @@
+import math
 import time
 import torch
 from torch import nn
@@ -44,7 +45,8 @@ class Threshold:
 
 class PPO:
     """PPO Implementation.  Adapted from from https://www.youtube.com/watch?v=MEt6rrxH8W4."""
-    def __init__(self, device, log_dir, **kwargs):
+    def __init__(self, log_dir, **kwargs):
+        self.device = kwargs.get('device', torch.device("cuda" if torch.cuda.is_available() else "cpu"))
         self.target_steps = kwargs.get('target_steps', TARGET_STEPS)
         self._norm_advantages = kwargs.get('norm_advantages', NORM_ADVANTAGES)
         self._clip_val_loss = kwargs.get('clip_val_loss', CLIP_VAL_LOSS)
@@ -62,7 +64,6 @@ class PPO:
         self.kwargs = kwargs
 
         self.log_dir = log_dir
-        self.device = device
         self.tensorboard = SummaryWriter(log_dir) if log_dir else None
 
         self.total_steps = 0
@@ -76,9 +77,7 @@ class PPO:
 
         env = create_env()
         try:
-            network = create_network(network, env.observation_space, env.action_space)
-            if (load_path := kwargs.get('load', None)) is not None:
-                network.load(load_path)
+            network = kwargs.get('model', None) or create_network(network, env.observation_space, env.action_space)
 
             if kwargs.get('dynamic_lr', False):
                 self.optimizer = torch.optim.Adam(network.parameters(), lr=LEARNING_RATE_MEDIUM, eps=self._epsilon)
@@ -98,8 +97,11 @@ class PPO:
                                   self._gamma, self._lambda)
 
         save_path = kwargs.get('save_path', None)
+        exit_criteria = kwargs.get('exit_criteria', None)
+        exit_threshold = kwargs.get('exit_threshold', None)
         next_tensorboard = Threshold(LOG_RATE)
         next_model_save = Threshold(SAVE_INTERVAL)
+        progress.total = math.ceil(iterations / buffer.memory_length) * buffer.memory_length
         total_iterations = 0
 
         while total_iterations < iterations:
@@ -112,6 +114,10 @@ class PPO:
                 network.metrics = MetricTracker.get_metrics_and_clear()
                 if network.metrics:
                     self._write_metrics(network.metrics, network.steps_trained)
+
+                    if exit_criteria and self._hit_exit_criteria(network.metrics, exit_criteria, exit_threshold):
+                        break
+
                     if kwargs.get('dynamic_lr', False):
                         self._adjust_learning_rate(network.metrics)
 
@@ -125,6 +131,9 @@ class PPO:
 
         return network
 
+    def _hit_exit_criteria(self, metrics, exit_criteria, exit_threshold):
+        return metrics.get(exit_criteria, 0) >= exit_threshold
+
     def _write_metrics(self, metrics, total_iterations):
         timestamp = time.time()
         for name, value in metrics.items():
@@ -132,6 +141,9 @@ class PPO:
                 name = f"metrics/{name}"
 
             self.tensorboard.add_scalar(name, value, total_iterations, timestamp)
+
+        if metrics:
+            self.tensorboard.flush()
 
     def _adjust_learning_rate(self, metrics):
         success_rate = metrics.get("success-rate", None)

--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -126,8 +126,8 @@ class PPO:
                 network.save(f"{save_path}/network_{network.steps_trained}.pt")
 
             # Optimize the network
-            network = self._optimize(network, buffer, total_iterations)
             network.steps_trained += buffer.memory_length
+            network = self._optimize(network, buffer, network.steps_trained)
 
         return network
 

--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -123,7 +123,8 @@ class PPO:
 
             # Save model, hopefully log rate and save interval are multiples of each other
             if save_path and next_model_save.add(buffer.memory_length):
-                network.save(f"{save_path}/network_{network.steps_trained}.pt")
+                model_name = kwargs.get('model_name', "network").replace(' ', '_')
+                network.save(f"{save_path}/{model_name}_{network.steps_trained}.pt")
 
             # Optimize the network
             network.steps_trained += buffer.memory_length

--- a/triforce/scenario_wrapper.py
+++ b/triforce/scenario_wrapper.py
@@ -94,6 +94,42 @@ class TrainingScenarioDefinition(BaseModel):
         """Loads the models and scenarios from triforce.json."""
         return list(TrainingScenarioDefinition._load_scenarios().values())
 
+class TrainingCircuitEntry(BaseModel):
+    """An entry in a training circuit."""
+    scenario : str
+    iterations : Optional[int] = None
+    exit_criteria : Optional[str] = None
+    threshold : Optional[float] = None
+
+class TrainingCircuitDefinition(BaseModel):
+    """A training circuit."""
+    name : str
+    description : str
+    scenarios : List[TrainingCircuitEntry]
+
+    @staticmethod
+    def _load_circuits():
+        """Loads the models and scenarios from triforce.json."""
+        circuits = {}
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(script_dir, 'triforce.json'), encoding='utf-8') as f:
+            for circuit in json.load(f)["training-circuits"]:
+                circuit = TrainingCircuitDefinition(**circuit)
+                circuits[circuit.name] = circuit
+
+        return circuits
+
+    @staticmethod
+    def get(name, default=None):
+        """Loads the models and scenarios from triforce.json."""
+        circuits = TrainingCircuitDefinition._load_circuits()
+        return circuits.get(name, default)
+
+    @staticmethod
+    def get_all():
+        """Loads the models and scenarios from triforce.json."""
+        return list(TrainingCircuitDefinition._load_circuits().values())
+
 class RoomResult:
     """Tracks whether link took damage in a room."""
     def __init__(self, room, came_from, health_lost, success):

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -17,6 +17,30 @@
             "action_space" : ["MOVE"]
         }
     ],
+    "training-circuits" :
+    [
+        {
+            "name" : "overworld-circuit",
+            "description" : "Train the overworld model by first teaching it to walk rooms, then to make it to dungeon1, then to grab the sword, then all together.",
+            "scenarios" : [
+                {
+                    "scenario" : "overworld-sword",
+                    "exit_criteria" : "success-rate",
+                    "threshold" : 0.80
+                },
+                {
+                    "scenario" : "small-room-walk",
+                    "exit_criteria" : "room-result/correct-exit",
+                    "threshold" : 0.90
+                },
+                {
+                    "scenario" : "start-overworld1",
+                    "exit_criteria" : "success-rate",
+                    "threshold" : 0.85
+                }
+            ]
+        }
+    ],
     "scenarios": [
         {
             "name": "start-overworld1",
@@ -35,15 +59,10 @@
                 "reward-details"
             ],
             "start": ["0_77"],
-            "use_hints" : true,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "sword" : 1
-            }
+            "use_hints" : true
         },
         {
-            "name": "initial-room-walk",
+            "name": "small-room-walk",
             "description": "A scoped down room walk",
             "iterations" : 2000000,
             "scenario_selector" : "probabilistic",
@@ -70,7 +89,7 @@
             }
         },
         {
-            "name": "overworld-room-walk",
+            "name": "large-room-walk",
             "description": "A training scenario to teach the model how to traverse the map and follow directions",
             "iterations" : 2000000,
             "scenario_selector" : "probabilistic",

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -69,7 +69,7 @@
             "objective" : "RoomWalk",
             "critic": "GameplayCritic",
             "end_conditions": ["LeftInitialRoomWalk", "NextRoomTimeout"],
-            "metrics" : ["room-result", "room-health", "ending", "reward-average", "reward-details"],
+            "metrics" : ["success-rate", "room-result", "room-health", "ending", "reward-average", "reward-details"],
             "start": [
                 "0_58e",
                 "0_58s",

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -36,7 +36,8 @@
                 {
                     "scenario" : "start-overworld1",
                     "exit_criteria" : "success-rate",
-                    "threshold" : 0.85
+                    "threshold" : 0.95,
+                    "iterations" : 40000000
                 }
             ]
         }

--- a/triforce/zelda_env.py
+++ b/triforce/zelda_env.py
@@ -24,7 +24,7 @@ def make_zelda_env(scenario : TrainingScenarioDefinition, action_space : str, **
     """
     render_mode = kwargs.get('render_mode', None)
     translation = kwargs.get('translation', True)
-    frame_stack = kwargs.get('frame_stack', 1)
+    frame_stack = kwargs.get('frame_stack', 3)
     obs_kind = kwargs.get('obs_kind', 'viewport')
 
     state = random.choice(scenario.start)


### PR DESCRIPTION
This pull request includes several changes to improve the flexibility and functionality of the PPO training process, as well as to introduce new training circuits. The most important changes include updates to the `PPO` class, enhancements to the `train.py` script, and the addition of new training circuit definitions.

### PPO Class Updates:
* Changed the `PPO` class constructor to accept `device` as a keyword argument and set a default device if not provided (`triforce/ml_ppo.py`).
* Updated the `train` method to use a pre-loaded model if provided in the `kwargs` (`triforce/ml_ppo.py`).

### Train Script Enhancements:
* Added `_get_kwargs_from_args` and `train_once` helper functions to handle argument parsing and training logic (`train.py`).
* Modified the `main` function to support training circuits and handle multiple scenarios (`train.py`).

### New Training Circuit Definitions:
* Introduced `TrainingCircuitEntry` and `TrainingCircuitDefinition` classes to define and load training circuits (`triforce/scenario_wrapper.py`).
* Added new training circuits to the `triforce.json` configuration file (`triforce/triforce.json`).

### Test Adjustments:
* Updated test cases in `tests/ppo_test.py` to reflect changes in the `PPO` constructor parameter order (`tests/ppo_test.py`). [[1]](diffhunk://#diff-8ff65cc26fefebc60719af71bbad72bbb2ec0dea4894af7a8aeabcc254fd9824L102-R102) [[2]](diffhunk://#diff-8ff65cc26fefebc60719af71bbad72bbb2ec0dea4894af7a8aeabcc254fd9824L146-R146)

### Miscellaneous:
* Set the default `frame_stack` to 3 in the `make_zelda_env` function (`triforce/zelda_env.py`).