### PR TITLE
Fix EnumMetric percentage calculation and propagate exit criteria

### DIFF
--- a/tests/test_weighted_circuits.py
+++ b/tests/test_weighted_circuits.py
@@ -176,10 +176,14 @@ class TestMetricTrackerWeighted:
         """Ensure clean state before each test."""
         MetricTracker.close()
         MetricTracker._buffered_metrics.clear()
+        MetricTracker._buffered_batch_counts.clear()
+        MetricTracker._buffered_percentage_prefixes.clear()
 
     def teardown_method(self):
         MetricTracker.close()
         MetricTracker._buffered_metrics.clear()
+        MetricTracker._buffered_batch_counts.clear()
+        MetricTracker._buffered_percentage_prefixes.clear()
 
     def test_normal_mode_flat_dict(self):
         """Non-weighted mode should return flat dict."""
@@ -218,3 +222,76 @@ class TestMetricTrackerWeighted:
 
         result = MetricTracker.get_metrics_and_clear()
         assert 'full-game' in result or 'dungeon1' in result
+
+    def test_ending_percentages_across_batches(self):
+        """EndingMetric percentages must sum to ~1.0 across single-episode batches.
+
+        Reproduces the bug where each failure type showed ~100% because missing
+        keys were not counted in the denominator.
+        """
+        # Batch 1: one episode ending with death
+        t1 = MetricTracker(['ending'], scenario_name='test-scenario')
+        t1.end_scenario(True, False, 'failure-death')
+        MetricTracker.close()
+
+        # Batch 2: one episode ending with stuck
+        t2 = MetricTracker(['ending'], scenario_name='test-scenario')
+        t2.end_scenario(False, True, 'failure-stuck')
+        MetricTracker.close()
+
+        # Batch 3: one episode ending with no-progress
+        t3 = MetricTracker(['ending'], scenario_name='test-scenario')
+        t3.end_scenario(False, True, 'failure-no-progress')
+        MetricTracker.close()
+
+        # Batch 4: one episode ending with death again
+        t4 = MetricTracker(['ending'], scenario_name='test-scenario')
+        t4.end_scenario(True, False, 'failure-death')
+
+        result = MetricTracker.get_metrics_and_clear()
+        assert 'test-scenario' in result
+        metrics = result['test-scenario']
+
+        # Each ending should appear with correct percentage (2 death, 1 stuck, 1 no-progress)
+        assert metrics['endings/failure-death'] == pytest.approx(0.5)
+        assert metrics['endings/failure-stuck'] == pytest.approx(0.25)
+        assert metrics['endings/failure-no-progress'] == pytest.approx(0.25)
+
+        # They must sum to 1.0
+        total = sum(v for k, v in metrics.items() if k.startswith('endings/'))
+        assert total == pytest.approx(1.0)
+
+    def test_late_appearing_key_uses_batch_count(self):
+        """A key that first appears in a late batch uses the total batch count."""
+        # Batches 1-3: all death
+        for _ in range(3):
+            t = MetricTracker(['ending'], scenario_name='test-scenario')
+            t.end_scenario(True, False, 'failure-death')
+            MetricTracker.close()
+
+        # Batch 4: stuck (first time this key appears)
+        t = MetricTracker(['ending'], scenario_name='test-scenario')
+        t.end_scenario(False, True, 'failure-stuck')
+
+        result = MetricTracker.get_metrics_and_clear()
+        metrics = result['test-scenario']
+
+        # 3 death out of 4 batches, 1 stuck out of 4
+        assert metrics['endings/failure-death'] == pytest.approx(0.75)
+        assert metrics['endings/failure-stuck'] == pytest.approx(0.25)
+
+    def test_non_percentage_metrics_unaffected(self):
+        """Non-percentage metrics like success-rate still use per-key averaging."""
+        t1 = MetricTracker(['success-rate'], scenario_name='test-scenario')
+        t1.end_scenario(True, False, 'success')
+        t1.end_scenario(True, False, 'success')
+        MetricTracker.close()
+
+        t2 = MetricTracker(['success-rate'], scenario_name='test-scenario')
+        t2.end_scenario(False, True, 'failure')
+
+        result = MetricTracker.get_metrics_and_clear()
+        metrics = result['test-scenario']
+
+        # Batch 1: 2/2 = 1.0, Batch 2: 0/1 = 0.0, average = 0.5
+        assert metrics['success-rate'] == pytest.approx(0.5)

