### PR TITLE
Fix game view overlay rendering and frame dimensions

### DIFF
--- a/tests/test_debugger_game_view.py
+++ b/tests/test_debugger_game_view.py
@@ -36,25 +36,25 @@ def test_initial_state_no_frame():
 def test_set_frame_creates_qimage():
     """Setting a frame creates a QImage with correct dimensions."""
     view = _make_game_view()
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
     assert view.frame_image is not None
     assert isinstance(view.frame_image, QImage)
-    assert view.frame_image.width() == 256
-    assert view.frame_image.height() == 240
+    assert view.frame_image.width() == 240
+    assert view.frame_image.height() == 224
     view.close()
 
 
 def test_set_frame_preserves_pixel_data():
     """Pixel data survives the numpy-to-QImage conversion."""
     view = _make_game_view()
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     # Set a known pixel: red at (0, 0)
     frame[0, 0] = [255, 0, 0]
     # Set a known pixel: green at (100, 50)
     frame[100, 50] = [0, 255, 0]
-    # Set a known pixel: blue at (239, 255)
-    frame[239, 255] = [0, 0, 255]
+    # Set a known pixel: blue at (223, 239)
+    frame[223, 239] = [0, 0, 255]
 
     view.set_frame(frame)
     img = view.frame_image
@@ -66,7 +66,7 @@ def test_set_frame_preserves_pixel_data():
     r, g, b, _ = img.pixelColor(50, 100).getRgb()
     assert (r, g, b) == (0, 255, 0), f"Expected green, got ({r}, {g}, {b})"
 
-    r, g, b, _ = img.pixelColor(255, 239).getRgb()
+    r, g, b, _ = img.pixelColor(239, 223).getRgb()
     assert (r, g, b) == (0, 0, 255), f"Expected blue, got ({r}, {g}, {b})"
     view.close()
 
@@ -84,7 +84,7 @@ def test_set_frame_non_nes_dimensions():
 def test_set_frame_none_clears():
     """Setting frame to None clears the current image."""
     view = _make_game_view()
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
     assert view.frame_image is not None
 
@@ -100,7 +100,7 @@ def test_scaled_rect_fits_in_widget():
     """Scaled rect should fit within the widget bounds."""
     view = _make_game_view()
     view.resize(960, 896)
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
 
     rect = view._scaled_rect()  # pylint: disable=protected-access
@@ -115,11 +115,11 @@ def test_scaled_rect_preserves_aspect_ratio():
     """Scaled rect should preserve the NES aspect ratio."""
     view = _make_game_view()
     view.resize(800, 600)
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
 
     rect = view._scaled_rect()  # pylint: disable=protected-access
-    original_ratio = 256 / 240
+    original_ratio = 240 / 224
     scaled_ratio = rect.width() / rect.height()
     assert abs(original_ratio - scaled_ratio) < 0.02, \
         f"Aspect ratio mismatch: {original_ratio:.3f} vs {scaled_ratio:.3f}"
@@ -149,7 +149,7 @@ def test_paint_without_crash():
     view.repaint()
 
     # Paint with a frame
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
     view.repaint()
 
@@ -159,8 +159,8 @@ def test_paint_without_crash():
 def test_minimum_size():
     """GameView has a minimum size of 256x240 (NES native)."""
     view = _make_game_view()
-    assert view.minimumWidth() == 256
-    assert view.minimumHeight() == 240
+    assert view.minimumWidth() == 240
+    assert view.minimumHeight() == 224
     view.close()
 
 
@@ -317,7 +317,7 @@ def test_paint_with_overlays_no_crash():
 
     view = _make_game_view()
     view.resize(800, 600)
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
 
     state = MagicMock()
@@ -350,7 +350,7 @@ def test_paint_overlays_without_state_no_crash():
 
     view = _make_game_view()
     view.resize(400, 300)
-    frame = np.zeros((240, 256, 3), dtype=np.uint8)
+    frame = np.zeros((224, 240, 3), dtype=np.uint8)
     view.set_frame(frame)
     view.set_overlay(OverlayFlags.WAVEFRONT, True)
     view.show()

--- a/tests/test_debugger_time_travel.py
+++ b/tests/test_debugger_time_travel.py
@@ -29,7 +29,7 @@ def _make_entry(step_number, frame=None, observation=None,
                 action_probs=None, action_mask_desc=None):
     """Build a StepEntry with sensible defaults."""
     if frame is None:
