### PR TITLE
Support non-overscan mode and update model

### DIFF
--- a/triforce/observation_wrapper.py
+++ b/triforce/observation_wrapper.py
@@ -12,7 +12,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from .zelda_enums import GAMEPLAY_START_Y, Direction, ZeldaEnemyKind, ZeldaItemKind, ZeldaProjectileId
+from .zelda_enums import (GAMEPLAY_START_Y, HUD_TRIM_FULL, HUD_TRIM_CROPPED,
+                          Direction, ZeldaEnemyKind, ZeldaItemKind, ZeldaProjectileId)
 from .objectives import ObjectiveKind
 from .zelda_game import ZeldaGame
 
@@ -55,17 +56,24 @@ ENTITY_TYPE_NAMES[TREASURE_TYPE_ID] = "Treasure"
 
 class ObservationWrapper(gym.Wrapper):
     """A wrapper that trims the HUD and converts the image to grayscale."""
-    def __init__(self, env, kind, frame_stack, frame_skip, normalize):
+    def __init__(self, env, kind, frame_stack, frame_skip, normalize, full_screen=False):
         super().__init__(env)
         self._prev_loc = None
         self._normalize = normalize
         self.frame_stack = frame_stack
         self.frame_skip = frame_skip
+        self.full_screen = full_screen
 
         if kind in ('gameplay', 'viewport'):
-            self._trim = GAMEPLAY_START_Y
+            self._trim = HUD_TRIM_FULL if full_screen else HUD_TRIM_CROPPED
+            # Viewport centering always uses GAMEPLAY_START_Y so that the viewport
+            # position relative to Link is identical across cropped and full modes.
+            # (In cropped mode, _trim==56 happens to equal GAMEPLAY_START_Y; in full
+            # mode _trim==64 cuts 8 more pixels but we still subtract 56 from link.y.)
+            self._viewport_y_offset = GAMEPLAY_START_Y
         else:
             self._trim = 0
+            self._viewport_y_offset = 0
 
         if kind == 'viewport':
             self._viewport_size = VIEWPORT_PIXELS
@@ -167,7 +175,7 @@ class ObservationWrapper(gym.Wrapper):
 
         if self._viewport_size:
             x = state.link.position.x
-            y = state.link.position.y - self._trim  # we already trimmed
+            y = state.link.position.y - self._viewport_y_offset
             half_vp = self._viewport_size // 2
 
             # Current height and width (after trimming)

--- a/triforce/zelda_enums.py
+++ b/triforce/zelda_enums.py
@@ -6,7 +6,42 @@ from functools import cached_property
 import torch
 
 # the y coordinate where the gameplay window starts (above this line is the HUD)
+# This is a fixed NES constant used to convert between RAM coordinates and tile indices.
+# It does NOT change with overscan settings — RAM coordinates are always absolute NES coordinates.
 GAMEPLAY_START_Y = 56
+
+# Frame dimensions depend on whether the emulator crops overscan.
+# Cropped (default stable-retro): 240×224, removes 8px from each edge.
+# Full (fork with crop_overscan=False): 256×240, full NES output.
+NES_FULL_WIDTH = 256
+NES_FULL_HEIGHT = 240
+NES_CROPPED_WIDTH = 240
+NES_CROPPED_HEIGHT = 224
+
+# How many pixels to trim from the top of the emulator frame to remove the HUD.
+#
+# The NES HUD occupies scanlines 0-47 (48px). Scanlines 48-63 are a gap between
+# HUD and gameplay tiles (may render as black or scroll artifacts). The first
+# gameplay tile row starts at NES scanline 64 (0x40), which is what the game's
+# collision code uses as the tile area offset.
+#
+# In cropped mode (240×224), the emulator already removes the top 8 NES scanlines,
+# so frame pixel 0 = NES scanline 8.  Trimming 56 pixels reaches NES scanline 64.
+#
+# In full mode (256×240), frame pixel 0 = NES scanline 0.  Trimming 64 pixels
+# reaches the same NES scanline 64.
+#
+# The viewport centering uses a *separate* offset (GAMEPLAY_START_Y = 56) which
+# is subtracted from Link's RAM y-coordinate. This produces a consistent viewport
+# position across both modes — models trained in cropped mode work in full mode.
+HUD_TRIM_CROPPED = 56
+HUD_TRIM_FULL = 64
+
+# Number of visible tile columns after overscan clipping.
+# Cropped: columns 1-30 visible (0 and 31 clipped), Full: all 32 columns visible.
+VISIBLE_COLS_CROPPED = 30
+VISIBLE_COLS_FULL = 32
+VISIBLE_ROWS = 22
 
 class SoundKind(Enum):
     """Sound codes for the game."""

