### PR TITLE
Adds link's health to the observation

### DIFF
--- a/tests/ppo_test.py
+++ b/tests/ppo_test.py
@@ -130,7 +130,7 @@ def test_ppo_training(device, num_envs):
     assert actions_taken == expected_actions, f"Expected actions {expected_actions}, but got {actions_taken}"
 
 @pytest.mark.parametrize("num_channels", [1, 3])
-@pytest.mark.parametrize("model_scenario", ["overworld start-overworld1", "overworld-sword overworld-sword"])
+@pytest.mark.parametrize("model_scenario", ["overworld overworld-skip-sword", "overworld-sword overworld-sword"])
 def test_model_training(model_scenario, num_channels):
     model_name, scenario_name = model_scenario.split(" ")
     model_def : ModelDefinition = ModelDefinition.get(model_name)

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -8,7 +8,7 @@ from triforce.action_space import ActionKind
 from triforce.rewards import REWARD_LARGE, REWARD_MAXIMUM, REWARD_MEDIUM, REWARD_MINIMUM, REWARD_SMALL, REWARD_TINY, \
     Penalty, Reward, StepRewards
 
-from .zelda_enums import SwordKind, ZeldaAnimationKind, AnimationState
+from .zelda_enums import SwordKind, ZeldaAnimationKind, AnimationState, ZeldaEnemyKind
 from .state_change_wrapper import StateChange
 
 HEALTH_LOST_PENALTY = Penalty("penalty-lost-health", -REWARD_LARGE)
@@ -33,6 +33,7 @@ PENALTY_CAVE_ATTACK = Penalty("penalty-attack-cave", -REWARD_MAXIMUM)
 USED_BOMB_PENALTY = Penalty("penalty-bomb-miss", -REWARD_MEDIUM)
 BOMB_HIT_REWARD = Reward("reward-bomb-hit", REWARD_SMALL)
 PENALTY_WRONG_LOCATION = Penalty("penalty-wrong-location", -REWARD_MAXIMUM)
+PENALTY_WALL_MASTER = Penalty("penalty-wall-master", -REWARD_MAXIMUM)
 
 def _init_equipment_rewards():
     """Initializes the equipment rewards."""
@@ -253,6 +254,10 @@ class GameplayCritic(ZeldaCritic):
 
         prev = state_change.previous.full_location
         curr = state_change.state.full_location
+
+        if prev != curr and any(x.id == ZeldaEnemyKind.WallMaster for x in state_change.previous.enemies):
+            if prev.manhattan_distance(curr) > 1:
+                rewards.add(PENALTY_WALL_MASTER)
 
         # Don't let the agent walk offscreen then right back on to get a quick reward
         if prev != curr and not self._correct_locations:

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -265,3 +265,11 @@ class LeftPlayArea(ZeldaEndCondition):
             return True, False, "failure-left-play-area"
 
         return False, False, None
+
+class Dungeon1DidntGetKey(ZeldaEndCondition):
+    """End condition for leaving the initial room walk scenario."""
+    def is_scenario_ended(self, state_change):
+        if state_change.state.location == 0x63 and state_change.state.link.keys == 0:
+            return True, False, "failure-no-key"
+
+        return False, False, None

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -2,7 +2,7 @@
 
 from .objectives import ObjectiveKind, ObjectiveSelector
 from .state_change_wrapper import StateChange
