### PR TITLE
Game progress metric

### DIFF
--- a/triforce/metrics.py
+++ b/triforce/metrics.py
@@ -320,6 +320,34 @@ METRICS = {
             (1, 0x36) : 11,
         }),
 
+    # Unified progress through the entire game.  Milestones are immutable and
+    # independent of scenario — reaching dungeon 1 boss is always milestone 16
+    # regardless of which scenario is being evaluated.
+    "game-progress" : lambda: RoomProgressMetric({
+            # Overworld: sword cave -> dungeon 1 entrance
+            (0, 0x77) : 0,     # start / sword cave
+            (0, 0x67) : 1,     # south of sword cave
+            (0, 0x78) : 1,     # east of sword cave
+            (0, 0x68) : 2,
+            (0, 0x58) : 3,
+            (0, 0x48) : 4,
+            (0, 0x38) : 5,
+            (0, 0x37) : 6,     # dungeon 1 entrance screen
+            # Dungeon 1
+            (1, 0x73) : 7,     # entry room
+            (1, 0x72) : 8,     # west from entry
+            (1, 0x74) : 8,     # east from entry
+            (1, 0x63) : 9,
+            (1, 0x53) : 10,
+            (1, 0x52) : 11,
+            (1, 0x42) : 12,
+            (1, 0x43) : 13,
+            (1, 0x44) : 14,
+            (1, 0x45) : 15,
+            (1, 0x35) : 16,    # boss room
+            (1, 0x36) : 17,    # triforce room
+        }),
+
     "room-result" : RoomResultMetric,
     "room-health" : RoomHealthChangeMetric,
     "success-rate" : SuccessMetric,

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -1,82 +1,104 @@
 {
-    "models" :
-    [
+    "models": [
         {
-            "name" : "overworld",
-            "neural_net" : "SharedNatureAgent",
-            "action_space" : ["MOVE", "SWORD", "BEAMS"]
+            "name": "overworld",
+            "neural_net": "SharedNatureAgent",
+            "action_space": [
+                "MOVE",
+                "SWORD",
+                "BEAMS"
+            ]
         },
         {
-            "name" : "dungeon",
-            "neural_net" : "SharedNatureAgent",
-            "action_space" : ["MOVE", "SWORD", "BEAMS"]
+            "name": "dungeon",
+            "neural_net": "SharedNatureAgent",
+            "action_space": [
+                "MOVE",
+                "SWORD",
+                "BEAMS"
+            ]
         },
         {
-            "name" : "overworld-sword",
-            "neural_net" : "SharedNatureAgent",
-            "action_space" : ["MOVE"]
+            "name": "overworld-sword",
+            "neural_net": "SharedNatureAgent",
+            "action_space": [
+                "MOVE"
+            ]
         }
     ],
-    "training-circuits" :
-    [
+    "training-circuits": [
         {
-            "name" : "overworld-circuit",
-            "description" : "Train the overworld model by first teaching it to walk rooms, then to make it to dungeon1, then to grab the sword, then all together.",
-            "scenarios" : [
+            "name": "overworld-circuit",
+            "description": "Train the overworld model through curriculum: room navigation, sword pickup, overworld traversal, dungeon 1, then full game.",
+            "scenarios": [
                 {
-                    "scenario" : "overworld-room-walk",
-                    "exit_criteria" : "room-result/correct-exit",
-                    "threshold" : 0.90
+                    "scenario": "overworld-room-walk",
+                    "exit_criteria": "room-result/correct-exit",
+                    "threshold": 0.9,
+                    "iterations": 250000
                 },
                 {
-                    "scenario" : "overworld-sword",
-                    "exit_criteria" : "success-rate",
-                    "threshold" : 0.80
+                    "scenario": "overworld-sword",
+                    "exit_criteria": "success-rate",
+                    "threshold": 0.8,
+                    "iterations": 250000
                 },
                 {
-                    "scenario" : "overworld-skip-sword",
-                    "exit_criteria" : "success-rate",
-                    "threshold" : 0.90
+                    "scenario": "overworld-skip-sword",
+                    "exit_criteria": "success-rate",
+                    "threshold": 0.9,
+                    "iterations": 500000
                 },
                 {
-                    "scenario" : "game-start",
-                    "iterations" : 7500000
+                    "scenario": "game-start",
+                    "exit_criteria": "success-rate",
+                    "threshold": 0.9,
+                    "iterations": 500000
+                },
+                {
+                    "scenario": "dungeon1",
+                    "exit_criteria": "success-rate",
+                    "threshold": 0.02,
+                    "iterations": 500000
+                },
+                {
+                    "scenario": "full-game"
                 }
             ]
         },
         {
-            "name" : "dungeon1-circuit",
-            "description" : "Train the dungeon model by first teaching it to walk rooms, then to make it to dungeon1, then to grab the sword, then all together.",
-            "scenarios" : [
+            "name": "dungeon1-circuit",
+            "description": "Train the dungeon model by first teaching it to walk rooms, then to make it to dungeon1, then to grab the sword, then all together.",
+            "scenarios": [
                 {
-                    "scenario" : "dungeon1-skip-opening",
-                    "exit_criteria" : "rewards",
-                    "threshold" : 0.0,
-                    "iterations" : 2000000
+                    "scenario": "dungeon1-skip-opening",
+                    "exit_criteria": "rewards",
+                    "threshold": 0.0,
+                    "iterations": 2000000
                 },
                 {
-                    "scenario" : "dungeon1-entry-room",
-                    "exit_criteria" : "room-result/correct-exit",
-                    "threshold" : 0.90
+                    "scenario": "dungeon1-entry-room",
+                    "exit_criteria": "room-result/correct-exit",
+                    "threshold": 0.9
                 },
                 {
-                    "scenario" : "dungeon1-side-room-opening",
-                    "exit_criteria" : "success-rate",
-                    "threshold" : 0.85
+                    "scenario": "dungeon1-side-room-opening",
+                    "exit_criteria": "success-rate",
+                    "threshold": 0.85
                 },
                 {
-                    "scenario" : "dungeon1-wallmaster",
-                    "exit_criteria" : "success-rate",
-                    "threshold" : 0.85
+                    "scenario": "dungeon1-wallmaster",
+                    "exit_criteria": "success-rate",
+                    "threshold": 0.85
                 },
                 {
-                    "scenario" : "dungeon1-entry-room",
-                    "exit_criteria" : "room-result/correct-exit",
-                    "threshold" : 0.90
+                    "scenario": "dungeon1-entry-room",
+                    "exit_criteria": "room-result/correct-exit",
+                    "threshold": 0.9
                 },
                 {
-                    "scenario" : "dungeon1",
-                    "iterations" : 20000000
+                    "scenario": "dungeon1",
+                    "iterations": 20000000
                 }
             ]
         }
@@ -85,12 +107,18 @@
         {
             "name": "full-game",
             "description": "Full game from start through dungeon 1 triforce",
-            "iterations" : 2000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 2000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "GainedTriforce", "GameOver", "Timeout"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftOverworld1Area",
+                "StartingSwordCondition",
+                "GainedTriforce",
+                "GameOver",
+                "Timeout"
+            ],
+            "metrics": [
                 "success-rate",
                 "game-progress",
                 "room-health",
@@ -98,18 +126,26 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["0_77c"],
-            "use_hints" : true
+            "start": [
+                "0_77c"
+            ],
+            "use_hints": true
         },
         {
             "name": "game-start",
             "description": "The full game with training variables",
-            "iterations" : 2000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 2000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftOverworld1Area",
+                "StartingSwordCondition",
+                "EnteredDungeon",
+                "GameOver",
+                "Timeout"
+            ],
+            "metrics": [
                 "success-rate",
                 "overworld-progress",
                 "room-health",
@@ -117,18 +153,25 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["0_77c"],
-            "use_hints" : true
+            "start": [
+                "0_77c"
+            ],
+            "use_hints": true
         },
         {
             "name": "dungeon1-dungeon2",
             "description": "",
-            "iterations" : 2000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 2000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftOverworld2Area", "EnteredDungeon", "GameOver", "Timeout"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftOverworld2Area",
+                "EnteredDungeon",
+                "GameOver",
+                "Timeout"
+            ],
+            "metrics": [
                 "success-rate",
                 "overworld-progress",
                 "room-health",
@@ -136,73 +179,102 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["0_37c"],
-            "use_hints" : false
+            "start": [
+                "0_37c"
+            ],
+            "use_hints": false
         },
         {
             "name": "no-end-conditions",
             "description": "The full game with training variables",
-            "iterations" : 2000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 2000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["GameOver"],
-            "metrics" : [
+            "end_conditions": [
+                "GameOver"
+            ],
+            "metrics": [
                 "reward-average",
                 "reward-details"
             ],
-            "per_reset":
-            {
-                "hearts_and_containers" : 51,
-                "partial_hearts" : 254
+            "per_reset": {
+                "hearts_and_containers": 51,
+                "partial_hearts": 254
             },
-            "start": ["0_37c"],
-            "use_hints" : false
+            "start": [
+                "0_37c"
+            ],
+            "use_hints": false
         },
         {
             "name": "overworld-sword",
             "description": "Start of the game to the sword",
-            "iterations" : 1000000,
-            "scenario_selector" : "none",
-            "objective" : "GameCompletion",
+            "iterations": 1000000,
+            "scenario_selector": "none",
+            "objective": "GameCompletion",
             "critic": "OverworldSwordCritic",
-            "end_conditions": ["StartingRoomConditions", "Timeout"],
-            "metrics" : ["success-rate", "ending", "reward-average", "reward-details"],
-            "start": ["0_77c"],
-            "per_reset":
-            {
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254
+            "end_conditions": [
+                "StartingRoomConditions",
+                "Timeout"
+            ],
+            "metrics": [
+                "success-rate",
+                "ending",
+                "reward-average",
+                "reward-details"
+            ],
+            "start": [
+                "0_77c"
+            ],
+            "per_reset": {
+                "hearts_and_containers": 34,
+                "partial_hearts": 254
             }
         },
         {
             "name": "overworld-skip-sword",
             "description": "A scoped down room walk",
-            "iterations" : 2500000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 2500000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["StartingSwordCondition", "EnteredDungeon", "GameOver", "Timeout"],
-            "metrics" : ["success-rate", "room-result", "room-health", "ending", "reward-average", "reward-details"],
-            "start": [ "0_67s" ],
-            "use_hints" : true,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "sword" : 1,
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254
+            "end_conditions": [
+                "StartingSwordCondition",
+                "EnteredDungeon",
+                "GameOver",
+                "Timeout"
+            ],
+            "metrics": [
+                "success-rate",
+                "room-result",
+                "room-health",
+                "ending",
+                "reward-average",
+                "reward-details"
+            ],
+            "start": [
+                "0_67s"
+            ],
+            "use_hints": true,
+            "per_reset": {
+                "bombs": 3,
+                "sword": 1,
+                "hearts_and_containers": 34,
+                "partial_hearts": 254
             }
         },
         {
             "name": "overworld-room-walk",
             "description": "A training scenario to teach the model how to traverse the map and follow directions",
-            "iterations" : 2000000,
-            "scenario_selector" : "probabilistic",
-            "objective" : "RoomWalk",
+            "iterations": 2000000,
+            "scenario_selector": "probabilistic",
+            "objective": "RoomWalk",
             "critic": "GameplayCritic",
-            "end_conditions": ["RoomWalkCondition"],
-            "metrics" : [
+            "end_conditions": [
+                "RoomWalkCondition"
+            ],
+            "metrics": [
                 "success-rate",
                 "room-result",
                 "room-health",
@@ -214,24 +286,26 @@
                 "0_58",
                 "0_68"
             ],
-            "use_hints" : false,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "sword" : 1,
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254
+            "use_hints": false,
+            "per_reset": {
+                "bombs": 3,
+                "sword": 1,
+                "hearts_and_containers": 34,
+                "partial_hearts": 254
             }
         },
         {
             "name": "dungeon1-room-walk",
             "description": "Dungeon 1 room walk.",
-            "iterations" : 5000000,
-            "scenario_selector" : "probabilistic",
-            "objective" : "RoomWalk",
+            "iterations": 5000000,
+            "scenario_selector": "probabilistic",
+            "objective": "RoomWalk",
             "critic": "GameplayCritic",
-            "end_conditions": ["RoomWalkCondition", "GainedTriforce"],
-            "metrics" : [
+            "end_conditions": [
+                "RoomWalkCondition",
+                "GainedTriforce"
+            ],
+            "metrics": [
                 "success-rate",
                 "room-result",
                 "room-health",
@@ -253,24 +327,26 @@
                 "1_52",
                 "1_53"
             ],
-            "use_hints" : false,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254,
-                "keys" : 4
+            "use_hints": false,
+            "per_reset": {
+                "bombs": 3,
+                "hearts_and_containers": 34,
+                "partial_hearts": 254,
+                "keys": 4
             }
         },
         {
             "name": "dungeon1-entry-room",
             "description": "Dungeon 1 entry room.",
-            "iterations" : 1000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "RoomWalk",
+            "iterations": 1000000,
+            "scenario_selector": "round-robin",
+            "objective": "RoomWalk",
             "critic": "GameplayCritic",
-            "end_conditions": ["RoomWalkCondition", "LeftDungeon"],
-            "metrics" : [
+            "end_conditions": [
+                "RoomWalkCondition",
+                "LeftDungeon"
+            ],
+            "metrics": [
                 "success-rate",
                 "room-result",
                 "room-health",
@@ -281,24 +357,29 @@
             "start": [
                 "1_73"
             ],
-            "use_hints" : false,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254,
-                "keys" : 4
+            "use_hints": false,
+            "per_reset": {
+                "bombs": 3,
+                "hearts_and_containers": 34,
+                "partial_hearts": 254,
+                "keys": 4
             }
         },
         {
             "name": "dungeon1-side-room-opening",
             "description": "Dungeon 1.",
-            "iterations" : 2000000,
-            "scenario_selector" : "probabilistic",
-            "objective" : "GameCompletion",
+            "iterations": 2000000,
+            "scenario_selector": "probabilistic",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout", "NowhereToGoCondition"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftDungeon",
+                "GainedTriforce",
+                "GameOver",
+                "Timeout",
+                "NowhereToGoCondition"
+            ],
+            "metrics": [
                 "success-rate",
                 "overworld-progress",
                 "room-health",
@@ -306,24 +387,35 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["1_72e", "1_74w", "1_63s", "1_44w"],
-            "use_hints" : false,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254
+            "start": [
+                "1_72e",
+                "1_74w",
+                "1_63s",
+                "1_44w"
+            ],
+            "use_hints": false,
+            "per_reset": {
+                "bombs": 3,
+                "hearts_and_containers": 34,
+                "partial_hearts": 254
             }
         },
         {
             "name": "dungeon1",
             "description": "Dungeon 1.",
-            "iterations" : 10000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 10000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout", "Dungeon1DidntGetKey", "NowhereToGoCondition"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftDungeon",
+                "GainedTriforce",
+                "GameOver",
+                "Timeout",
+                "Dungeon1DidntGetKey",
+                "NowhereToGoCondition"
+            ],
+            "metrics": [
                 "success-rate",
                 "overworld-progress",
                 "room-health",
@@ -331,18 +423,26 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["1_73s"],
-            "use_hints" : false
+            "start": [
+                "1_73s"
+            ],
+            "use_hints": false
         },
         {
             "name": "dungeon1-wallmaster",
             "description": "Dungeon 1.",
-            "iterations" : 2000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 2000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout", "LeftWallmasterRoom"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftDungeon",
+                "GainedTriforce",
+                "GameOver",
+                "Timeout",
+                "LeftWallmasterRoom"
+            ],
+            "metrics": [
                 "success-rate",
                 "overworld-progress",
                 "room-health",
@@ -350,23 +450,31 @@
                 "reward-average",
                 "reward-details"
             ],
-            "per_reset":
-            {
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254
+            "per_reset": {
+                "hearts_and_containers": 34,
+                "partial_hearts": 254
             },
-            "start": ["1_45w"],
-            "use_hints" : false
+            "start": [
+                "1_45w"
+            ],
+            "use_hints": false
         },
         {
             "name": "dungeon1-skip-opening",
             "description": "Dungeon 1.",
-            "iterations" : 5000000,
-            "scenario_selector" : "round-robin",
-            "objective" : "GameCompletion",
+            "iterations": 5000000,
+            "scenario_selector": "round-robin",
+            "objective": "GameCompletion",
             "critic": "GameplayCritic",
-            "end_conditions": ["LeftDungeon", "GainedTriforce", "GameOver", "Timeout", "NowhereToGoCondition", "LeftPlayArea"],
-            "metrics" : [
+            "end_conditions": [
+                "LeftDungeon",
+                "GainedTriforce",
+                "GameOver",
+                "Timeout",
+                "NowhereToGoCondition",
+                "LeftPlayArea"
+            ],
+            "metrics": [
                 "room-result",
                 "success-rate",
                 "dungeon1-progress",
@@ -375,14 +483,15 @@
                 "reward-average",
                 "reward-details"
             ],
-            "start": ["1_63s"],
-            "use_hints" : true,
-            "per_reset":
-            {
-                "bombs" : 3,
-                "hearts_and_containers" : 34,
-                "partial_hearts" : 254,
-                "keys" : 3
+            "start": [
+                "1_63s"
+            ],
+            "use_hints": true,
+            "per_reset": {
+                "bombs": 3,
+                "hearts_and_containers": 34,
+                "partial_hearts": 254,
+                "keys": 3
             }
         }
     ]

--- a/triforce/triforce.json
+++ b/triforce/triforce.json
@@ -92,7 +92,7 @@
             "end_conditions": ["LeftOverworld1Area", "StartingSwordCondition", "GainedTriforce", "GameOver", "Timeout"],
             "metrics" : [
                 "success-rate",
-                "overworld-progress",
+                "game-progress",
                 "room-health",
                 "ending",
                 "reward-average",


### PR DESCRIPTION
This pull request introduces improvements to the training pipeline, scenario curriculum, and metrics tracking for the Zelda RL project. The main changes include enhanced iteration budgeting for scenario training, expanded scenario curriculum for overworld training, and unified game progress tracking. Additionally, the configuration files have been reformatted for clarity and maintainability, and scenario definitions have been updated to use more consistent criteria and thresholds.

### Training pipeline improvements

* Added support for total iteration budgeting across scenarios in `train.py`, allowing the training process to allocate and track iteration counts more flexibly and skip scenarios when the budget is exhausted. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R96-R118) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L122-R137)
* Modified `train_once` to return both the trained model and the number of iterations used, enabling accurate iteration tracking.

### Scenario curriculum and configuration enhancements

* Expanded the overworld training circuit in `triforce.json` to include additional scenarios such as dungeon1 and full-game, and updated exit criteria and thresholds for more granular curriculum learning.
* Updated scenario definitions in `triforce.json` to use consistent formatting for lists and dictionaries, improving readability and maintainability. [[1]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L92-R131) [[2]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L111-R147) [[3]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L120-R158) [[4]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L130-R173) [[5]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L139-R184) [[6]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L149-R207) [[7]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L169-R230) [[8]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L185-R260) [[9]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L204-R276) [[10]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L218-R290) [[11]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L233-R307) [[12]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L257-R331) [[13]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L272-R348) [[14]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L285-R361) [[15]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L300-R381) [[16]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L309-R397) [[17]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L325-R417) [[18]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L334-R428) [[19]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L344-R444)

### Metrics and evaluation improvements

* Introduced a new unified `game-progress` metric in `triforce/metrics.py` to track progress milestones throughout the game, independent of scenario.
* Updated scenario metrics in `triforce.json` to use `game-progress` instead of `overworld-progress` for more comprehensive progress tracking.

### Minor scenario adjustments

* Added explicit iteration counts and updated thresholds for several scenarios in `triforce.json` to better control training duration and success criteria. [[1]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L2-R65) [[2]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L60-R82) [[3]](diffhunk://#diff-0110ccc5ae564bd1078ffe786a1ddc2a593f2b6fc6bf17ad33cc40e32b0f0ab1L75-R97)

These changes collectively improve the robustness and clarity of the training process, scenario curriculum, and evaluation metrics for the Zelda RL project.