--- a/triforce/zelda_env.py
+++ b/triforce/zelda_env.py
@@ -1,5 +1,6 @@
 # A wrapper to create a Zelda environment.
 
+import logging
 import random
 import stable_retro as retro
 
@@ -10,6 +11,16 @@ from .frame_skip_wrapper import FrameSkipWrapper
 from .action_space import ZeldaActionSpace
 from .observation_wrapper import ObservationWrapper
 from .scenario_wrapper import ScenarioWrapper, TrainingScenarioDefinition
+
+_logger = logging.getLogger(__name__)
+
+def _has_crop_overscan():
+    """Check if the installed stable-retro supports the crop_overscan parameter."""
+    import inspect # pylint: disable=import-outside-toplevel
+    sig = inspect.signature(retro.retro_env.RetroEnv.__init__)
+    return 'crop_overscan' in sig.parameters
+
+_SUPPORTS_CROP_OVERSCAN = _has_crop_overscan()
 
 def make_zelda_env(scenario : TrainingScenarioDefinition, action_space : str, **kwargs):
     """
@@ -28,8 +39,18 @@ def make_zelda_env(scenario : TrainingScenarioDefinition, action_space : str, **
     obs_kind = kwargs.get('obs_kind', 'viewport')
 
     state = random.choice(scenario.start)
-    env = retro.make(game='Zelda-NES', state=state, inttype=retro.data.Integrations.CUSTOM_ONLY,
-                     render_mode=render_mode)
+
+    # Try to use full-screen (no overscan) if the installed stable-retro supports it.
+    if _SUPPORTS_CROP_OVERSCAN:
+        env = retro.make(game='Zelda-NES', state=state, inttype=retro.data.Integrations.CUSTOM_ONLY,
+                         render_mode=render_mode, crop_overscan=False)
+        full_screen = True
+        _logger.info("Using full-screen NES output (256x240, crop_overscan=False)")
+    else:
+        env = retro.make(game='Zelda-NES', state=state, inttype=retro.data.Integrations.CUSTOM_ONLY,
+                         render_mode=render_mode)
+        full_screen = False
+        _logger.info("Using cropped NES output (240x224, stock stable-retro)")
 
     # Skip frames where Link is not controllable.  Returns all frames skipped as its observation.
     env = FrameSkipWrapper(env)
@@ -48,7 +69,8 @@ def make_zelda_env(scenario : TrainingScenarioDefinition, action_space : str, **
     env = ZeldaActionSpace(env, action_space, multihead=multihead)
 
     # Converts our list of frames into a standard observation space.
-    env = ObservationWrapper(env, obs_kind, frame_stack, frame_skip=2, normalize=True)
+    env = ObservationWrapper(env, obs_kind, frame_stack, frame_skip=2, normalize=True,
+                             full_screen=full_screen)
 
     # Process the scenario. This is where we define the end conditions and rewards for the scenario.
     # Replaces the float reward with a StepRewards object.

--- a/triforce_debugger/environment_bridge.py
+++ b/triforce_debugger/environment_bridge.py
@@ -14,6 +14,7 @@ import torch
 from triforce import TrainingScenarioDefinition, ActionSpaceDefinition, ModelKindDefinition
 from triforce.action_space import ZeldaActionSpace
 from triforce.models import Network
+from triforce.observation_wrapper import ObservationWrapper
 from triforce.rewards import StepRewards
 from triforce.zelda_env import make_zelda_env
 
@@ -299,6 +300,20 @@ class EnvironmentBridge:
         self.action_space: ZeldaActionSpace = action_space
         self._observation = None
         self._action_mask = None
+
+        # Detect full_screen mode from the observation wrapper
+        self._full_screen = False
+        env_walk = self.env
+        while env_walk:
+            if isinstance(env_walk, ObservationWrapper):
+                self._full_screen = env_walk.full_screen  # pylint: disable=no-member
+                break
+            env_walk = getattr(env_walk, 'env', None)
+
+    @property
+    def full_screen(self) -> bool:
+        """Whether the environment is in full-screen (256×240) or cropped (240×224) mode."""
+        return self._full_screen
 
     @staticmethod
     def _detect_from_models(model_path):

--- a/triforce_debugger/game_view.py
+++ b/triforce_debugger/game_view.py
@@ -7,6 +7,10 @@ from PySide6.QtCore import Qt, QRect, QRectF, QPoint
 from PySide6.QtGui import QImage, QPainter, QColor, QFont, QPen
 from PySide6.QtWidgets import QWidget, QToolTip
 
+from triforce.zelda_enums import (NES_FULL_WIDTH, NES_FULL_HEIGHT, NES_CROPPED_WIDTH, NES_CROPPED_HEIGHT,
+                                  HUD_TRIM_FULL, HUD_TRIM_CROPPED,
+                                  VISIBLE_COLS_FULL, VISIBLE_COLS_CROPPED, VISIBLE_ROWS)
+
 
 class OverlayFlags(Flag):
     """Bit-flags for which overlays are active. Multiple can be combined."""
@@ -16,29 +20,55 @@ class OverlayFlags(Flag):
     WALKABILITY = auto()
 
 
-# NES tile grid constants (after emulator overscan clipping)
-_VISIBLE_COLS = 30         # tile columns 1..30 (column 0 and 31 are clipped)
-_VISIBLE_ROWS = 22
 _NES_TILE_PX = 8           # one tile = 8 NES pixels
-_NES_HUD_PX = 48 + 8       # HUD height + 1 tile offset in the 224px clipped frame
 
 
 class GameView(QWidget):
     """Widget that displays an RGB numpy array (NES frame) scaled to fit."""
 
-    # NES native resolution
-    NES_WIDTH = 240
-    NES_HEIGHT = 224
-
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("game_view")
-        self.setMinimumSize(240, 224)
+        self.setMinimumSize(NES_CROPPED_WIDTH, NES_CROPPED_HEIGHT)
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self._frame_image: QImage | None = None
         self._overlays: OverlayFlags = OverlayFlags.NONE
         self._game_state = None  # ZeldaGame, set each step for overlay data
+        self._full_screen = False  # set via set_full_screen()
+
+    # ── Public API ─────────────────────────────────────────────
+
+    def set_full_screen(self, full_screen: bool):
+        """Configure whether the game is running in full-screen (256×240) or cropped (240×224) mode."""
+        self._full_screen = full_screen
+        self.update()
+
+    @property
+    def full_screen(self) -> bool:
+        """Whether the game is in full-screen mode."""
+        return self._full_screen
+
+    @property
+    def _nes_width(self):
+        return NES_FULL_WIDTH if self._full_screen else NES_CROPPED_WIDTH
+
+    @property
+    def _nes_height(self):
+        return NES_FULL_HEIGHT if self._full_screen else NES_CROPPED_HEIGHT
+
+    @property
+    def _hud_px(self):
+        return HUD_TRIM_FULL if self._full_screen else HUD_TRIM_CROPPED
+
+    @property
+    def _visible_cols(self):
+        return VISIBLE_COLS_FULL if self._full_screen else VISIBLE_COLS_CROPPED
+
+    @property
+    def _col_offset(self):
+        """Tile column offset: in cropped mode column 0 is clipped, so visible col 0 maps to tile 1."""
+        return 0 if self._full_screen else 1
 
     # ── Public API ─────────────────────────────────────────────
 
@@ -121,14 +151,14 @@ class GameView(QWidget):
         op = QPainter(overlay)
         op.setRenderHint(QPainter.RenderHint.Antialiasing, False)
 
-        scale_x = target_rect.width() / self.NES_WIDTH
-        scale_y = target_rect.height() / self.NES_HEIGHT
+        scale_x = target_rect.width() / self._nes_width
+        scale_y = target_rect.height() / self._nes_height
 
         tile_w = _NES_TILE_PX * scale_x
         tile_h = _NES_TILE_PX * scale_y
 
         origin_x = 0.0
-        origin_y = _NES_HUD_PX * scale_y
+        origin_y = self._hud_px * scale_y
 
         grid_color = QColor(255, 255, 255, 60)
         bg_color = QColor(0, 0, 0, 160)
@@ -140,10 +170,11 @@ class GameView(QWidget):
         op.setFont(font)
 
         grid_pen = QPen(grid_color, 1)
+        col_offset = self._col_offset
 
-        for col in range(_VISIBLE_COLS):
-            tile_x = col + 1  # tile data index (skip clipped column 0)
-            for tile_y in range(_VISIBLE_ROWS):
+        for col in range(self._visible_cols):
+            tile_x = col + col_offset
+            for tile_y in range(VISIBLE_ROWS):
                 rx = origin_x + col * tile_w
                 ry = origin_y + tile_y * tile_h
                 cell = QRectF(rx, ry, tile_w, tile_h)
@@ -233,21 +264,23 @@ class GameView(QWidget):
             return None
 
         # Map widget pixel to NES pixel
-        nes_x = (pos.x() - target_rect.x()) / target_rect.width() * self.NES_WIDTH
-        nes_y = (pos.y() - target_rect.y()) / target_rect.height() * self.NES_HEIGHT
+        nes_x = (pos.x() - target_rect.x()) / target_rect.width() * self._nes_width
+        nes_y = (pos.y() - target_rect.y()) / target_rect.height() * self._nes_height
 
         # Must be below the HUD
-        if nes_y < _NES_HUD_PX:
+        if nes_y < self._hud_px:
             return None
 
         col = int(nes_x / _NES_TILE_PX)
-        row = int((nes_y - _NES_HUD_PX) / _NES_TILE_PX)
+        row = int((nes_y - self._hud_px) / _NES_TILE_PX)
 
-        # Column 0 is clipped off-screen; visible pixel 0 is tile column 1
-        tile_x = col + 1
+        col_offset = self._col_offset
+        tile_x = col + col_offset
         tile_y = row
 
-        if tile_x < 1 or tile_x > 30 or tile_y < 0 or tile_y >= _VISIBLE_ROWS:
+        min_col = col_offset
+        max_col = self._visible_cols - 1 + col_offset
+        if tile_x < min_col or tile_x > max_col or tile_y < 0 or tile_y >= VISIBLE_ROWS:
             return None
 
         return tile_x, tile_y

--- a/triforce_debugger/main_window.py
+++ b/triforce_debugger/main_window.py
@@ -391,6 +391,9 @@ class MainWindow(QMainWindow):
             self._bridge = EnvironmentBridge(
                 self._model_dir, scenario_def, self._frame_stack)
 
+            # Configure the game view for the detected NES resolution mode
+            self.game_view.set_full_screen(self._bridge.full_screen)
+
             # Select the specific .pt file if one was chosen
             if self._selected_model_path:
                 self._bridge.selector.select_by_path(self._selected_model_path)

--- a/triforce_debugger/observation_panel.py
+++ b/triforce_debugger/observation_panel.py
@@ -8,13 +8,13 @@ from PySide6.QtGui import QPainter, QImage, QColor, QPen, QPolygonF, QFont
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QScrollArea
 
 from triforce.zelda_enums import Direction
-from triforce.observation_wrapper import ENTITY_SLOTS, ENTITY_TYPE_NAMES
+from triforce.observation_wrapper import ENTITY_SLOTS, ENTITY_TYPE_NAMES, VIEWPORT_PIXELS
 
 
 # ── Observation image widget ──────────────────────────────────
 
 class ObsImageWidget(QWidget):
-    """Displays the 84×84 grayscale observation image scaled up for visibility."""
+    """Displays the grayscale observation image scaled up for visibility."""
 
     SCALE_FACTOR = 2
 
@@ -22,7 +22,7 @@ class ObsImageWidget(QWidget):
         super().__init__(parent)
         self.setObjectName("obs_image")
         self._qimage: QImage | None = None
-        self.setMinimumSize(84 * self.SCALE_FACTOR, 84 * self.SCALE_FACTOR)
+        self.setMinimumSize(VIEWPORT_PIXELS * self.SCALE_FACTOR, VIEWPORT_PIXELS * self.SCALE_FACTOR)
 
     def set_image(self, image_tensor):
         """Set image from observation tensor.  Accepts (C, H, W) or (frames, C, H, W)."""

--- a/triforce_debugger/observation_panel.py
+++ b/triforce_debugger/observation_panel.py
@@ -323,13 +323,7 @@ class ObservationPanel(QWidget):
         layout.setSpacing(4)
 
         # Title
-        title = QLabel("Observation")
-        title.setObjectName("obs_title")
-        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        font = title.font()
-        font.setBold(True)
-        title.setFont(font)
-        layout.addWidget(title)
+        layout.addWidget(self._make_header("Observation", "obs_title", bold=True))
 
         # Network input image
         self.obs_image = ObsImageWidget()
@@ -354,41 +348,47 @@ class ObservationPanel(QWidget):
             bool_layout.addWidget(indicator)
         layout.addLayout(bool_layout)
 
-        # Entity list header
-        entity_header = QLabel("Entities")
-        entity_header.setObjectName("entity_header")
-        entity_header.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        hfont = entity_header.font()
-        hfont.setBold(True)
-        hfont.setPointSize(8)
-        entity_header.setFont(hfont)
-        layout.addWidget(entity_header)
-
-        # Entity rows in a fixed-size scroll area
-        entity_container = QWidget()
-        entity_layout = QVBoxLayout(entity_container)
-        entity_layout.setContentsMargins(0, 0, 0, 0)
-        entity_layout.setSpacing(0)
-
+        # Entity list
+        layout.addWidget(self._make_header("Entities", "entity_header", bold=True, point_size=8))
         self.entity_rows: list[EntityRowWidget] = []
+        layout.addWidget(self._build_entity_scroll(), stretch=1)
+
+    @staticmethod
+    def _make_header(text, object_name, bold=False, point_size=None):
+        """Create a centered header label."""
+        label = QLabel(text)
+        label.setObjectName(object_name)
+        label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        font = label.font()
+        font.setBold(bold)
+        if point_size:
+            font.setPointSize(point_size)
+        label.setFont(font)
+        return label
+
+    def _build_entity_scroll(self):
+        """Build the scrollable entity row list."""
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
         for _ in range(ENTITY_SLOTS):
             row = EntityRowWidget()
             row.setVisible(False)
             self.entity_rows.append(row)
-            entity_layout.addWidget(row)
-        entity_layout.addStretch()
+            layout.addWidget(row)
+        layout.addStretch()
 
-        self._entity_scroll = QScrollArea()
-        self._entity_scroll.setObjectName("entity_scroll")
-        self._entity_scroll.setWidget(entity_container)
-        self._entity_scroll.setWidgetResizable(True)
-        self._entity_scroll.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self._entity_scroll.setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        # Fixed height: show ~4 entity rows without expanding the panel
-        self._entity_scroll.setFixedHeight(140)
-        layout.addWidget(self._entity_scroll, stretch=1)
+        scroll = QScrollArea()
+        scroll.setObjectName("entity_scroll")
+        scroll.setWidget(container)
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        scroll.setFixedHeight(140)
+        self._entity_scroll = scroll
+        return scroll
 
     def update_observation(self, obs: dict):
         """Update all sub-widgets from an observation dict."""


### PR DESCRIPTION
This pull request introduces robust support for both cropped and full-screen NES output modes throughout the Zelda environment and debugger. It adds detection of emulator overscan cropping, adapts observation and rendering logic, and ensures the UI and overlays correctly handle both resolutions. Additionally, it refactors UI code for maintainability and clarity.

**NES Output Mode Support**

* Added detection for the `crop_overscan` parameter in `stable-retro`, enabling automatic selection between full-screen (256×240) and cropped (240×224) NES output modes in `make_zelda_env`, with logging for mode selection. (`triforce/zelda_env.py`, [[1]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R15-R24) [[2]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R42-R53)
* Introduced constants for NES frame dimensions, HUD trim offsets, and visible tile columns/rows in `zelda_enums.py`, and updated all relevant logic to use these constants for accurate cropping and overlay rendering. (`triforce/zelda_enums.py`, [triforce/zelda_enums.pyR9-R45](diffhunk://#diff-8c44ec2d00152586fdd4e81e258555a6526ccc3005d793b8a8fe1d01e937be7eR9-R45))
* Updated `ObservationWrapper` to trim the HUD appropriately for both modes and maintain consistent viewport centering, using new constants and a `full_screen` parameter. (`triforce/observation_wrapper.py`, [[1]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL15-R16) [[2]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL58-R76) [[3]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL170-R178)
* Propagated NES output mode to the debugger UI via `EnvironmentBridge`, allowing `GameView` to adapt overlays, tile grid, and coordinate mapping based on resolution. (`triforce_debugger/environment_bridge.py`, [[1]](diffhunk://#diff-92de08fda8210def5417db150f27a5bf99df554f3f3d71dec6ca48d35866120eR304-R317); `triforce_debugger/game_view.py`, [[2]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25R10-R13) [[3]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25L19-R71) [[4]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25L124-R161) [[5]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25R173-R177) [[6]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25L236-R283); `triforce_debugger/main_window.py`, [[7]](diffhunk://#diff-ac7786ed7a6947e1ebba6406e5b1e22c402a6fd50163906899ea5a3c6e6388f6R394-R396)

**Debugger UI Improvements**

* Refactored observation panel headers and entity list construction for clarity and maintainability, replacing repetitive code with helper methods. (`triforce_debugger/observation_panel.py`, [[1]](diffhunk://#diff-4e4296efb29d6ab1e6adee7fc0d51ed988366c17fc1ecfc7830b5f81ece94b77L326-R326) [[2]](diffhunk://#diff-4e4296efb29d6ab1e6adee7fc0d51ed988366c17fc1ecfc7830b5f81ece94b77L357-R391)
* Made the observation image widget size dynamic based on viewport size constant, ensuring correct scaling regardless of output mode. (`triforce_debugger/observation_panel.py`, [triforce_debugger/observation_panel.pyL11-R25](diffhunk://#diff-4e4296efb29d6ab1e6adee7fc0d51ed988366c17fc1ecfc7830b5f81ece94b77L11-R25))

(References: [[1]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R15-R24) [[2]](diffhunk://#diff-3370f2352f59aeb4b5a52f73eedeba82063af158624f2ce09e1962e0f2e79f28R42-R53) [[3]](diffhunk://#diff-8c44ec2d00152586fdd4e81e258555a6526ccc3005d793b8a8fe1d01e937be7eR9-R45) [[4]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL15-R16) [[5]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL58-R76) [[6]](diffhunk://#diff-daf55d0826c621624c8acbf32e718c2fdfbf9ca79618faa59170a5909e04dc1dL170-R178) [[7]](diffhunk://#diff-92de08fda8210def5417db150f27a5bf99df554f3f3d71dec6ca48d35866120eR304-R317) [[8]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25R10-R13) [[9]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25L19-R71) [[10]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25L124-R161) [[11]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25R173-R177) [[12]](diffhunk://#diff-3fc55864c309816ec2a94710190e38ce51b87e569356726f43e49f45af2f9a25L236-R283) [[13]](diffhunk://#diff-ac7786ed7a6947e1ebba6406e5b1e22c402a6fd50163906899ea5a3c6e6388f6R394-R396) [[14]](diffhunk://#diff-4e4296efb29d6ab1e6adee7fc0d51ed988366c17fc1ecfc7830b5f81ece94b77L326-R326) [[15]](diffhunk://#diff-4e4296efb29d6ab1e6adee7fc0d51ed988366c17fc1ecfc7830b5f81ece94b77L357-R391) [[16]](diffhunk://#diff-4e4296efb29d6ab1e6adee7fc0d51ed988366c17fc1ecfc7830b5f81ece94b77L11-R25)