-from .zelda_enums import SwordKind
+from .zelda_enums import SwordKind, ZeldaEnemyKind
 
 class ZeldaEndCondition:
     """
@@ -143,6 +143,10 @@ class LeftDungeon(ZeldaEndCondition):
     def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
         if state_change.state.level == 0:
             return True, False, "failure-left-dungeon"
+        
+        if any(x.id == ZeldaEnemyKind.WallMaster for x in state_change.previous.enemies) \
+                and state_change.previous.full_location.manhattan_distance(state_change.state.full_location) > 1:
+            return True, False, "failure-wallmastered"
 
         return False, False, None
 

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -143,7 +143,7 @@ class LeftDungeon(ZeldaEndCondition):
     def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
         if state_change.state.level == 0:
             return True, False, "failure-left-dungeon"
-        
+
         if any(x.id == ZeldaEnemyKind.WallMaster for x in state_change.previous.enemies) \
                 and state_change.previous.full_location.manhattan_distance(state_change.state.full_location) > 1:
             return True, False, "failure-wallmastered"

--- a/triforce/observation_wrapper.py
+++ b/triforce/observation_wrapper.py
@@ -18,7 +18,7 @@ from .objectives import Objective, ObjectiveKind
 from .zelda_game import ZeldaGame
 
 GRAYSCALE_WEIGHTS = torch.FloatTensor([0.2989, 0.5870, 0.1140])
-BOOLEAN_FEATURES = 12
+BOOLEAN_FEATURES = 14
 DISTANCE_SCALE = 100.0
 VIEWPORT_PIXELS = 128
 
@@ -337,9 +337,11 @@ class ObservationWrapper(gym.Wrapper):
         source_direction = torch.zeros(4, dtype=torch.float32)
         self._assign_direction(source_direction, state.full_location.get_direction_to(self._prev_loc))
 
-        features = torch.zeros(2, dtype=torch.float32)
+        features = torch.zeros(4, dtype=torch.float32)
         features[0] = 1.0 if state.active_enemies else 0.0
         features[1] = 1.0 if state.link.are_beams_available else 0.0
+        features[2] = 1.0 if state.link.heart_halves <= 2 else 0.0
+        features[3] = 1.0 if state.link.is_health_full else 0.0
 
         return torch.concatenate([objectives, source_direction, features])
 

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -203,7 +203,7 @@
             "scenario_selector" : "round-robin",
             "objective" : "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout"],
+            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout", "Dungeon1DidntGetKey"],
             "metrics" : [
                 "success-rate",
                 "overworld-progress",
@@ -213,13 +213,7 @@
                 "reward-details"
             ],
             "start": ["1_73s"],
-            "use_hints" : false,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "max_health" : 2,
-                "health" : 3
-            }
+            "use_hints" : false
         },
         {
             "name": "dungeon1-skip-opening",

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -34,12 +34,12 @@
                     "threshold" : 0.80
                 },
                 {
-                    "scenario" : "overworld-skip-opening",
+                    "scenario" : "overworld-skip-sword",
                     "exit_criteria" : "success-rate",
                     "threshold" : 0.90
                 },
                 {
-                    "scenario" : "start-overworld1",
+                    "scenario" : "overworld",
                     "exit_criteria" : "success-rate",
                     "threshold" : 0.98,
                     "iterations" : 40000000
@@ -68,7 +68,7 @@
     ],
     "scenarios": [
         {
-            "name": "start-overworld1",
+            "name": "overworld",
             "description": "The full game with training variables",
             "iterations" : 2000000,
             "scenario_selector" : "round-robin",
@@ -87,7 +87,23 @@
             "use_hints" : true
         },
         {
-            "name": "overworld-skip-opening",
+            "name": "overworld-sword",
+            "description": "Start of the game to the sword",
+            "iterations" : 1000000,
+            "scenario_selector" : "none",
+            "objective" : "GameCompletion",
+            "critic": "OverworldSwordCritic",
+            "end_conditions": ["StartingRoomConditions", "Timeout"],
+            "metrics" : ["success-rate", "ending", "reward-average", "reward-details"],
+            "start": ["0_77c"],
+            "per_reset":
+            {
+                "hearts_and_containers" : 34,
+                "partial_hearts" : 254
+            }
+        },
+        {
+            "name": "overworld-skip-sword",
             "description": "A scoped down room walk",
             "iterations" : 2500000,
             "scenario_selector" : "round-robin",
@@ -97,6 +113,34 @@
             "metrics" : ["success-rate", "room-result", "room-health", "ending", "reward-average", "reward-details"],
             "start": [ "0_67s" ],
             "use_hints" : true,
+            "per_reset":
+            {
+                "bombs" : 3,
+                "sword" : 1,
+                "health" : "max_health"
+            }
+        },
+        {
+            "name": "overworld-room-walk",
+            "description": "A training scenario to teach the model how to traverse the map and follow directions",
+            "iterations" : 2000000,
+            "scenario_selector" : "probabilistic",
+            "objective" : "RoomWalk",
+            "critic": "GameplayCritic",
+            "end_conditions": ["RoomWalkCondition"],
+            "metrics" : [
+                "success-rate",
+                "room-result",
+                "room-health",
+                "ending",
+                "reward-average",
+                "reward-details"
+            ],
+            "start": [
+                "0_58",
+                "0_68"
+            ],
+            "use_hints" : false,
             "per_reset":
             {
                 "bombs" : 3,
@@ -141,34 +185,6 @@
                 "max_health" : 2,
                 "health" : 3,
                 "keys" : 4
-            }
-        },
-        {
-            "name": "overworld-room-walk",
-            "description": "A training scenario to teach the model how to traverse the map and follow directions",
-            "iterations" : 2000000,
-            "scenario_selector" : "probabilistic",
-            "objective" : "RoomWalk",
-            "critic": "GameplayCritic",
-            "end_conditions": ["RoomWalkCondition"],
-            "metrics" : [
-                "success-rate",
-                "room-result",
-                "room-health",
-                "ending",
-                "reward-average",
-                "reward-details"
-            ],
-            "start": [
-                "0_58",
-                "0_68"
-            ],
-            "use_hints" : false,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "sword" : 1,
-                "health" : "max_health"
             }
         },
         {
@@ -240,45 +256,6 @@
                 "max_health" : 2,
                 "health" : 3,
                 "keys" : 3
-            }
-        },
-        {
-            "name": "refinement",
-            "description": "The full game with training variables",
-            "iterations" : 8000000,
-            "scenario_selector" : "probabilistic",
-            "objective" : "GameCompletion",
-            "critic": "GameplayCritic",
-            "end_conditions": ["StartingSwordCondition", "GainedTriforce", "GameOver", "Timeout"],
-            "metrics" : [
-                "success-rate",
-                "overworld-progress",
-                "room-health",
-                "ending",
-                "reward-average",
-                "reward-details"
-            ],
-            "start": ["0_67s"],
-            "per_reset":
-            {
-                "health" : "max_health",
-                "bombs" : 3
-            }
-        },
-        {
-            "name": "overworld-sword",
-            "description": "Start of the game to the sword",
-            "iterations" : 1000000,
-            "scenario_selector" : "none",
-            "objective" : "GameCompletion",
-            "critic": "OverworldSwordCritic",
-            "end_conditions": ["StartingRoomConditions", "Timeout"],
-            "metrics" : ["success-rate", "ending", "reward-average", "reward-details"],
-            "start": ["0_77c"],
-            "per_reset":
-            {
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254
             }
         }
     ]

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -57,6 +57,11 @@
                     "iterations" : 2000000
                 },
                 {
+                    "scenario" : "dungeon1-entry-room",
+                    "exit_criteria" : "room-result/correct-exit",
+                    "threshold" : 0.90
+                },
+                {
                     "scenario" : "dungeon1-side-room-opening"
                 },
                 {
@@ -188,6 +193,34 @@
             }
         },
         {
+            "name": "dungeon1-entry-room",
+            "description": "Dungeon 1 entry room.",
+            "iterations" : 1000000,
+            "scenario_selector" : "round-robin",
+            "objective" : "RoomWalk",
+            "critic": "GameplayCritic",
+            "end_conditions": ["RoomWalkCondition", "LeftDungeon"],
+            "metrics" : [
+                "success-rate",
+                "room-result",
+                "room-health",
+                "ending",
+                "reward-average",
+                "reward-details"
+            ],
+            "start": [
+                "1_73"
+            ],
+            "use_hints" : false,
+            "per_reset":
+            {
+                "bombs" : 3,
+                "max_health" : 2,
+                "health" : 3,
+                "keys" : 4
+            }
+        },
+        {
             "name": "dungeon1-side-room-opening",
             "description": "Dungeon 1.",
             "iterations" : 2000000,
@@ -203,7 +236,7 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["1_72e", "1_74w", "1_63s"],
+            "start": ["1_72e", "1_74w", "1_63s", "1_44w"],
             "use_hints" : false,
             "per_reset":
             {


### PR DESCRIPTION
- Adds whether link's health is full to the observation (so the agent knows if it will get beams back soon if they are disabled).
- Adds whether link's health is at 1 heart or less, which is equivalent to the beeping sound you get in game at low health.  I considered just using 1/2 heart notification as any hit will kill link at that point, but I'm starting with what the game uses.
- Add penalties and end condition for getting caught by a wallmaster.
- Fixed some circuit issues.  Expanded the dungeon1 circuit.

### Enhancements to Reward and Penalty System:
* Added `ZeldaEnemyKind` to the import statements in `triforce/critics.py` and `triforce/end_conditions.py`. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL11-R11) [[2]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L5-R5)
* Introduced a new penalty `PENALTY_WALL_MASTER` for encountering Wall Masters.
* Updated the `critique_location_change` method to apply the `PENALTY_WALL_MASTER` if a Wall Master is encountered and the location change distance is greater than 1.

### Updates to End Conditions:
* Added a new end condition to terminate the scenario if a Wall Master is encountered and the location change distance is greater than 1.
* Introduced a new end condition class `Dungeon1DidntGetKey` to handle scenarios where the player leaves the initial room without obtaining a key.

### Modifications to Scenario Configurations:
* Updated various scenario names and descriptions in `triforce.json` to better reflect their purpose and adjusted their configurations accordingly. [[1]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L37-R42) [[2]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1R59-R63) [[3]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L71-R76)
* Added new scenarios such as `dungeon1-entry-room` and `overworld-room-walk` with specific exit criteria and metrics. [[1]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1R128-R155) [[2]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L147-R202)
* Removed redundant or outdated scenarios from `triforce.json` to streamline the configuration.

### Enhancements to Observation Wrapper:
* Increased the `BOOLEAN_FEATURES` count from 12 to 14 in `triforce/observation_wrapper.py`.
* Updated the `_get_information` method to include additional features related to the player's health status.