### PR TITLE
Fix masks reshape bug: slice to memory_length before flatten

### DIFF
--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -259,7 +259,7 @@ class PPO:
         b_logprobs = logprobs.reshape(-1)
         b_values   = values.reshape(-1)
 
-        masks     = variables.masks
+        masks     = variables.masks[:, :variables.memory_length]
         b_masks    = masks.reshape(-1, masks.shape[-1]).to(self.device)
 
         # flatten returns, advantages


### PR DESCRIPTION
masks tensor is (n_envs, memory_length+1, n_actions) but was reshaped without slicing off the +1 sentinel. With n_envs>1 this causes progressive index misalignment — env 0 is fine but by env N, mask indices point to completely wrong data, corrupting policy gradients and producing a random policy.