--- a/train.py
+++ b/train.py
@@ -969,15 +969,17 @@ def train_once(ppo, scenario_def, model_kind, action_space_def, checkpoint_dir, 
     return model, model.steps_trained - steps_before
 
 def _run_circuit(ppo, circuit, model_kind, action_space_def, checkpoint_dir, kwargs, total_budget,
-                 callback=None, circuit_def=None, skip_to=None):
+                 callback=None, circuit_def=None, skip_to=None, outer_exit_criteria=None):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     """Run training circuit and return (final_model, final_scenario_def).
 
     For weighted circuits, dispatches to _run_weighted_circuit.
+    outer_exit_criteria: ExitCriteria from the parent sequential entry, overrides inner criteria.
     """
     if circuit_def is not None and circuit_def.kind == 'weighted':
         return _run_weighted_circuit(ppo, circuit_def, model_kind, action_space_def,
-                                     checkpoint_dir, kwargs, total_budget, callback)
+                                     checkpoint_dir, kwargs, total_budget, callback,
+                                     outer_exit_criteria=outer_exit_criteria)
 
     return _run_sequential_circuit(ppo, circuit, model_kind, action_space_def,
                                     checkpoint_dir, kwargs, total_budget, callback,
@@ -1065,7 +1067,8 @@ def _run_sequential_circuit(ppo, circuit, model_kind, action_space_def, checkpoi
             sub_callback = _SubCircuitCallback(callback) if callback else None
             model, scenario_def = _run_circuit(ppo, sub_circuit_def.scenarios, model_kind,
                                                action_space_def, checkpoint_dir, sub_kwargs,
-                                               sub_budget, sub_callback, sub_circuit_def)
+                                               sub_budget, sub_callback, sub_circuit_def,
+                                               outer_exit_criteria=scenario_entry.exit_criteria)
 
             if callback:
                 callback.on_scenario_end(f"[circuit] {scenario_entry.circuit}")
@@ -1131,12 +1134,14 @@ def _run_sequential_circuit(ppo, circuit, model_kind, action_space_def, checkpoi
 
 
 def _run_weighted_circuit(ppo, circuit_def, model_kind, action_space_def, checkpoint_dir, kwargs,
-                           total_budget, callback=None):
+                           total_budget, callback=None, outer_exit_criteria=None):
     # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     """Run a weighted training circuit.
 
     All scenarios run concurrently with step-count proportional to their weights.
     The WeightedScenarioSelector (via RPC) decides which scenario each worker runs on reset.
+    outer_exit_criteria: ExitCriteria from the parent sequential entry. When provided, overrides
+    inner entry exit criteria — applied to the first (primary) scenario.
     """
     # Resolve scenario definitions and weights
     scenario_defs = []
@@ -1151,6 +1156,10 @@ def _run_weighted_circuit(ppo, circuit_def, model_kind, action_space_def, checkp
         weights.append(entry.weight)
         if entry.exit_criteria:
             exit_criteria_map[entry.scenario] = entry.exit_criteria
+
+    # Outer exit criteria overrides inner — applied to the first (primary) scenario
+    if outer_exit_criteria and scenario_defs:
+        exit_criteria_map = {scenario_defs[0].name: outer_exit_criteria}
 
     # Determine iteration budget
     if total_budget is not None:

--- a/triforce/metrics.py
+++ b/triforce/metrics.py
@@ -360,6 +360,8 @@ class MetricTracker:
     """
     _instance : 'MetricTracker' = None
     _buffered_metrics : dict = {}
+    _buffered_batch_counts : dict = {}
+    _buffered_percentage_prefixes : dict = {}
 
     @staticmethod
     def get_instance():
@@ -369,6 +371,8 @@ class MetricTracker:
     def __init__(self, metric_names, scenario_name=None):
         self.metrics = [METRICS[name]() for name in metric_names]
         self._scenario_name = scenario_name
+        self._percentage_prefixes = frozenset(
+            m.base_name for m in self.metrics if isinstance(m, EnumMetric) and m.percentage)
 
         assert MetricTracker._instance is None
         MetricTracker._instance = self
@@ -379,28 +383,47 @@ class MetricTracker:
         return self._scenario_name
 
     @staticmethod
+    def _accumulate_buffered(scenario_name, metrics, percentage_prefixes):
+        """Accumulate metric values into the per-scenario buffer.
+
+        Tracks a shared batch count per scenario so that percentage-group metrics
+        (from EnumMetric) use total batches as the denominator, not just batches
+        where a particular key appeared.
+        """
+        if scenario_name not in MetricTracker._buffered_metrics:
+            MetricTracker._buffered_metrics[scenario_name] = {}
+        existing = MetricTracker._buffered_metrics[scenario_name]
+
+        MetricTracker._buffered_batch_counts[scenario_name] = \
+            MetricTracker._buffered_batch_counts.get(scenario_name, 0) + 1
+
+        if percentage_prefixes:
+            if scenario_name not in MetricTracker._buffered_percentage_prefixes:
+                MetricTracker._buffered_percentage_prefixes[scenario_name] = set()
+            MetricTracker._buffered_percentage_prefixes[scenario_name].update(
+                percentage_prefixes)
+
+        for key, value in metrics.items():
+            if '/max' in key:
+                if key in existing:
+                    existing[key] = (max(existing[key][0], value), 1)
+                else:
+                    existing[key] = (value, 1)
+            elif key in existing:
+                old_val, old_count = existing[key]
+                existing[key] = (old_val + value, old_count + 1)
+            else:
+                existing[key] = (value, 1)
+
+    @staticmethod
     def close():
         """Closes the metric tracker, buffering metrics if in weighted mode."""
         instance = MetricTracker._instance
         if instance is not None and instance.scenario_name is not None:
             metrics = instance.get_metrics()
             if metrics:
-                name = instance.scenario_name
-                if name not in MetricTracker._buffered_metrics:
-                    MetricTracker._buffered_metrics[name] = {}
-                existing = MetricTracker._buffered_metrics[name]
-                for key, value in metrics.items():
-                    if '/max' in key:
-                        # Track maximum, not sum
-                        if key in existing:
-                            existing[key] = (max(existing[key][0], value), 1)
-                        else:
-                            existing[key] = (value, 1)
-                    elif key in existing:
-                        old_val, old_count = existing[key]
-                        existing[key] = (old_val + value, old_count + 1)
-                    else:
-                        existing[key] = (value, 1)
+                MetricTracker._accumulate_buffered(
+                    instance.scenario_name, metrics, instance._percentage_prefixes)
         MetricTracker._instance = None
 
     def begin_scenario(self, state):
@@ -460,28 +483,29 @@ class MetricTracker:
         if instance is not None and instance.scenario_name is not None:
             current = instance.get_metrics()
             if current:
-                name = instance.scenario_name
-                if name not in buffered:
-                    buffered[name] = {}
-                existing = buffered[name]
-                for key, value in current.items():
-                    if '/max' in key:
-                        if key in existing:
-                            existing[key] = (max(existing[key][0], value), 1)
-                        else:
-                            existing[key] = (value, 1)
-                    elif key in existing:
-                        old_val, old_count = existing[key]
-                        existing[key] = (old_val + value, old_count + 1)
-                    else:
-                        existing[key] = (value, 1)
+                MetricTracker._accumulate_buffered(
+                    instance.scenario_name, current, instance._percentage_prefixes)
 
             for metric in instance.metrics:
                 metric.clear()
 
-        # Flatten accumulated (value, count) tuples to averages
+        # Flatten accumulated (value, count) tuples to final values.
+        # For percentage-group metrics (EnumMetric), use the shared batch count as the
+        # denominator so that missing keys correctly contribute 0 instead of being omitted.
         result = {}
         for scenario_name, metrics in buffered.items():
-            result[scenario_name] = {key: total / count for key, (total, count) in metrics.items()}
+            batch_count = MetricTracker._buffered_batch_counts.get(scenario_name, 1)
+            pct_prefixes = MetricTracker._buffered_percentage_prefixes.get(scenario_name, set())
+            scenario_result = {}
+            for key, (total, count) in metrics.items():
+                if '/max' in key:
+                    scenario_result[key] = total
+                elif pct_prefixes and any(key.startswith(p) for p in pct_prefixes):
+                    scenario_result[key] = total / batch_count
+                else:
+                    scenario_result[key] = total / count
+            result[scenario_name] = scenario_result
         buffered.clear()
+        MetricTracker._buffered_batch_counts.clear()
+        MetricTracker._buffered_percentage_prefixes.clear()
         return result

--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -242,14 +242,17 @@ class PPO:
             metrics: {scenario_name: {metric_name: value}} from weighted mode
             exit_criteria_map: {scenario_name: ExitCriteria} for scenarios with exit criteria
         Returns:
-            True if any scenario's exit criteria is met.
+            True if ALL scenarios with exit criteria have met their threshold.
         """
+        if not exit_criteria_map:
+            return False
         for scenario_name, criteria in exit_criteria_map.items():
-            if scenario_name in metrics:
-                scenario_metrics = metrics[scenario_name]
-                if scenario_metrics.get(criteria.metric, 0) >= criteria.threshold:
-                    return True
-        return False
+            if scenario_name not in metrics:
+                return False
+            scenario_metrics = metrics[scenario_name]
+            if scenario_metrics.get(criteria.metric, 0) < criteria.threshold:
+                return False
+        return True
 
     def train_weighted(self, network_class, create_env, scenario_defs, weights,
                        action_space, iterations, exit_criteria_map, callback=None, **kwargs):
@@ -442,15 +445,18 @@ class PPO:
         """Average a list of per-scenario metric dicts from weighted workers.
 
         Each dict is {scenario_name: {metric: value}} from workers. Averages per-scenario
-        metrics across workers that reported for that scenario.
+        metrics across workers that reported for that scenario. Missing keys are padded
+        with 0 so percentage metrics use the correct denominator.
         """
         if not dicts:
             return {}
 
-        # Collect: {scenario: {metric: [values]}}
+        # Collect: {scenario: {metric: [values]}} and count workers per scenario
         combined = {}
+        scenario_worker_counts = {}
         for d in dicts:
             for scenario, metrics in d.items():
+                scenario_worker_counts[scenario] = scenario_worker_counts.get(scenario, 0) + 1
                 if scenario not in combined:
                     combined[scenario] = {}
                 for key, value in metrics.items():
@@ -458,9 +464,17 @@ class PPO:
                         combined[scenario][key] = []
                     combined[scenario][key].append(value)
 
-        return {scenario: {key: (max(vals) if '/max' in key else sum(vals) / len(vals))
-                          for key, vals in metrics.items()}
-                for scenario, metrics in combined.items()}
+        result = {}
+        for scenario, metrics in combined.items():
+            worker_count = scenario_worker_counts[scenario]
+            scenario_result = {}
+            for key, vals in metrics.items():
+                if '/max' in key:
+                    scenario_result[key] = max(vals)
+                else:
+                    scenario_result[key] = sum(vals) / worker_count
+            result[scenario] = scenario_result
+        return result
 
     @staticmethod
     def _average_metric_dicts(dicts):

--- a/triforce/ml_ppo_worker.py
+++ b/triforce/ml_ppo_worker.py
@@ -136,10 +136,16 @@ def _aggregate_metrics(metrics_list):
 
     return {key: _reduce_metric(key, values) for key, values in combined.items()}
 def _aggregate_weighted_metrics(metrics_list):
-    """Averages per-scenario metric dicts: {scenario: {metric: [values]}}."""
+    """Averages per-scenario metric dicts: {scenario: {metric: [values]}}.
+
+    Missing keys are padded with 0 per scenario so that percentage metrics
+    (like endings/) use the correct denominator across workers.
+    """
     combined = {}
+    scenario_worker_counts = {}
     for metrics in metrics_list:
         for scenario, scenario_metrics in metrics.items():
+            scenario_worker_counts[scenario] = scenario_worker_counts.get(scenario, 0) + 1
             if scenario not in combined:
                 combined[scenario] = {}
             for key, value in scenario_metrics.items():
@@ -147,8 +153,18 @@ def _aggregate_weighted_metrics(metrics_list):
                     combined[scenario][key] = []
                 combined[scenario][key].append(value)
 
-    return {scenario: {key: _reduce_metric(key, vals) for key, vals in metrics.items()}
-            for scenario, metrics in combined.items()}
+    result = {}
+    for scenario, metrics in combined.items():
+        worker_count = scenario_worker_counts[scenario]
+        scenario_result = {}
+        for key, vals in metrics.items():
+            if '/max' in key:
+                scenario_result[key] = max(vals)
+            else:
+                # Pad with 0 for workers that didn't report this key
+                scenario_result[key] = sum(vals) / worker_count
+        result[scenario] = scenario_result
+    return result
 
 
 class RolloutWorkerPool:


### PR DESCRIPTION
This pull request addresses a bug in how percentage metrics (such as episode ending statistics) are aggregated and averaged across batches and workers, especially in weighted training circuits. The key improvement ensures that missing keys (e.g., an ending type not seen in a batch) are correctly counted as zero, so that percentages sum to 1.0 and late-appearing keys use the correct denominator. The changes also clarify and fix exit criteria logic for weighted circuits. Comprehensive tests are added to verify the correct behavior.

**Metric aggregation and averaging fixes:**

* Refactored the `MetricTracker` class to track batch counts and percentage metric prefixes per scenario, ensuring that percentage metrics (like episode endings) are averaged using the total number of batches, not just the batches where a key appeared. This fixes the bug where each ending type could incorrectly show 100%. (`triforce/metrics.py`) [[1]](diffhunk://#diff-9fb9edd58cc9b38b98bf3050be417aedf46dc291f60a071f4ad7098973197db8R363-R364) [[2]](diffhunk://#diff-9fb9edd58cc9b38b98bf3050be417aedf46dc291f60a071f4ad7098973197db8R374-R375) [[3]](diffhunk://#diff-9fb9edd58cc9b38b98bf3050be417aedf46dc291f60a071f4ad7098973197db8L382-L394) [[4]](diffhunk://#diff-9fb9edd58cc9b38b98bf3050be417aedf46dc291f60a071f4ad7098973197db8R417-R426) [[5]](diffhunk://#diff-9fb9edd58cc9b38b98bf3050be417aedf46dc291f60a071f4ad7098973197db8L463-R510)
* Updated metric aggregation in both the main process and worker processes to pad missing keys with zeros when averaging across workers, so that percentage metrics use the correct denominator. (`triforce/ml_ppo.py`, `triforce/ml_ppo_worker.py`) [[1]](diffhunk://#diff-cf76c1877c67983f3f27979c45683149927bc89045e64b12122a6ce8b002f012L445-R477) [[2]](diffhunk://#diff-fe05efa7f8b07ac9ed6cec05304ba160934225ce2e9978e69ba360bcccb6c262L139-R167)

**Weighted circuit and exit criteria improvements:**

* Modified weighted circuit execution to allow an outer exit criteria (from a parent sequential circuit) to override the inner exit criteria for the primary scenario, ensuring correct stopping behavior in nested circuits. (`train.py`) [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L972-R982) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L1068-R1071) [[3]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L1134-R1144) [[4]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1160-R1163)
* Fixed the logic for checking weighted circuit exit criteria: now, all scenarios with exit criteria must meet their thresholds to stop, rather than any single one. (`triforce/ml_ppo.py`)

**Testing:**

* Added comprehensive tests to verify correct aggregation and averaging of percentage metrics across batches, including cases with late-appearing keys and non-percentage metrics. (`tests/test_weighted_circuits.py`) [[1]](diffhunk://#diff-c98fccc71da8ec08fa7742a80e1e829383ebafd2e1937242f48ba669001ea62dR179-R186) [[2]](diffhunk://#diff-c98fccc71da8ec08fa7742a80e1e829383ebafd2e1937242f48ba669001ea62dR225-R297)