-        frame = np.zeros((240, 256, 3), dtype=np.uint8)
+        frame = np.zeros((224, 240, 3), dtype=np.uint8)
     return StepEntry(
         step_number=step_number,
         action="MOVE_N",
@@ -49,7 +49,7 @@ def _make_window_with_steps(count=5):
     """Create a MainWindow with steps in the history."""
     window = MainWindow()
     for i in range(count):
-        frame = np.full((240, 256, 3), i * 50, dtype=np.uint8)
+        frame = np.full((224, 240, 3), i * 50, dtype=np.uint8)
         entry = _make_entry(i, frame=frame)
         window.step_history.append_step(entry)
     return window

--- a/triforce_debugger/game_view.py
+++ b/triforce_debugger/game_view.py
@@ -17,24 +17,24 @@ class OverlayFlags(Flag):
     COORDINATES = auto()
 
 
-# NES tile grid constants
-_GRID_WIDTH = 32
-_GRID_HEIGHT = 22
-_NES_TILE_PX = 8          # one tile = 8 NES pixels
-_NES_TOP_HUD_PX = 56      # HUD height above the tile area
+# NES tile grid constants (after emulator overscan clipping)
+_VISIBLE_COLS = 30         # tile columns 1..30 (column 0 and 31 are clipped)
+_VISIBLE_ROWS = 22
+_NES_TILE_PX = 8           # one tile = 8 NES pixels
+_NES_HUD_PX = 48 + 8       # HUD height + 1 tile offset in the 224px clipped frame
 
 
 class GameView(QWidget):
     """Widget that displays an RGB numpy array (NES frame) scaled to fit."""
 
     # NES native resolution
-    NES_WIDTH = 256
-    NES_HEIGHT = 240
+    NES_WIDTH = 240
+    NES_HEIGHT = 224
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("game_view")
-        self.setMinimumSize(256, 240)
+        self.setMinimumSize(240, 224)
         self._frame_image: QImage | None = None
         self._overlays: OverlayFlags = OverlayFlags.NONE
         self._game_state = None  # ZeldaGame, set each step for overlay data
@@ -111,47 +111,53 @@ class GameView(QWidget):
         painter.end()
 
     def _paint_overlays(self, painter: QPainter, target_rect: QRect):
-        """Draw active overlays over the game frame."""
+        """Draw active overlays into a transparent image and composite it over the frame."""
         state = self._game_state
 
-        # Compute per-pixel scale from NES coords to widget coords
+        overlay = QImage(target_rect.size(), QImage.Format.Format_ARGB32_Premultiplied)
+        overlay.fill(QColor(0, 0, 0, 0))
+
+        op = QPainter(overlay)
+        op.setRenderHint(QPainter.RenderHint.Antialiasing, False)
+
         scale_x = target_rect.width() / self.NES_WIDTH
         scale_y = target_rect.height() / self.NES_HEIGHT
 
         tile_w = _NES_TILE_PX * scale_x
         tile_h = _NES_TILE_PX * scale_y
 
-        # The tile grid starts 1 tile left of the frame origin and _NES_TOP_HUD_PX below it
-        origin_x = target_rect.x() - tile_w
-        origin_y = target_rect.y() + _NES_TOP_HUD_PX * scale_y
+        origin_x = 0.0
+        origin_y = _NES_HUD_PX * scale_y
 
-        # Choose text color: white for dungeons/caves, black for overworld
-        is_dark = state.level != 0 or getattr(state, 'in_cave', False)
-        text_color = QColor(255, 255, 255) if is_dark else QColor(0, 0, 0)
-        grid_color = QColor(0, 0, 0, 120) if not is_dark else QColor(255, 255, 255, 120)
+        grid_color = QColor(255, 255, 255, 60)
+        bg_color = QColor(0, 0, 0, 160)
+        text_color = QColor(255, 255, 255)
 
-        font_size = max(6, int(min(tile_w, tile_h) * 0.5))
+        font_size = max(6, int(min(tile_w, tile_h) * 0.45))
         font = QFont("monospace", font_size)
         font.setStyleHint(QFont.StyleHint.Monospace)
-        painter.setFont(font)
+        op.setFont(font)
 
         grid_pen = QPen(grid_color, 1)
 
-        for tile_x in range(_GRID_WIDTH):
-            for tile_y in range(_GRID_HEIGHT):
-                rx = origin_x + tile_x * tile_w
+        for col in range(_VISIBLE_COLS):
+            tile_x = col + 1  # tile data index (skip clipped column 0)
+            for tile_y in range(_VISIBLE_ROWS):
+                rx = origin_x + col * tile_w
                 ry = origin_y + tile_y * tile_h
                 cell = QRectF(rx, ry, tile_w, tile_h)
 
-                # Grid lines
-                painter.setPen(grid_pen)
-                painter.drawRect(cell)
+                op.setPen(grid_pen)
+                op.drawRect(cell)
 
-                # Collect text from the highest-priority active overlay
                 text = self._overlay_text(state, tile_x, tile_y)
                 if text:
-                    painter.setPen(text_color)
-                    painter.drawText(cell, Qt.AlignmentFlag.AlignCenter, text)
+                    op.fillRect(cell, bg_color)
+                    op.setPen(text_color)
+                    op.drawText(cell, Qt.AlignmentFlag.AlignCenter, text)
+
+        op.end()
+        painter.drawImage(target_rect, overlay)
 
     def _overlay_text(self, state, tile_x: int, tile_y: int) -> str:
         """Return overlay text for one tile cell based on active flags.


### PR DESCRIPTION
- Render overlays into a transparent QImage composited over the frame instead of drawing QPainter primitives directly on the widget
- Add semi-transparent black background behind overlay text for readability
- Fix NES frame dimensions: 240x224 (emulator clips overscan), not 256x240
- Fix tile grid alignment: 30 visible columns at correct HUD offset
- Update tests for corrected frame dimensions