### PR TITLE
Fix issue with infinite rewards

### DIFF
--- a/triforce/wavefront.py
+++ b/triforce/wavefront.py
@@ -36,16 +36,17 @@ class Wavefront:
 
         # fill in the remaineder of the room
         for tile, dist in wavefront.items():
-            heapq.heappush(todo, (dist, tile))
+            heapq.heappush(todo, (-dist, tile))
 
         while todo:
             dist, tile = heapq.heappop(todo)
+            dist = -dist
             for neighbor in self._get_neighbors(room, tile):
                 if neighbor in wavefront:
                     continue
 
                 wavefront[neighbor] = dist + 1
-                heapq.heappush(todo, (dist + 1, neighbor))
+                heapq.heappush(todo, (-dist - 1, neighbor))
 
         self._wavefront = wavefront
         self._targets = targets


### PR DESCRIPTION
- Ensure wavefront consideres the highest next-door value instead of lowest when filling out the remainder of the map.