### PR TITLE
Reduce rewards

### DIFF
--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -13,7 +13,7 @@ from .state_change_wrapper import StateChange
 
 HEALTH_LOST_PENALTY = Penalty("penalty-lost-health", -REWARD_LARGE)
 HEALTH_GAINED_REWARD = Reward("reward-gained-health", REWARD_LARGE)
-USED_KEY_REWARD = Reward("reward-used-key", REWARD_LARGE)
+USED_KEY_REWARD = Reward("reward-used-key", REWARD_SMALL)
 WALL_COLLISION_PENALTY = Penalty("penalty-wall-collision", -REWARD_SMALL)
 MOVE_CLOSER_REWARD = Reward("reward-move-closer", REWARD_TINY)
 MOVE_AWAY_PENALTY = Penalty("penalty-move-away", -REWARD_TINY - REWARD_MINIMUM)
@@ -24,11 +24,11 @@ ATTACK_NO_ENEMIES_PENALTY = Penalty("penalty-attack-no-enemies", -MOVE_CLOSER_RE
 ATTACK_MISS_PENALTY = Penalty("penalty-attack-miss", -REWARD_TINY - REWARD_MINIMUM)
 
 DIDNT_FIRE_PENALTY = Penalty("penalty-didnt-fire", -REWARD_TINY)
-BLOCK_PROJECTILE_REWARD = Reward("reward-block-projectile", REWARD_LARGE)
+BLOCK_PROJECTILE_REWARD = Reward("reward-block-projectile", REWARD_MEDIUM)
 FIRED_CORRECTLY_REWARD = Reward("reward-fired-correctly", REWARD_TINY)
-INJURE_KILL_REWARD = Reward("reward-hit", REWARD_MEDIUM)
+INJURE_KILL_REWARD = Reward("reward-hit", REWARD_SMALL)
 INJURE_KILL_MOVEMENT_ROOM_REWARD = Reward("reward-incidental-hit", REWARD_SMALL)
-BEAM_ATTACK_REWARD = Reward("reward-beam-hit", REWARD_MEDIUM)
+BEAM_ATTACK_REWARD = Reward("reward-beam-hit", REWARD_SMALL)
 PENALTY_CAVE_ATTACK = Penalty("penalty-attack-cave", -REWARD_MAXIMUM)
 USED_BOMB_PENALTY = Penalty("penalty-bomb-miss", -REWARD_MEDIUM)
 BOMB_HIT_REWARD = Reward("reward-bomb-hit", REWARD_SMALL)
@@ -92,9 +92,7 @@ class GameplayCritic(ZeldaCritic):
         super().__init__()
 
         self._correct_locations = set()
-        self._seen_locations = set()
         self._total_hits = 0
-        self._room_enter_health = None
         self._equipment_rewards = {}
         self._progress = 0.0
         self._tile_count = {}
@@ -102,9 +100,7 @@ class GameplayCritic(ZeldaCritic):
     def clear(self):
         super().clear()
         self._correct_locations.clear()
-        self._seen_locations.clear()
         self._total_hits = 0
-        self._room_enter_health = None
         self._progress = 0.0
         self._tile_count.clear()
 
@@ -289,9 +285,6 @@ class GameplayCritic(ZeldaCritic):
 
     def critique_location_change(self, state_change : StateChange, rewards):
         """Critiques the discovery of new locations."""
-        if self._room_enter_health is None:
-            self._room_enter_health = state_change.previous.link.health
-
         prev = state_change.previous.full_location
         curr = state_change.state.full_location
 
@@ -300,22 +293,14 @@ class GameplayCritic(ZeldaCritic):
             self._correct_locations.add((prev, curr))
 
         if prev != curr:
-            health_change = state_change.previous.link.health - self._room_enter_health
-            # clamp the reward to [-1, 1]
-            reward = (max(min(health_change, 3.0), -3.0) + 3) / 6
-            reward = max(min(reward, REWARD_MAXIMUM), REWARD_MINIMUM)
-
-            if curr in state_change.previous.objectives.next_rooms:
-                if (curr, prev) in self._correct_locations:
-                    reward = REWARD_MINIMUM
-                else:
-                    self._correct_locations.add((curr, prev))
-
-                rewards.add(Reward("reward-new-location", reward))
+            if curr in self._correct_locations:
+                rewards.add(REWARD_REVIST_LOCATION)
+            elif curr in state_change.previous.objectives.next_rooms:
+                rewards.add(REWARD_NEW_LOCATION)
+                self._correct_locations.add(curr)
             else:
                 rewards.add(PENALTY_WRONG_LOCATION)
 
-            self._room_enter_health = state_change.state.link.health
 
     def critique_tile_position(self, state_change : StateChange, rewards):
         """Critiques landing on the same tile over and over."""
@@ -419,6 +404,7 @@ class GameplayCritic(ZeldaCritic):
 REWARD_ENTERED_CAVE = Reward("reward-entered-cave", REWARD_LARGE)
 REWARD_LEFT_CAVE = Reward("reward-left-cave", REWARD_LARGE)
 REWARD_NEW_LOCATION = Reward("reward-new-location", REWARD_LARGE)
+REWARD_REVIST_LOCATION = Reward("reward-revisit-location", REWARD_TINY)
 PENALTY_REENTERED_CAVE = Penalty("penalty-reentered-cave", -REWARD_MAXIMUM)
 PENALTY_LEFT_CAVE_EARLY = Penalty("penalty-left-cave-early", -REWARD_MAXIMUM)
 PENALTY_LEFT_SCENARIO = Penalty("penalty-left-scenario", -REWARD_LARGE)

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -145,9 +145,7 @@ class StartingSwordCondition(ZeldaEndCondition):
 class GainedTriforce(ZeldaEndCondition):
     """End the scenario if the agent gains a piece of triforce."""
     def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
-        prev_link, curr_link = state_change.previous.link, state_change.state.link
-        if prev_link.triforce_pieces < curr_link.triforce_pieces \
-                or prev_link.triforce_of_power < curr_link.triforce_of_power:
+        if state_change.gained_triforce:
             return True, False, "success-gained-triforce"
 
         return False, False, None
@@ -156,7 +154,8 @@ class LeftDungeon(ZeldaEndCondition):
     """End the scenario if the agent leaves the dungeon."""
     def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
         if state_change.state.level == 0:
-            return True, False, "failure-left-dungeon"
+            if not state_change.gained_triforce:
+                return True, False, "failure-left-dungeon"
 
         if any(x.id == ZeldaEnemyKind.WallMaster for x in state_change.previous.enemies) \
                 and state_change.previous.full_location.manhattan_distance(state_change.state.full_location) > 1:

--- a/triforce/models.py
+++ b/triforce/models.py
@@ -116,7 +116,7 @@ class Network(nn.Module):
 
     def load(self, path) -> 'Network':
         """Load the network from a file."""
-        save_data = torch.load(path)
+        save_data = torch.load(path, weights_only=False)
 
         self.load_state_dict(save_data["model_state_dict"])
         self.steps_trained = save_data["steps_trained"]

--- a/triforce/state_change_wrapper.py
+++ b/triforce/state_change_wrapper.py
@@ -61,6 +61,12 @@ class StateChange:
                 f"Current: {self.state}\n"
 
     @property
+    def gained_triforce(self):
+        """Returns True if the player gained a triforce piece."""
+        return self.previous.link.triforce_pieces < self.state.link.triforce_pieces or \
+               not self.previous.link.triforce_of_power and self.state.link.triforce_of_power
+
+    @property
     def changed_location(self):
         """Returns True if the location changed."""
         return self.previous.full_location != self.state.full_location

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -97,7 +97,7 @@
                 "reward-details"
             ],
             "start": ["0_77c"],
