### PR TITLE
Add special coding for wallmaster enemies

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ def train_once(ppo : PPO, scenario_def, model_def, model_directory, iterations, 
     def create_env():
         return make_zelda_env(scenario_def, model_def.action_space, **kwargs)
 
-    model = ppo.train(model_def.neural_net, create_env, iterations, tqdm(), save_path=model_directory, **kwargs)
+    model = ppo.train(model_def.neural_net, create_env, iterations, tqdm(ncols=100), save_path=model_directory, **kwargs)
     model_name = model_def.name.replace(' ', '_')
     model.save(f"{model_directory}/{model_name}-{scenario_def.name}.pt")
     return model
@@ -114,7 +114,8 @@ def main():
             del kwargs['exit_threshold']
 
         kwargs['model_name'] = model_def.name + '-' + scenario_def.name
-        print(f"Training {model_def.name} on {scenario_def.name} for up to {iterations:,} iterations")
+        criteria = f" or {scenario_entry.exit_criteria} >= {scenario_entry.threshold}" if scenario_entry.exit_criteria else ""
+        print(f"Training {model_def.name} on {scenario_def.name} for up to {iterations:,} iterations{criteria}.")
         model = train_once(ppo, scenario_def, model_def, model_directory, iterations, **kwargs)
         kwargs['model'] = model
 

--- a/train.py
+++ b/train.py
@@ -60,14 +60,14 @@ def _get_kwargs_from_args(args, model_def):
 
     return kwargs, circuit
 
-def train_once(ppo : PPO, scenario_def, model_def, model_directory, iterations, **kwargs):
+def train_once(ppo : PPO, scenario_def, model_def, save_path, iterations, **kwargs):
     """Trains a model with the given scenario"""
     def create_env():
         return make_zelda_env(scenario_def, model_def.action_space, **kwargs)
 
-    model = ppo.train(model_def.neural_net, create_env, iterations, tqdm(ncols=100), save_path=model_directory, **kwargs)
+    model = ppo.train(model_def.neural_net, create_env, iterations, tqdm(ncols=100), save_path=save_path, **kwargs)
     model_name = model_def.name.replace(' ', '_')
-    model.save(f"{model_directory}/{model_name}-{scenario_def.name}.pt")
+    model.save(f"{save_path}/{model_name}-{scenario_def.name}.pt")
     return model
 
 def main():
@@ -114,7 +114,11 @@ def main():
             del kwargs['exit_threshold']
 
         kwargs['model_name'] = model_def.name + '-' + scenario_def.name
-        criteria = f" or {scenario_entry.exit_criteria} >= {scenario_entry.threshold}" if scenario_entry.exit_criteria else ""
+        if scenario_entry.exit_criteria:
+            criteria = f" and {scenario_entry.exit_criteria} >= {scenario_entry.threshold}"
+        else:
+            criteria = ""
+
         print(f"Training {model_def.name} on {scenario_def.name} for up to {iterations:,} iterations{criteria}.")
         model = train_once(ppo, scenario_def, model_def, model_directory, iterations, **kwargs)
         kwargs['model'] = model

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -34,9 +34,9 @@ USED_BOMB_PENALTY = Penalty("penalty-bomb-miss", -REWARD_MEDIUM)
 BOMB_HIT_REWARD = Reward("reward-bomb-hit", REWARD_SMALL)
 PENALTY_WRONG_LOCATION = Penalty("penalty-wrong-location", -REWARD_MAXIMUM)
 PENALTY_WALL_MASTER = Penalty("penalty-wall-master", -REWARD_MAXIMUM)
-FIGHTING_WALLMASTER_PENALTY = Penalty("penalty-fighting-wallmaster", -REWARD_MINIMUM)
-MOVED_OFF_OF_WALLMASTER_REWARD = Reward("reward-moved-off-wallmaster", REWARD_SMALL)
-MOVED_ONTO_WALLMASTER_PENALTY = Penalty("penalty-moved-onto-wallmaster", -REWARD_SMALL + REWARD_MINIMUM)
+FIGHTING_WALLMASTER_PENALTY = Penalty("penalty-fighting-wallmaster", -REWARD_TINY)
+MOVED_OFF_OF_WALLMASTER_REWARD = Reward("reward-moved-off-wallmaster", REWARD_TINY - REWARD_MINIMUM)
+MOVED_ONTO_WALLMASTER_PENALTY = Penalty("penalty-moved-onto-wallmaster", -REWARD_TINY)
 
 def _init_equipment_rewards():
     """Initializes the equipment rewards."""
@@ -216,7 +216,7 @@ class GameplayCritic(ZeldaCritic):
 
         # Did we get wallmastered?
         if prev.full_location != curr.full_location:
-            if prev.manhattan_distance(curr) > 1:
+            if prev.full_location.manhattan_distance(curr.full_location) > 1:
                 rewards.add(PENALTY_WALL_MASTER)
 
         # Are we on a tile which could be wallmastered?  If so, push away from it.

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -34,6 +34,9 @@ USED_BOMB_PENALTY = Penalty("penalty-bomb-miss", -REWARD_MEDIUM)
 BOMB_HIT_REWARD = Reward("reward-bomb-hit", REWARD_SMALL)
 PENALTY_WRONG_LOCATION = Penalty("penalty-wrong-location", -REWARD_MAXIMUM)
 PENALTY_WALL_MASTER = Penalty("penalty-wall-master", -REWARD_MAXIMUM)
+FIGHTING_WALLMASTER_PENALTY = Penalty("penalty-fighting-wallmaster", -REWARD_MINIMUM)
+MOVED_OFF_OF_WALLMASTER_REWARD = Reward("reward-moved-off-wallmaster", REWARD_SMALL)
+MOVED_ONTO_WALLMASTER_PENALTY = Penalty("penalty-moved-onto-wallmaster", -REWARD_SMALL + REWARD_MINIMUM)
 
 def _init_equipment_rewards():
     """Initializes the equipment rewards."""
@@ -123,6 +126,9 @@ class GameplayCritic(ZeldaCritic):
 
         self.critique_health_change(state_change, rewards)
 
+        # Special cases
+        self.critique_wallmaster(state_change, rewards)
+
         # If we lost health, remove all rewards since we want that to be the focus
         if state_change.health_lost > 0:
             rewards.remove_rewards()
@@ -201,6 +207,35 @@ class GameplayCritic(ZeldaCritic):
         if not prev_link.triforce_of_power and curr_link.triforce_of_power:
             rewards.add(EQUIPMENT_REWARD_MAP['triforce'])
 
+    def critique_wallmaster(self, state_change : StateChange, rewards):
+        """Special handling for rooms with a wallmaster."""
+        prev, curr = state_change.previous, state_change.state
+
+        if ZeldaEnemyKind.WallMaster not in curr.enemies:
+            return
+
+        # Did we get wallmastered?
+        if prev.full_location != curr.full_location:
+            if prev.manhattan_distance(curr) > 1:
+                rewards.add(PENALTY_WALL_MASTER)
+
+        # Are we on a tile which could be wallmastered?  If so, push away from it.
+        elif self._is_wallmaster_tile(curr.link.tile):
+            if state_change.action.kind != ActionKind.MOVE:
+                rewards.add(FIGHTING_WALLMASTER_PENALTY)
+
+            elif not self._is_wallmaster_tile(prev.link.tile):
+                rewards.add(MOVED_ONTO_WALLMASTER_PENALTY)
+        
+        elif self._is_wallmaster_tile(prev.link.tile):
+            # If we moved off the wallmaster tile, reward the agent
+            if state_change.action.kind == ActionKind.MOVE:
+                rewards.add(MOVED_OFF_OF_WALLMASTER_REWARD)
+
+    def _is_wallmaster_tile(self, tile): 
+        return tile.x in (0x4, 0x1a) or tile.y in (0x4, 0x10)
+            
+
     def critique_block(self, state_change : StateChange, rewards):
         """Critiques blocking of projectiles."""
         prev_link, curr_link = state_change.previous.link, state_change.state.link
@@ -254,10 +289,6 @@ class GameplayCritic(ZeldaCritic):
 
         prev = state_change.previous.full_location
         curr = state_change.state.full_location
-
-        if prev != curr and any(x.id == ZeldaEnemyKind.WallMaster for x in state_change.previous.enemies):
-            if prev.manhattan_distance(curr) > 1:
-                rewards.add(PENALTY_WALL_MASTER)
 
         # Don't let the agent walk offscreen then right back on to get a quick reward
         if prev != curr and not self._correct_locations:

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -226,15 +226,15 @@ class GameplayCritic(ZeldaCritic):
 
             elif not self._is_wallmaster_tile(prev.link.tile):
                 rewards.add(MOVED_ONTO_WALLMASTER_PENALTY)
-        
+
         elif self._is_wallmaster_tile(prev.link.tile):
             # If we moved off the wallmaster tile, reward the agent
             if state_change.action.kind == ActionKind.MOVE:
                 rewards.add(MOVED_OFF_OF_WALLMASTER_REWARD)
 
-    def _is_wallmaster_tile(self, tile): 
+    def _is_wallmaster_tile(self, tile):
         return tile.x in (0x4, 0x1a) or tile.y in (0x4, 0x10)
-            
+
 
     def critique_block(self, state_change : StateChange, rewards):
         """Critiques blocking of projectiles."""

--- a/triforce/enemy.py
+++ b/triforce/enemy.py
@@ -16,6 +16,9 @@ class Enemy(ZeldaObject):
     spawn_state : int
     status : int
 
+    def __eq__(self, value):
+        return self.id == value or super().__eq__(value)
+
     @property
     def dimensions(self) -> Tuple[int, int]:
         """The dimensions of the object."""

--- a/triforce/models.py
+++ b/triforce/models.py
@@ -258,6 +258,7 @@ class CombinedExtractor(nn.Module):
                 item_features: torch.Tensor, projectile_features: torch.Tensor,
                 information: torch.Tensor) -> torch.Tensor:
         """Forward pass."""
