### PR TITLE
Dungeon2 route

### DIFF
--- a/triforce/action_space.py
+++ b/triforce/action_space.py
@@ -311,6 +311,9 @@ class ZeldaActionSpace(gym.Wrapper):
 
     def is_valid_action(self, action, action_mask):
         """Returns True if the action is valid."""
+        if action is None:
+            return False
+
         action = self.get_action_taken(action)
         return action_mask[action.id]
 

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -179,10 +179,10 @@ class EnteredDungeon(ZeldaEndCondition):
         if state.level == 0:
             return False, False, None
 
-        if state.level == state.link.triforce_pieces + 1:
-            return True, False, "success-entered-dungeon"
+        if state.link.has_triforce(state.level):
+            return True, False, "failure-reentered-dungeon"
 
-        return False, True, "truncated-entered-dungeon"
+        return True, False, "success-entered-dungeon"
 
 class LeftOverworld1Area(ZeldaEndCondition):
     """End the scenario if the agent leaves the allowable areas between the start room and dungeon 1."""
@@ -192,6 +192,19 @@ class LeftOverworld1Area(ZeldaEndCondition):
         state = state_change.state
         if state.level == 0 and state.location not in self.overworld_dungeon1_walk_rooms:
             return True, False, "failure-left-play-area"
+
+        return False, False, None
+
+class LeftOverworld2Area(ZeldaEndCondition):
+    """End the scenario if the agent leaves the allowable areas between the start room and dungeon 1."""
+    def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
+        state = state_change.state
+        if state.level == 0 and state.location != 0x37:
+            if state.full_location.y < 2 or state.full_location.y > 6:
+                return True, False, "failure-left-play-area"
+
+            if state.full_location.x < 8 or state.full_location.x > 13:
+                return True, False, "failure-left-play-area"
 
         return False, False, None
 

--- a/triforce/frame_skip_wrapper.py
+++ b/triforce/frame_skip_wrapper.py
@@ -29,6 +29,7 @@ MODE_UNDERGROUND = 9
 MODE_UNDERGROUND_TRANSITION = 10
 MODE_CAVE = 11
 MODE_CAVE_TRANSITION = 16
+MODE_HOLDING_TRIFORCE = 18
 
 STUN_FLAG = 0x40
 
@@ -40,7 +41,7 @@ def is_in_cave(state):
 def is_mode_scrolling(state):
     """Returns True if the game is in a scrolling mode, and therefore we cannot take actions."""
     return state in (MODE_SCROLL_COMPLETE, MODE_SCROLL, MODE_SCROLL_START, MODE_UNDERGROUND_TRANSITION, \
-                     MODE_CAVE_TRANSITION, MODE_REVEAL, MODE_DUNGEON_TRANSITION)
+                     MODE_CAVE_TRANSITION, MODE_REVEAL, MODE_DUNGEON_TRANSITION, MODE_HOLDING_TRIFORCE)
 
 def is_link_stunned(status_ac):
     """Returns True if link is stunned.  This is used to determine if link can take actions."""

--- a/triforce/link.py
+++ b/triforce/link.py
@@ -189,7 +189,7 @@ class Link(ZeldaObject):
 
     def has_triforce(self, level):
         """Returns whether link has the triforce for the given level."""
-        return self.game.triforce & (1 << level)
+        return self.game.triforce & (1 << (level - 1))
 
     @property
     def is_health_full(self) -> bool:

--- a/triforce/objectives.py
+++ b/triforce/objectives.py
@@ -14,11 +14,11 @@ LOCKED_DISTANCE = 4
 overworld_to_item = {
     0x77 : SwordKind.WOOD,
     0x37 : 1,
-    0x22 : 2,
+    0x3c : 2,
     0x23 : SwordKind.WHITE,
 }
 
-dungeon_entrances = { 1: 0x73 }
+dungeon_entrances = { 1: 0x73, 2 : 0x7d }
 
 dungeon_to_item = {
     0x72 : ZeldaItemKind.Key,
@@ -32,6 +32,8 @@ dungeon_to_item = {
     0x36: ZeldaItemKind.Triforce1,
     0x43 : ZeldaItemKind.Map,
     0x54 : ZeldaItemKind.Compass,
+
+    0x00 : ZeldaItemKind.Triforce2,
 }
 
 item_to_overworld = {v: k for k, v in overworld_to_item.items()}

--- a/triforce/scenario_wrapper.py
+++ b/triforce/scenario_wrapper.py
@@ -250,7 +250,7 @@ class ProbabilisticSelector(RoomSelector):
     @staticmethod
     def get_name_from_direction_location(direction, location):
         """Returns the name of the state file."""
-        d = direction.name[0].lower() if direction is not None else ''
+        d = direction.name[0].lower() if direction not in (None, Direction.NONE) else 'c'
         return f"{location.level}_{location.value:02x}{d}.state"
 
     def _select_probabilistically(self):

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -97,7 +97,46 @@
                 "reward-details"
             ],
             "start": ["0_77c"],
