### PR TITLE
Changes to try to better account for wallmasters.

### DIFF
--- a/triforce/training_hints.py
+++ b/triforce/training_hints.py
@@ -33,7 +33,7 @@ class TrainingHintWrapper(gym.Wrapper):
                 self._check_room_direction(state, info, Direction.E)
             elif link.tile.y == 0:
                 self._check_room_direction(state, info, Direction.N)
-            elif link.tile.y == 0x14:
+            elif link.tile.y >= 0x14:
                 self._check_room_direction(state, info, Direction.S)
 
     def _check_room_direction(self, state, info, direction):


### PR DESCRIPTION
This pull request includes several changes to the `triforce` module, primarily focusing on refining the critique logic for player actions and enhancing the handling of game state transitions. The most important changes include adding a new import, refining the critique logic for attacks and movements, and enhancing the handling of room directions in training hints.

Enhancements to critique logic:

* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR10-R12): Added import for `ZeldaGame` and included `Direction` in the import statement from `zelda_enums`.
* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR249-R255): Updated `critique_attack` method to avoid penalties or rewards for hitting WallMasters up close.
* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR282-R283): Added a penalty for missed attacks when no active enemies are present.
* [`triforce/critics.py`](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL348-R358): Refactored movement critique to use a new helper method `_did_link_run_into_wall` for checking wall collisions. [[1]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeL348-R358) [[2]](diffhunk://#diff-58c1d2e3cf503f8d55ac1eaafffdc780097a18eb85f2c4d3d47390ee20e5b4eeR382-R398)

Enhancements to training hints:

* [`triforce/training_hints.py`](diffhunk://#diff-c294e508448bf86896e16b6942e13930abf5679c7ee4a6fff14accad17e93c88L36-R36): Modified `_disable_actions` method to handle cases where `link.tile.y` is greater than or equal to `0x14` for checking room directions.