+        # pylint: disable=too-many-locals
         bsz = image.shape[0]
         # CNN on image
         img_out = self.image_extractor(image)

--- a/triforce/zelda_objects.py
+++ b/triforce/zelda_objects.py
@@ -80,6 +80,9 @@ class ZeldaObject:
 @dataclass
 class Projectile(ZeldaObject):
     """Structured data for a projectile."""
+    def __eq__(self, value):
+        return self.id == value or super().__eq__(value)
+    
     @property
     def blockable(self) -> bool:
         """Returns True if the projectile can be blocked by a shield."""
@@ -89,6 +92,9 @@ class Projectile(ZeldaObject):
 class Item(ZeldaObject):
     """Structured data for an item."""
     timer : int
+
+    def __eq__(self, value):
+        return self.id == value or super().__eq__(value)
 
     @property
     def dimensions(self) -> Tuple[int, int]:

--- a/triforce/zelda_objects.py
+++ b/triforce/zelda_objects.py
@@ -82,7 +82,7 @@ class Projectile(ZeldaObject):
     """Structured data for a projectile."""
     def __eq__(self, value):
         return self.id == value or super().__eq__(value)
-    
+
     @property
     def blockable(self) -> bool:
         """Returns True if the projectile can be blocked by a shield."""


### PR DESCRIPTION
This pull request includes several changes aimed at enhancing the training process and improving the critique system for the Zelda environment. The most important changes include updates to the training script to provide more detailed output, the addition of new penalties and rewards related to WallMasters, and the implementation of equality checks in various classes.

### Training Script Enhancements:
* [`train.py`](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L68-R68): Updated the `train_once` function to use a progress bar with a fixed width and modified the `main` function to include exit criteria in the training message. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L68-R68) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L117-R118)

### Critique System Improvements:
* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR37-R39): Added new penalties and rewards for interactions with WallMasters, and integrated a new `critique_wallmaster` method to handle these cases. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR37-R39) [[2]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR129-R131) [[3]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR210-R238) [[4]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL258-L261)

### Equality Checks Implementation:
* `triforce/enemy.py`, `triforce/zelda_objects.py`: Implemented `__eq__` methods for the `Enemy`, `Projectile`, and `Item` classes to allow for more intuitive comparisons based on object IDs. [[1]](diffhunk://#diff-9899ee8f7d59e33006956035c7443159f9cba59643e0bfccd73bcb46f1803aa3R19-R21) [[2]](diffhunk://#diff-0eb4ae5a1e960c9c39b96f4d7b702637153ecbfea697607275f835fdd3ea44d3R83-R85) [[3]](diffhunk://#diff-0eb4ae5a1e960c9c39b96f4d7b702637153ecbfea697607275f835fdd3ea44d3R96-R98)