-            "use_hints" : true
+            "use_hints" : false
+        },
+        {
+            "name": "dungeon1-dungeon2",
+            "description": "",
+            "iterations" : 2000000,
+            "scenario_selector" : "round-robin",
+            "objective" : "GameCompletion",
+            "critic": "GameplayCritic",
+            "end_conditions": ["LeftOverworld2Area", "EnteredDungeon", "GameOver", "Timeout"],
+            "metrics" : [
+                "success-rate",
+                "overworld-progress",
+                "room-health",
+                "ending",
+                "reward-average",
+                "reward-details"
+            ],
+            "start": ["0_37c"],
+            "use_hints" : false
+        },
+        {
+            "name": "no-end-conditions",
+            "description": "The full game with training variables",
+            "iterations" : 2000000,
+            "scenario_selector" : "round-robin",
+            "objective" : "GameCompletion",
+            "critic": "GameplayCritic",
+            "end_conditions": ["GameOver"],
+            "metrics" : [
+                "reward-average",
+                "reward-details"
+            ],
+            "per_reset":
+            {
+                "hearts_and_containers" : 51,
+                "partial_hearts" : 254
+            },
+            "start": ["0_37c"],
+            "use_hints" : false
         },
         {
             "name": "overworld-sword",

--- a/triforce/zelda_enums.py
+++ b/triforce/zelda_enums.py
@@ -167,6 +167,7 @@ class ZeldaProjectileId(Enum):
     # pylint: disable=invalid-name
     OtorokRock : int = 83
     ZoraFireball : int = 85
+    Arrow : int = 91
     Boomerang : int = 92
 
 class ZeldaItemKind(Enum):

--- a/triforce/zelda_objects.py
+++ b/triforce/zelda_objects.py
@@ -86,7 +86,7 @@ class Projectile(ZeldaObject):
     @property
     def blockable(self) -> bool:
         """Returns True if the projectile can be blocked by a shield."""
-        return self.id in (ZeldaProjectileId.OtorokRock, ZeldaProjectileId.Boomerang)
+        return self.id in (ZeldaProjectileId.OtorokRock, ZeldaProjectileId.Boomerang, ZeldaProjectileId.Arrow)
 
 @dataclass
 class Item(ZeldaObject):


### PR DESCRIPTION
This pull request includes various changes to the `triforce` package, focusing on game state handling, end conditions, and scenario configurations. The most important changes include updates to the action validation, end condition logic, and scenario configurations.

### Action validation improvements:
* [`triforce/action_space.py`](diffhunk://#diff-91dfe18526c4f51067c04dae9b4e85386a775dbae653aa2d891dfea4541dc593R314-R316): Added a check to return `False` if the action is `None` in the `is_valid_action` method.

### End condition logic updates:
* [`triforce/end_conditions.py`](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L182-R185): Modified the `is_scenario_ended` method to correctly handle scenarios where the player reenters a dungeon or successfully enters a dungeon. Added a new end condition class `LeftOverworld2Area` to handle specific area constraints. [[1]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L182-R185) [[2]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041R198-R210)

### Scenario configuration changes:
* [`triforce/triforce.json`](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L100-R139): Added new scenarios "dungeon1-dungeon2" and "no-end-conditions" with specific objectives, end conditions, and metrics.

### Game state and item handling:
* [`triforce/link.py`](diffhunk://#diff-cf3329d14e9dcb45a3f9e14cf3e0c71b5a3b0602cddd36690704c52f536fd437L192-R192): Corrected the `has_triforce` method to check the correct bit for the given level.
* [`triforce/objectives.py`](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L17-R21): Updated item and dungeon entrance mappings to reflect new game objectives and locations. [[1]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0L17-R21) [[2]](diffhunk://#diff-4940750812e79613bfab11ecadf9a280f6ec62ecc909c5fc416aa122ab17f8e0R35-R36)

### Additional changes:
* [`triforce/frame_skip_wrapper.py`](diffhunk://#diff-40116c9cc00b4f038c3e1b2517b9a2a4905fe7da67578d14902941e67a68710bR32): Added `MODE_HOLDING_TRIFORCE` to the list of modes where actions cannot be taken. [[1]](diffhunk://#diff-40116c9cc00b4f038c3e1b2517b9a2a4905fe7da67578d14902941e67a68710bR32) [[2]](diffhunk://#diff-40116c9cc00b4f038c3e1b2517b9a2a4905fe7da67578d14902941e67a68710bL43-R44)
* [`triforce/zelda_enums.py`](diffhunk://#diff-8c44ec2d00152586fdd4e81e258555a6526ccc3005d793b8a8fe1d01e937be7eR170): Added a new projectile ID for `Arrow`.
* [`triforce/zelda_objects.py`](diffhunk://#diff-0eb4ae5a1e960c9c39b96f4d7b702637153ecbfea697607275f835fdd3ea44d3L89-R89): Updated the `blockable` property to include `Arrow` as a blockable projectile.