-            "use_hints" : false
+            "use_hints" : true
         },
         {
             "name": "dungeon1-dungeon2",
@@ -169,7 +169,8 @@
             {
                 "bombs" : 3,
                 "sword" : 1,
-                "health" : "max_health"
+                "hearts_and_containers" : 34,
+                "partial_hearts" : 254
             }
         },
         {
@@ -197,7 +198,8 @@
             {
                 "bombs" : 3,
                 "sword" : 1,
-                "health" : "max_health"
+                "hearts_and_containers" : 34,
+                "partial_hearts" : 254
             }
         },
         {
@@ -234,8 +236,8 @@
             "per_reset":
             {
                 "bombs" : 3,
-                "max_health" : 2,
-                "health" : 3,
+                "hearts_and_containers" : 34,
+                "partial_hearts" : 254,
                 "keys" : 4
             }
         },
@@ -262,8 +264,8 @@
             "per_reset":
             {
                 "bombs" : 3,
-                "max_health" : 2,
-                "health" : 3,
+                "hearts_and_containers" : 34,
+                "partial_hearts" : 254,
                 "keys" : 4
             }
         },
@@ -288,8 +290,8 @@
             "per_reset":
             {
                 "bombs" : 3,
-                "max_health" : 2,
-                "health" : 3
+                "hearts_and_containers" : 34,
+                "partial_hearts" : 254
             }
         },
         {

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -60,7 +60,9 @@
                     "threshold" : 0.90
                 },
                 {
-                    "scenario" : "dungeon1-side-room-opening"
+                    "scenario" : "dungeon1-side-room-opening",
+                    "exit_criteria" : "success-rate",
+                    "threshold" : 0.85
                 },
                 {
                     "scenario" : "dungeon1-wallmaster",


### PR DESCRIPTION
This pull request includes several changes to the `triforce` module, focusing on adjusting reward values, refining state change handling, and updating configuration settings.

### Adjustments to Reward Values:

* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL16-R16): Modified reward values for `USED_KEY_REWARD`, `BLOCK_PROJECTILE_REWARD`, `INJURE_KILL_REWARD`, and `BEAM_ATTACK_REWARD` to use smaller reward constants. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL16-R16) [[2]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL27-R31)

### Refinements in State Change Handling:

* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR198-R207): Added a check to prevent health gain rewards after picking up the triforce and removed unnecessary attributes from the class initialization. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR198-R207) [[2]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL95-L107)
* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL292-L318): Added logic to avoid rewarding or penalizing location changes upon triforce pickup.
* [`triforce/end_conditions.py`](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L148-R148): Simplified the `is_scenario_ended` method to use the new `gained_triforce` property. [[1]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041L148-R148) [[2]](diffhunk://#diff-7b6d87efe1b340bc85816bf76c4815ed981bcca37b8dceaa662567849846a041R157)
* [`triforce/state_change_wrapper.py`](diffhunk://#diff-6e32d11b2444710e7be2740017be96000083b94fc31b6e202d621f1b1731deffR63-R68): Introduced a new `gained_triforce` property to determine if a triforce piece was gained.

### Configuration Updates:

* [`triforce/triforce.json`](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L63-R65): Updated scenarios with new exit criteria and adjusted health settings to use `hearts_and_containers` and `partial_hearts` instead of `max_health` and `health`. [[1]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L63-R65) [[2]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L100-R102) [[3]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L172-R175) [[4]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L200-R204) [[5]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L237-R242) [[6]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L265-R270) [[7]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L291-R296)

### Other Changes:

* [`triforce/models.py`](diffhunk://#diff-b977d445e76dac96dfea63b3c7ff482e1b87d63be9297927aa79776f9c3fd084L119-R119): Modified the `save` method to include the `weights_only` parameter when loading data.