### PR TITLE
Record experiment5 results + Dungeon 1 completion plan

### DIFF
--- a/.agents/skills/triforce-evaluation/SKILL.md
+++ b/.agents/skills/triforce-evaluation/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: triforce-evaluation
+description: Use when running, comparing, or inspecting long Triforce model evaluations through OMP. Requires the evaluation plugin instead of direct evaluate.py execution.
+---
+
+# Triforce Evaluation Skill
+
+Use this skill when the user asks to evaluate a Triforce model, compare eval JSON files, run final evaluation, inspect a `.eval.json` or `.eval.md`, or evaluate a checkpoint/run directory.
+
+Rule: Use the triforce_evaluation_* tools. Do not call evaluate.py directly. If the plugin or Python environment fails, ask the user to fix that problem instead of bypassing the plugin.
+
+Evaluation is optional and not a training gate. The training skill may recommend evaluation during finish/reporting, but evaluation is never required before training continue/restart decisions.
+
+## Defaults
+
+- `episodes = 50`.
+- `reprocess = false` unless the user explicitly asks to overwrite prior evaluation or the prior eval has fewer than requested episodes.
+- `frame_stack = 3`.
+- `limit = -1`.
+
+## Running an evaluation
+
+1. Confirm model path and scenario from user input or current training milestone/status (`final_model_path`, `latest_checkpoint_path`, or `final_eval_scenario`). Do not ask when those paths are present in the report/status.
+2. Call `triforce_evaluation_start` with episodes default 50.
+3. Stop; wait for the plugin's completion or failure wake.
+4. On completion, read the result paths from the wake/status, then summarize results in chat or append to experiment `summary.md` when this is part of a training experiment.
+5. On failure, ask the user to fix the plugin/environment issue. Do not run evaluate.py directly.
+
+## Comparing evaluations
+
+1. Use `triforce_evaluation_compare` for `evaluate.py --compare` behavior.
+2. Stop until the plugin sends the completion or failure wake.
+3. Summarize `compare.md`. Do not run compare directly in bash.
+
+## Failure handling
+
+If the plugin reports a missing `.venv/bin/python`, missing model path, missing eval JSON path, failed process, or `complete_no_results`, report the plugin/environment issue and ask the user how they want it fixed. Do not bypass the plugin by running `evaluate.py` directly.

--- a/.agents/skills/triforce-evaluation/SKILL.md
+++ b/.agents/skills/triforce-evaluation/SKILL.md
@@ -22,15 +22,15 @@ Evaluation is optional and not a training gate. The training skill may recommend
 
 1. Confirm model path and scenario from user input or current training milestone/status (`final_model_path`, `latest_checkpoint_path`, or `final_eval_scenario`). Do not ask when those paths are present in the report/status.
 2. Call `triforce_evaluation_start` with episodes default 50.
-3. Stop; wait for the plugin's completion or failure wake.
-4. On completion, read the result paths from the wake/status, then summarize results in chat or append to experiment `summary.md` when this is part of a training experiment.
+3. End the turn immediately after the tool returns. Do not sleep, poll, wait, or call status in a loop; the plugin will wake the agent on completion or failure.
+4. On the completion wake, read the result paths from the wake/status, then summarize results in chat or append to experiment `summary.md` when this is part of a training experiment.
 5. On failure, ask the user to fix the plugin/environment issue. Do not run evaluate.py directly.
 
 ## Comparing evaluations
 
 1. Use `triforce_evaluation_compare` for `evaluate.py --compare` behavior.
-2. Stop until the plugin sends the completion or failure wake.
-3. Summarize `compare.md`. Do not run compare directly in bash.
+2. End the turn immediately after the tool returns. Do not sleep, poll, wait, or call status in a loop; the plugin will wake the agent on completion or failure.
+3. On the completion wake, summarize `compare.md`. Do not run compare directly in bash.
 
 ## Failure handling
 

--- a/.agents/skills/triforce-experiment/SKILL.md
+++ b/.agents/skills/triforce-experiment/SKILL.md
@@ -84,15 +84,14 @@ Use when training is reward hacking, diverging, stuck, or the experiment hypothe
 
 Use when the experiment succeeded, failed after exhausting high-value ideas, hit a guardrail, or needs human review.
 
-1. Run final evaluation commands:
+1. Use the evaluation plugin for final evaluation and comparison:
 
-```bash
-source .venv/bin/activate
-python evaluate.py <final_model_or_run_dir> <scenario> --episodes <N> --reprocess
-python evaluate.py --compare <baseline.eval.json> <new.eval.json>
-```
+   - Call `triforce_evaluation_start` with the final model path, final evaluation scenario, and the evaluation plugin default of 50 episodes unless the journal records a different user-approved episode count.
+   - Stop until the evaluation plugin sends a completion or failure wake.
+   - When comparing against a baseline `.eval.json`, call `triforce_evaluation_compare` and stop until its completion or failure wake.
+   - If the evaluation plugin fails, record the failure in `summary.md` and ask the user to fix the plugin/environment. Do not bypass the plugin by calling `evaluate.py` directly.
 
-Use `N=100` unless the journal records a different user-approved episode count.
+Evaluation is part of finish/reporting only. It is not a gate for training continue/restart decisions.
 
 2. Write `training/experiments/<experiment-id>/summary.md` with what was tried, code/config changes, outcomes, comparison results, and final decision.
 3. End `summary.md` with this exact heading and subsections:

--- a/.agents/skills/triforce-experiment/SKILL.md
+++ b/.agents/skills/triforce-experiment/SKILL.md
@@ -87,8 +87,8 @@ Use when the experiment succeeded, failed after exhausting high-value ideas, hit
 1. Use the evaluation plugin for final evaluation and comparison:
 
    - Call `triforce_evaluation_start` with the final model path, final evaluation scenario, and the evaluation plugin default of 50 episodes unless the journal records a different user-approved episode count.
-   - Stop until the evaluation plugin sends a completion or failure wake.
-   - When comparing against a baseline `.eval.json`, call `triforce_evaluation_compare` and stop until its completion or failure wake.
+   - End the turn immediately after `triforce_evaluation_start` returns. Do not sleep, poll, wait, or call evaluation status in a loop; the evaluation plugin will wake the agent on completion or failure.
+   - When comparing against a baseline `.eval.json`, call `triforce_evaluation_compare`, then end the turn immediately and rely on the plugin wake; do not sleep or poll.
    - If the evaluation plugin fails, record the failure in `summary.md` and ask the user to fix the plugin/environment. Do not bypass the plugin by calling `evaluate.py` directly.
 
 Evaluation is part of finish/reporting only. It is not a gate for training continue/restart decisions.

--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,6 @@ docs/todo/
 .bookkeeping/
 triforce/custom_integrations/Zelda-NES/*.png
 triforce/custom_integrations/Zelda-NES/*.yaml
+
+# graphify tool output
+graphify-out/

--- a/.omp/extensions/triforce-evaluation/index.ts
+++ b/.omp/extensions/triforce-evaluation/index.ts
@@ -1,0 +1,793 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+interface EvaluationState {
+  evalId: string;
+  evalDir: string;
+  modelPath: string;
+  scenario: string;
+  episodes: number;
+  reprocess: boolean;
+  compare: [string, string] | null;
+  childPid: number | null;
+  child: ChildProcess | null;
+  processOutput: ProcessOutput;
+  startedAt: number;
+  completedAt: number | null;
+  resultJsonPath: string | null;
+  resultMdPath: string | null;
+  compareOutputPath: string | null;
+  statusPath: string;
+  wakeSent: boolean;
+  widgetTimer: NodeJS.Timeout | null;
+}
+
+interface ProcessOutput {
+  stdoutPath: string;
+  stderrPath: string;
+  stdoutTail: string[];
+  stderrTail: string[];
+}
+
+interface EvaluationStartParams {
+  eval_id?: string;
+  model_path: string;
+  scenario: string;
+  episodes: number;
+  reprocess: boolean;
+  render: boolean;
+  limit: number;
+  frame_stack: number;
+  steps?: number[];
+  extra_args: string[];
+}
+
+interface EvaluationCompareParams {
+  eval_id?: string;
+  baseline_eval_json: string;
+  candidate_eval_json: string;
+}
+
+interface EvalSummary {
+  episodes?: number;
+  scenario?: string;
+  successRate?: number | null;
+  maxProgressReached?: number;
+  maxProgressPercent?: number;
+}
+
+interface UiHooks {
+  hasUI: () => boolean;
+  setWidget: (lines: string[]) => void | Promise<void>;
+}
+
+let state: EvaluationState | null = null;
+let uiHooks: UiHooks | null = null;
+
+export default function triforceEvaluation(pi: ExtensionAPI): void {
+  const z = pi.zod;
+  pi.setLabel("Triforce Evaluations");
+
+  pi.on("session_start", async (_event, ctx) => {
+    uiHooks = {
+      hasUI: () => ctx.hasUI,
+      setWidget: (lines: string[]) => ctx.ui.setWidget("aboveEditor", lines),
+    };
+  });
+
+  pi.on("session_shutdown", async () => {
+    if (state?.child && state.childPid && isProcessAlive(state.childPid)) {
+      state.child.kill("SIGTERM");
+    }
+    stopWidgetTimer();
+  });
+
+  pi.registerTool({
+    name: "triforce_evaluation_start",
+    label: "Start Triforce Evaluation",
+    description: "Run a long Triforce evaluate.py job through OMP and wake only when it completes or fails.",
+    parameters: z.object({
+      eval_id: z.string().optional(),
+      model_path: z.string(),
+      scenario: z.string(),
+      episodes: z.number().int().positive().default(50),
+      reprocess: z.boolean().default(false),
+      render: z.boolean().default(false),
+      limit: z.number().int().default(-1),
+      frame_stack: z.number().int().positive().default(3),
+      steps: z.array(z.number().int()).optional(),
+      extra_args: z.array(z.string()).default([]),
+    }),
+    async execute(_toolCallId, params) {
+      const parsed = normalizeStartParams(params);
+      const validation = validateLaunch(parsed.model_path);
+      if (validation) {
+        return toolResult(validation, {}, true);
+      }
+      const result = startEvaluation(pi, parsed);
+      return toolResult(result.message, result.details, !result.ok);
+    },
+  });
+
+  pi.registerTool({
+    name: "triforce_evaluation_compare",
+    label: "Compare Triforce Evaluations",
+    description: "Run evaluate.py --compare through OMP and wake only when comparison completes or fails.",
+    parameters: z.object({
+      eval_id: z.string().optional(),
+      baseline_eval_json: z.string(),
+      candidate_eval_json: z.string(),
+    }),
+    async execute(_toolCallId, params) {
+      const parsed = normalizeCompareParams(params);
+      const validation = validateCompareLaunch(parsed.baseline_eval_json, parsed.candidate_eval_json);
+      if (validation) {
+        return toolResult(validation, {}, true);
+      }
+      const result = startComparison(pi, parsed);
+      return toolResult(result.message, result.details, !result.ok);
+    },
+  });
+
+  pi.registerTool({
+    name: "triforce_evaluation_status",
+    label: "Triforce Evaluation Status",
+    description: "Return the active or latest Triforce evaluation plugin status.",
+    parameters: z.object({}),
+    async execute() {
+      return toolResult("Triforce evaluation status loaded.", {
+        active: state !== null,
+        status: readStatusForTool(),
+      }, false);
+    },
+  });
+
+  pi.registerTool({
+    name: "triforce_evaluation_cancel",
+    label: "Cancel Triforce Evaluation",
+    description: "Cancel the active Triforce evaluation without waking the LLM.",
+    parameters: z.object({ reason: z.string().default("") }),
+    async execute(_toolCallId, params) {
+      const reason = readStringField(params, "reason") ?? "";
+      if (!state) {
+        return toolResult("No active Triforce evaluation to cancel.", {}, true);
+      }
+      await cancelEvaluation(reason);
+      return toolResult("Triforce evaluation cancelled.", { eval_id: state?.evalId ?? null }, false);
+    },
+  });
+}
+
+function startEvaluation(pi: ExtensionAPI, params: EvaluationStartParams) {
+  const pythonPath = path.join(process.cwd(), ".venv", "bin", "python");
+  const evalId = sanitizeExperimentId(params.eval_id ?? `eval-${params.scenario}-${timestampSlug()}`);
+  const evalDir = path.join("training", "evaluations", evalId);
+  fs.mkdirSync(evalDir, { recursive: true });
+  const args = ["evaluate.py", params.model_path, params.scenario, "--episodes", String(params.episodes), "--frame-stack", String(params.frame_stack)];
+  if (params.reprocess) {
+    args.push("--reprocess");
+  }
+  if (params.render) {
+    args.push("--render");
+  }
+  if (params.limit !== -1) {
+    args.push("--limit", String(params.limit));
+  }
+  if (params.steps && params.steps.length > 0) {
+    args.push("--steps", ...params.steps.map(String));
+  }
+  args.push(...params.extra_args);
+
+  const child = spawn(pythonPath, args, {
+    cwd: process.cwd(),
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const processOutput = makeProcessOutput(evalDir, child.pid ?? 0);
+  const expected = expectedResultPaths(params.model_path);
+  state = {
+    evalId,
+    evalDir,
+    modelPath: params.model_path,
+    scenario: params.scenario,
+    episodes: params.episodes,
+    reprocess: params.reprocess,
+    compare: null,
+    childPid: child.pid ?? null,
+    child,
+    processOutput,
+    startedAt: Date.now() / 1000,
+    completedAt: null,
+    resultJsonPath: expected.primaryJson,
+    resultMdPath: expected.primaryMd,
+    compareOutputPath: null,
+    statusPath: path.join(evalDir, "status.json"),
+    wakeSent: false,
+    widgetTimer: null,
+  };
+  writeStatus("running", { command: [pythonPath, ...args], expected_eval_json_path: expected.primaryJson, expected_eval_md_path: expected.primaryMd });
+  wireChild(pi, child, false);
+  child.unref();
+  startWidgetTimer();
+  return {
+    ok: true,
+    message: "Triforce evaluation started.",
+    details: { eval_id: evalId, eval_dir: evalDir, child_pid: child.pid ?? null, status_path: state.statusPath },
+  };
+}
+
+function startComparison(pi: ExtensionAPI, params: EvaluationCompareParams) {
+  const pythonPath = path.join(process.cwd(), ".venv", "bin", "python");
+  const evalId = sanitizeExperimentId(params.eval_id ?? `compare-${timestampSlug()}`);
+  const evalDir = path.join("training", "evaluations", evalId);
+  fs.mkdirSync(evalDir, { recursive: true });
+  const args = ["evaluate.py", "--compare", params.baseline_eval_json, params.candidate_eval_json];
+  const child = spawn(pythonPath, args, {
+    cwd: process.cwd(),
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  state = {
+    evalId,
+    evalDir,
+    modelPath: params.candidate_eval_json,
+    scenario: "compare",
+    episodes: 0,
+    reprocess: false,
+    compare: [params.baseline_eval_json, params.candidate_eval_json],
+    childPid: child.pid ?? null,
+    child,
+    processOutput: makeProcessOutput(evalDir, child.pid ?? 0),
+    startedAt: Date.now() / 1000,
+    completedAt: null,
+    resultJsonPath: null,
+    resultMdPath: null,
+    compareOutputPath: path.join(evalDir, "compare.md"),
+    statusPath: path.join(evalDir, "status.json"),
+    wakeSent: false,
+    widgetTimer: null,
+  };
+  writeStatus("running", { command: [pythonPath, ...args], compare_output_path: state.compareOutputPath });
+  wireChild(pi, child, true);
+  child.unref();
+  startWidgetTimer();
+  return {
+    ok: true,
+    message: "Triforce evaluation comparison started.",
+    details: { eval_id: evalId, eval_dir: evalDir, child_pid: child.pid ?? null, status_path: state.statusPath },
+  };
+}
+
+function wireChild(pi: ExtensionAPI, child: ChildProcess, compare: boolean): void {
+  child.stdout?.on("data", (chunk: Buffer) => appendProcessOutput("stdout", chunk.toString("utf8")));
+  child.stderr?.on("data", (chunk: Buffer) => appendProcessOutput("stderr", chunk.toString("utf8")));
+  child.on("exit", (code, signal) => {
+    if (!state) {
+      return;
+    }
+    state.child = null;
+    state.completedAt = Date.now() / 1000;
+    if (code === 0 && !signal) {
+      completeEvaluation(pi, compare, code, signal);
+    } else {
+      failEvaluation(pi, code, signal, "Evaluation process failed.");
+    }
+  });
+}
+
+function completeEvaluation(pi: ExtensionAPI, compare: boolean, code: number | null, signal: NodeJS.Signals | null): void {
+  if (!state || state.wakeSent) {
+    return;
+  }
+  if (compare && state.compareOutputPath) {
+    const stdout = readTextIfExists(state.processOutput.stdoutPath) ?? "";
+    fs.writeFileSync(state.compareOutputPath, stdout, "utf8");
+    writeStatus("complete", { exit_code: code, signal, compare_output_path: state.compareOutputPath });
+    void sendCompletionWake(pi, "Comparison complete.");
+    return;
+  }
+  const resultPaths = discoverResultPaths(state.modelPath);
+  const primary = resultPaths[0] ?? null;
+  state.resultJsonPath = primary?.jsonPath ?? state.resultJsonPath;
+  state.resultMdPath = primary?.mdPath ?? state.resultMdPath;
+  const summary = primary ? summarizeEvalJson(primary.jsonPath) : null;
+  const finalState = primary ? "complete" : "complete_no_results";
+  writeStatus(finalState, {
+    exit_code: code,
+    signal,
+    result_json_paths: resultPaths.map(result => result.jsonPath),
+    result_md_paths: resultPaths.map(result => result.mdPath),
+    summary,
+  });
+  const message = primary
+    ? "Evaluation complete."
+    : "Evaluation exited successfully but no .eval.json result was found. Ask the user whether to re-run through the plugin. Do not run evaluate.py directly.";
+  void sendCompletionWake(pi, message);
+}
+
+function failEvaluation(pi: ExtensionAPI, code: number | null, signal: NodeJS.Signals | null, details: string): void {
+  if (!state || state.wakeSent) {
+    return;
+  }
+  writeStatus("failed", {
+    exit_code: code,
+    signal,
+    stdout_tail: state.processOutput.stdoutTail.join(""),
+    stderr_tail: state.processOutput.stderrTail.join(""),
+  });
+  void sendFailureWake(pi, details);
+}
+
+async function sendCompletionWake(pi: ExtensionAPI, headline: string): Promise<void> {
+  if (!state || state.wakeSent) {
+    return;
+  }
+  state.wakeSent = true;
+  clearWidget();
+  const status = readJsonFile(state.statusPath);
+  const summary = isRecord(status) && isRecord(status.summary) ? renderSummary(status.summary) : "No parsed summary.";
+  const message = [
+    `Triforce evaluation complete: ${state.evalId}`,
+    "",
+    headline,
+    "",
+    `Model: ${state.modelPath}`,
+    `Scenario: ${state.scenario}`,
+    `Episodes: ${state.episodes}`,
+    `Status: ${state.statusPath}`,
+    `Stdout log: ${state.processOutput.stdoutPath}`,
+    `Stderr log: ${state.processOutput.stderrPath}`,
+    `Result JSON: ${state.resultJsonPath ?? "none"}`,
+    `Result Markdown: ${state.resultMdPath ?? "none"}`,
+    `Compare output: ${state.compareOutputPath ?? "none"}`,
+    "",
+    "## Summary",
+    summary,
+    "",
+    "Use the triforce-evaluation skill. Summarize the result or append it to summary.md if this was part of a training experiment.",
+  ].join("\n");
+  await pi.sendMessage({
+    customType: "triforce-evaluation-complete",
+    content: message,
+    display: true,
+    attribution: "user",
+  }, { deliverAs: "nextTurn", triggerTurn: true });
+}
+
+async function sendFailureWake(pi: ExtensionAPI, details: string): Promise<void> {
+  if (!state || state.wakeSent) {
+    return;
+  }
+  state.wakeSent = true;
+  clearWidget();
+  const message = [
+    `Triforce evaluation failed: ${state.evalId}`,
+    "",
+    details,
+    "",
+    `Model: ${state.modelPath}`,
+    `Scenario: ${state.scenario}`,
+    `Status: ${state.statusPath}`,
+    `Stdout log: ${state.processOutput.stdoutPath}`,
+    `Stderr log: ${state.processOutput.stderrPath}`,
+    "",
+    "## stdout tail",
+    "```text",
+    state.processOutput.stdoutTail.join("").trimEnd(),
+    "```",
+    "",
+    "## stderr tail",
+    "```text",
+    state.processOutput.stderrTail.join("").trimEnd(),
+    "```",
+    "",
+    "Ask the user to fix the evaluation plugin/environment problem. Do not run evaluate.py directly.",
+  ].join("\n");
+  await pi.sendMessage({
+    customType: "triforce-evaluation-failure",
+    content: message,
+    display: true,
+    attribution: "user",
+  }, { deliverAs: "nextTurn", triggerTurn: true });
+}
+
+async function cancelEvaluation(reason: string): Promise<void> {
+  if (!state) {
+    return;
+  }
+  const child = state.child;
+  if (child && state.childPid && isProcessAlive(state.childPid)) {
+    child.kill("SIGTERM");
+    const exitPromise = waitForExit(child);
+    const timeoutPromise = delay(30_000).then(() => "timeout" as const);
+    const result = await Promise.race([exitPromise, timeoutPromise]);
+    if (result === "timeout" && state.childPid && isProcessAlive(state.childPid)) {
+      child.kill("SIGKILL");
+    }
+  }
+  writeStatus("cancelled", { reason });
+  clearWidget();
+}
+
+function startWidgetTimer(): void {
+  if (!state || state.widgetTimer) {
+    return;
+  }
+  state.widgetTimer = setInterval(updateWidget, 30_000);
+  updateWidget();
+}
+
+function stopWidgetTimer(): void {
+  if (!state?.widgetTimer) {
+    return;
+  }
+  clearInterval(state.widgetTimer);
+  state.widgetTimer = null;
+}
+
+function updateWidget(): void {
+  if (!state || !(uiHooks?.hasUI() ?? false)) {
+    return;
+  }
+  const lastStdout = lastNonEmptyLine(state.processOutput.stdoutTail.join(""));
+  const lines = [
+    `Triforce eval: ${statusState()} pid=${state.childPid ?? "n/a"}`,
+    `Model: ${path.basename(state.modelPath)}`,
+    `Scenario: ${state.scenario}`,
+    `Episodes: ${state.episodes}`,
+    `Elapsed: ${formatDuration(Date.now() / 1000 - state.startedAt)}`,
+    `Output: ${state.evalDir}`,
+    `Stdout: ${lastStdout ?? "n/a"}`,
+    `Result: ${state.resultJsonPath ? path.basename(state.resultJsonPath) : "pending"}`,
+  ];
+  void uiHooks.setWidget(lines);
+}
+
+function clearWidget(): void {
+  stopWidgetTimer();
+  if (uiHooks?.hasUI()) {
+    void uiHooks.setWidget([]);
+  }
+}
+
+function writeStatus(status: string, extra: Record<string, unknown>): void {
+  if (!state) {
+    return;
+  }
+  const payload = {
+    state: status,
+    eval_id: state.evalId,
+    eval_dir: state.evalDir,
+    model_path: state.modelPath,
+    scenario: state.scenario,
+    episodes: state.episodes,
+    reprocess: state.reprocess,
+    compare: state.compare,
+    pid: state.childPid,
+    started_at: state.startedAt,
+    completed_at: state.completedAt,
+    stdout_path: state.processOutput.stdoutPath,
+    stderr_path: state.processOutput.stderrPath,
+    result_json_path: state.resultJsonPath,
+    result_md_path: state.resultMdPath,
+    compare_output_path: state.compareOutputPath,
+    updated_at: Date.now() / 1000,
+    ...extra,
+  } satisfies Record<string, unknown>;
+  fs.writeFileSync(state.statusPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function readStatusForTool(): unknown {
+  if (state) {
+    return readJsonFile(state.statusPath) ?? { state: statusState(), eval_id: state.evalId };
+  }
+  const latest = latestStatusPath();
+  return latest ? readJsonFile(latest) : { state: "inactive" };
+}
+
+function statusState(): string {
+  if (!state) {
+    return "inactive";
+  }
+  if (state.completedAt !== null) {
+    const parsed = readJsonFile(state.statusPath);
+    return isRecord(parsed) && typeof parsed.state === "string" ? parsed.state : "complete";
+  }
+  return "running";
+}
+
+function validateLaunch(modelPath: string): string | null {
+  const common = validateRootAndPython();
+  if (common) {
+    return common;
+  }
+  if (!fs.existsSync(modelPath)) {
+    return `Model path does not exist: ${modelPath}`;
+  }
+  return null;
+}
+
+function validateCompareLaunch(baselinePath: string, candidatePath: string): string | null {
+  const common = validateRootAndPython();
+  if (common) {
+    return common;
+  }
+  if (!fs.existsSync(baselinePath)) {
+    return `Evaluation JSON path does not exist: ${baselinePath}`;
+  }
+  if (!fs.existsSync(candidatePath)) {
+    return `Evaluation JSON path does not exist: ${candidatePath}`;
+  }
+  return null;
+}
+
+function validateRootAndPython(): string | null {
+  if (!isTriforceRoot(process.cwd())) {
+    return "Run OMP from the Triforce repository root.";
+  }
+  const pythonPath = path.join(process.cwd(), ".venv", "bin", "python");
+  if (!fs.existsSync(pythonPath)) {
+    return "Missing .venv/bin/python. Ask the user to fix the Triforce Python environment; do not run evaluate.py directly.";
+  }
+  return null;
+}
+
+function expectedResultPaths(modelPath: string): { primaryJson: string | null; primaryMd: string | null } {
+  if (fs.existsSync(modelPath) && fs.statSync(modelPath).isFile() && modelPath.endsWith(".pt")) {
+    return { primaryJson: modelPath.replace(/\.pt$/, ".eval.json"), primaryMd: modelPath.replace(/\.pt$/, ".eval.md") };
+  }
+  return { primaryJson: null, primaryMd: null };
+}
+
+function discoverResultPaths(modelPath: string): Array<{ jsonPath: string; mdPath: string }> {
+  if (fs.existsSync(modelPath) && fs.statSync(modelPath).isFile() && modelPath.endsWith(".pt")) {
+    const paths = expectedResultPaths(modelPath);
+    if (paths.primaryJson && fs.existsSync(paths.primaryJson)) {
+      return [{ jsonPath: paths.primaryJson, mdPath: paths.primaryMd ?? paths.primaryJson.replace(/\.json$/, ".md") }];
+    }
+    return [];
+  }
+  const results: Array<{ jsonPath: string; mdPath: string }> = [];
+  for (const filename of safeReadDir(modelPath)) {
+    if (!filename.endsWith(".pt")) {
+      continue;
+    }
+    const modelFile = path.join(modelPath, filename);
+    const jsonPath = modelFile.replace(/\.pt$/, ".eval.json");
+    if (fs.existsSync(jsonPath)) {
+      results.push({ jsonPath, mdPath: modelFile.replace(/\.pt$/, ".eval.md") });
+    }
+  }
+  results.sort((left, right) => left.jsonPath.localeCompare(right.jsonPath));
+  return results;
+}
+
+function summarizeEvalJson(jsonPath: string): EvalSummary | null {
+  const parsed = readJsonFile(jsonPath);
+  if (!isRecord(parsed)) {
+    return null;
+  }
+  const progressValues = Array.isArray(parsed.progress_values) ? parsed.progress_values : [];
+  const maxProgress = typeof parsed.max_progress === "number" ? parsed.max_progress : null;
+  const successCount = maxProgress === null ? 0 : progressValues.filter(value => typeof value === "number" && value >= maxProgress).length;
+  const metrics = isRecord(parsed.metrics) ? parsed.metrics : {};
+  const episodes = typeof parsed.episodes === "number" ? parsed.episodes : undefined;
+  return {
+    episodes,
+    scenario: typeof parsed.scenario === "string" ? parsed.scenario : undefined,
+    successRate: typeof metrics["success-rate"] === "number" ? metrics["success-rate"] : null,
+    maxProgressReached: successCount,
+    maxProgressPercent: episodes && episodes > 0 ? successCount / episodes : undefined,
+  };
+}
+
+function renderSummary(summary: Record<string, unknown>): string {
+  return [
+    `- Episodes: ${summary.episodes ?? "unknown"}`,
+    `- Scenario: ${summary.scenario ?? "unknown"}`,
+    `- Success rate: ${typeof summary.successRate === "number" ? summary.successRate : "n/a"}`,
+    `- Max-progress successes: ${summary.maxProgressReached ?? "unknown"}`,
+    `- Max-progress percent: ${typeof summary.maxProgressPercent === "number" ? (summary.maxProgressPercent * 100).toFixed(1) : "n/a"}%`,
+  ].join("\n");
+}
+
+function normalizeStartParams(value: unknown): EvaluationStartParams {
+  return {
+    eval_id: readStringField(value, "eval_id"),
+    model_path: requireStringField(value, "model_path"),
+    scenario: requireStringField(value, "scenario"),
+    episodes: readNumberField(value, "episodes") ?? 50,
+    reprocess: readBooleanField(value, "reprocess") ?? false,
+    render: readBooleanField(value, "render") ?? false,
+    limit: readNumberField(value, "limit") ?? -1,
+    frame_stack: readNumberField(value, "frame_stack") ?? 3,
+    steps: readNumberArrayField(value, "steps"),
+    extra_args: readStringArrayField(value, "extra_args") ?? [],
+  };
+}
+
+function normalizeCompareParams(value: unknown): EvaluationCompareParams {
+  return {
+    eval_id: readStringField(value, "eval_id"),
+    baseline_eval_json: requireStringField(value, "baseline_eval_json"),
+    candidate_eval_json: requireStringField(value, "candidate_eval_json"),
+  };
+}
+
+function makeProcessOutput(evalDir: string, pid: number): ProcessOutput {
+  fs.mkdirSync(evalDir, { recursive: true });
+  const suffix = pid > 0 ? String(pid) : "unknown";
+  return {
+    stdoutPath: path.join(evalDir, `evaluate-${suffix}.stdout.log`),
+    stderrPath: path.join(evalDir, `evaluate-${suffix}.stderr.log`),
+    stdoutTail: [],
+    stderrTail: [],
+  };
+}
+
+function appendProcessOutput(kind: "stdout" | "stderr", text: string): void {
+  if (!state) {
+    return;
+  }
+  const output = state.processOutput;
+  const targetPath = kind === "stdout" ? output.stdoutPath : output.stderrPath;
+  fs.appendFileSync(targetPath, text, "utf8");
+  const tail = kind === "stdout" ? output.stdoutTail : output.stderrTail;
+  tail.push(text);
+  while (tail.join("").length > 8_000 && tail.length > 1) {
+    tail.shift();
+  }
+}
+
+function latestStatusPath(): string | null {
+  const root = path.join("training", "evaluations");
+  let latest: { mtime: number; statusPath: string } | null = null;
+  for (const evalName of safeReadDir(root)) {
+    const statusPath = path.join(root, evalName, "status.json");
+    if (!fs.existsSync(statusPath)) {
+      continue;
+    }
+    const mtime = fs.statSync(statusPath).mtimeMs;
+    if (!latest || mtime > latest.mtime) {
+      latest = { mtime, statusPath };
+    }
+  }
+  return latest?.statusPath ?? null;
+}
+
+function waitForExit(child: ChildProcess): Promise<"exit"> {
+  const { promise, resolve } = Promise.withResolvers<"exit">();
+  child.once("exit", () => resolve("exit"));
+  return promise;
+}
+
+function delay(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+function toolResult(text: string, details: Record<string, unknown>, isError: boolean) {
+  return {
+    content: [{ type: "text", text }],
+    details,
+    isError,
+  };
+}
+
+function isTriforceRoot(cwd: string): boolean {
+  return fs.existsSync(path.join(cwd, "train.py")) && fs.existsSync(path.join(cwd, "triforce", "triforce.yaml"));
+}
+
+function sanitizeExperimentId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+function timestampSlug(): string {
+  const now = new Date();
+  const pad = (part: number) => String(part).padStart(2, "0");
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readTextIfExists(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function requireStringField(value: unknown, key: string): string {
+  const candidate = readStringField(value, key);
+  if (!candidate) {
+    throw new Error(`${key} is required.`);
+  }
+  return candidate;
+}
+
+function readBooleanField(value: unknown, key: string): boolean | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return typeof candidate === "boolean" ? candidate : undefined;
+}
+
+function readNumberField(value: unknown, key: string): number | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
+}
+
+function readStringArrayField(value: unknown, key: string): string[] | undefined {
+  if (!isRecord(value) || !Array.isArray(value[key])) {
+    return undefined;
+  }
+  const values = value[key];
+  return values.every(item => typeof item === "string") ? values : undefined;
+}
+
+function readNumberArrayField(value: unknown, key: string): number[] | undefined {
+  if (!isRecord(value) || !Array.isArray(value[key])) {
+    return undefined;
+  }
+  const values = value[key];
+  return values.every(item => typeof item === "number" && Number.isInteger(item)) ? values : undefined;
+}
+
+function safeReadDir(dirPath: string): string[] {
+  try {
+    return fs.readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function lastNonEmptyLine(text: string): string | null {
+  const lines = text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  return lines.length > 0 ? lines[lines.length - 1] : null;
+}
+
+function formatDuration(seconds: number): string {
+  const rounded = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(rounded / 60);
+  const secs = rounded % 60;
+  if (minutes < 60) {
+    return `${minutes}m${String(secs).padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h${String(minutes % 60).padStart(2, "0")}m`;
+}

--- a/.omp/extensions/triforce-experiment/index.ts
+++ b/.omp/extensions/triforce-experiment/index.ts
@@ -551,7 +551,7 @@ function updateWidget(): void {
     `Latest: success=${formatUnknown(metrics["success-rate"])} reward=${formatUnknown(latestReward)} entropy=${formatUnknown(stats["losses/entropy"])}`,
     `KL=${formatUnknown(stats["losses/approx_kl"])} clip=${formatUnknown(stats["losses/clipfrac"])} EV=${formatUnknown(stats["losses/explained_variance"])}`,
     `Checkpoint: ${status.latest_checkpoint_path ? path.basename(status.latest_checkpoint_path) : "none"}`,
-    `Last wake: ${status.last_milestone_reason ?? "none"} @ ${status.last_milestone_step ?? "n/a"}`,
+    `Last wake: ${status.last_milestone_reason ?? "none"} @ model-step ${status.last_milestone_step ?? "n/a"}`,
   ];
   void uiHooks?.setWidget(lines);
 }

--- a/.omp/extensions/triforce-experiment/index.ts
+++ b/.omp/extensions/triforce-experiment/index.ts
@@ -542,12 +542,13 @@ function updateWidget(): void {
   const metrics = status.latest_metrics ?? {};
   const legEtaSeconds = calculateLegEta(current, overall);
   const stats = status.latest_stats ?? {};
+  const latestReward = metrics["reward-average"] ?? metrics["rewards"];
   const lines = [
     `Triforce: ${status.state ?? "unknown"} ${status.scenario ?? "unknown"} pid=${status.pid ?? state.childPid ?? "n/a"}`,
     `Run: ${state.experimentId}`,
     `Leg: ${current.name ?? "none"} ${formatInt(current.steps)}/${formatInt(current.total_steps)} ${formatPct(current.pct)} ETA=${formatEta(legEtaSeconds)}`,
     `Total: ${formatInt(overall.steps)}/${formatInt(overall.total_steps)} ${formatPct(overall.pct)} SPS=${formatNumber(overall.sps)} ETA=${formatEta(overall.eta_seconds)}`,
-    `Latest: success=${formatUnknown(metrics["success-rate"])} reward=${formatUnknown(metrics["reward-average"])} entropy=${formatUnknown(stats["losses/entropy"])}`,
+    `Latest: success=${formatUnknown(metrics["success-rate"])} reward=${formatUnknown(latestReward)} entropy=${formatUnknown(stats["losses/entropy"])}`,
     `KL=${formatUnknown(stats["losses/approx_kl"])} clip=${formatUnknown(stats["losses/clipfrac"])} EV=${formatUnknown(stats["losses/explained_variance"])}`,
     `Checkpoint: ${status.latest_checkpoint_path ? path.basename(status.latest_checkpoint_path) : "none"}`,
     `Last wake: ${status.last_milestone_reason ?? "none"} @ ${status.last_milestone_step ?? "n/a"}`,

--- a/diagnose.py
+++ b/diagnose.py
@@ -22,6 +22,7 @@ Usage:
 import argparse
 import glob as globmod
 import os
+import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -1045,12 +1046,134 @@ def _generate_invariant_report(violations, model_name, scenario_name, model_path
     return "\n".join(lines)
 
 
+DEMO_ACTION_TYPE_INDEX = {ActionKind.MOVE: 0}
+DEMO_DIRECTION_INDEX = {Direction.N: 0, Direction.S: 1, Direction.W: 2, Direction.E: 3}
+
+
+def parse_demo_trace(path: str) -> list[tuple[ActionKind, Direction]]:
+    """Parse a wallmaster movement trace from normalized or reverse trace format."""
+    with open(path, 'r', encoding='utf-8') as file:
+        lines = file.readlines()
+
+    normalized = []
+    in_normalized = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Normalized forward trace":
+            in_normalized = True
+            continue
+        if stripped == "## Original reverse trace":
+            break
+        if in_normalized and stripped and not stripped.startswith('#'):
+            parts = stripped.split()
+            if len(parts) == 2:
+                normalized.append((ActionKind[parts[0]], Direction[parts[1]]))
+
+    if normalized:
+        actions = normalized
+    else:
+        reverse_entries = []
+        pattern = re.compile(r"^#(\d+)\s+(\S+)(?:\s+(\S+))?")
+        for line in lines:
+            match = pattern.match(line.strip())
+            if not match:
+                continue
+            step = int(match.group(1))
+            action_name = match.group(2)
+            direction_name = match.group(3)
+            if action_name == "None":
+                continue
+            reverse_entries.append((step, ActionKind[action_name], Direction[direction_name]))
+        actions = [(action, direction) for _, action, direction in sorted(reverse_entries)]
+
+    if not actions:
+        raise ValueError("Demo trace did not contain any actions")
+    if any(action != ActionKind.MOVE for action, _ in actions):
+        raise ValueError("Wallmaster demo traces must contain only MOVE actions")
+    return actions
+
+
+def demo_action_to_indices(action, direction):
+    """Convert a demo action to all-items MultiDiscrete indices."""
+    return DEMO_ACTION_TYPE_INDEX[action], DEMO_DIRECTION_INDEX[direction]
+
+
+def is_demo_action_allowed(action_mask, action, direction):
+    """Return whether a demo action is allowed by the joint action mask."""
+    action_type, direction_index = demo_action_to_indices(action, direction)
+    return bool(action_mask[action_type * 4 + direction_index])
+
+
+def _format_location(location):
+    return f"{location.level}:0x{location.value:02x}{'c' if location.in_cave else ''}"
+
+
+def run_demo_trace_report(trace_path, scenario_name, prefix_min, prefix_max, output_path=None):
+    """Replay an expert movement trace across optional east-prefix lengths."""
+    actions = parse_demo_trace(trace_path)
+    scenario_def = TrainingScenarioDefinition.get(scenario_name)
+    action_space_def = ActionSpaceDefinition.get("all-items")
+    env = make_zelda_env(scenario_def, action_space_def.actions,
+                         multihead=True, translation=False, frame_stack=4)
+    env = DiagnosticWrapper(env)
+    lines = [
+        "# Demo Trace Report",
+        f"trace: {trace_path}",
+        f"scenario: {scenario_name}",
+        "",
+        "| prefix_east | success | final_location | ending | total_reward | terminal_success | issue |",
+        "|---:|---|---|---|---:|---|---|",
+    ]
+    best_prefix = None
+    try:
+        for prefix in range(prefix_min, prefix_max + 1):
+            sequence = [(ActionKind.MOVE, Direction.E)] * prefix + actions
+            _obs, info = env.reset()
+            total_reward = 0.0
+            issue = ""
+            ending = ""
+            terminal_success = False
+            final_location = env.last_reset_state.full_location
+            for step, (action, direction) in enumerate(sequence, start=1):
+                action_mask = info.get('action_mask')
+                if action_mask is None or not is_demo_action_allowed(action_mask, action, direction):
+                    issue = f"invalid_action_at_step_{step}:{action.name}_{direction.name}"
+                    break
+                _obs, reward, terminated, truncated, info = env.step((action, direction))
+                total_reward += reward
+                rewards = env.last_rewards
+                state = env.last_state_change.state
+                final_location = state.full_location
+                terminal_success = terminal_success or rewards is not None and 'reward-terminal-success' in rewards
+                if terminated or truncated:
+                    ending = rewards.ending if rewards else "unknown"
+                    break
+            success = final_location.level == 1 and final_location.value == 0x35 and ending.startswith("success-")
+            if success and best_prefix is None:
+                best_prefix = prefix
+            lines.append(f"| {prefix} | {success} | {_format_location(final_location)} | {ending or 'none'} | "
+                         f"{total_reward:.3f} | {terminal_success} | {issue or 'none'} |")
+    finally:
+        env.close()
+
+    lines.append("")
+    lines.append(f"best_prefix_east: {best_prefix if best_prefix is not None else 'none'}")
+    report = "\n".join(lines)
+    if output_path:
+        with open(output_path, 'w', encoding='utf-8') as file:
+            file.write(report)
+        print(f"Demo report written to: {output_path}")
+    else:
+        print(report)
+    if best_prefix is None:
+        sys.exit(2)
+
 def parse_args():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Diagnostic tool for trained triforce models")
-    parser.add_argument("--model", required=True, help="Model name from triforce.yaml")
-    parser.add_argument("--scenario", required=True, help="Scenario name from triforce.yaml")
-    parser.add_argument("--model-path", required=True,
+    parser.add_argument("--model", required=False, help="Model name from triforce.yaml")
+    parser.add_argument("--scenario", required=False, help="Scenario name from triforce.yaml")
+    parser.add_argument("--model-path", required=False,
                         help="Path to .pt model file (supports glob patterns)")
     parser.add_argument("--episodes", type=int, default=20, help="Number of episodes to run")
     parser.add_argument("--output", "-o", default=None, help="Output file path (default: stdout)")
@@ -1062,6 +1185,15 @@ def parse_args():
     parser.add_argument("--invariants", action="store_true",
                         help="Run movement/reward invariant checker: detect zero-movement, "
                              "missing wavefronts, empty masks, and zero-PBRS violations")
+    parser.add_argument("--demo-report", action="store_true",
+                        help="Replay a movement demo trace without loading a model")
+    parser.add_argument("--demo-trace", default=None, help="Path to demo movement trace")
+    parser.add_argument("--demo-scenario", default="dungeon1-wallmaster-north-exit",
+                        help="Scenario to use for --demo-report")
+    parser.add_argument("--demo-prefix-east-min", type=int, default=0,
+                        help="Minimum number of MOVE E prefix actions for --demo-report")
+    parser.add_argument("--demo-prefix-east-max", type=int, default=3,
+                        help="Maximum number of MOVE E prefix actions for --demo-report")
     return parser.parse_args()
 
 
@@ -1094,6 +1226,19 @@ def resolve_model_path(pattern):
 def main():
     """Entry point."""
     args = parse_args()
+
+    if args.demo_report:
+        if args.demo_trace is None:
+            print("Error: --demo-report requires --demo-trace")
+            sys.exit(1)
+        run_demo_trace_report(args.demo_trace, args.demo_scenario,
+                              args.demo_prefix_east_min, args.demo_prefix_east_max, args.output)
+        return
+
+    if args.model is None or args.scenario is None or args.model_path is None:
+        print("Error: --model, --scenario, and --model-path are required unless --demo-report is set")
+        sys.exit(1)
+
     model_path = resolve_model_path(args.model_path)
 
     if args.infinite_pbrs:

--- a/diagnose.py
+++ b/diagnose.py
@@ -22,7 +22,6 @@ Usage:
 import argparse
 import glob as globmod
 import os
-import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -33,6 +32,7 @@ import gymnasium as gym
 from triforce import ActionSpaceDefinition, ModelKindDefinition, Network, TrainingScenarioDefinition, make_zelda_env
 from triforce.action_space import ActionKind
 from triforce.critics import PBRS_SCALE
+from triforce.demo import demo_action_to_indices, is_demo_action_allowed, parse_demo_trace
 from triforce.observation_wrapper import infer_obs_kind
 from triforce.room import Room
 from triforce.zelda_enums import MapLocation, Direction
@@ -1046,63 +1046,6 @@ def _generate_invariant_report(violations, model_name, scenario_name, model_path
     return "\n".join(lines)
 
 
-DEMO_ACTION_TYPE_INDEX = {ActionKind.MOVE: 0}
-DEMO_DIRECTION_INDEX = {Direction.N: 0, Direction.S: 1, Direction.W: 2, Direction.E: 3}
-
-
-def parse_demo_trace(path: str) -> list[tuple[ActionKind, Direction]]:
-    """Parse a wallmaster movement trace from normalized or reverse trace format."""
-    with open(path, 'r', encoding='utf-8') as file:
-        lines = file.readlines()
-
-    normalized = []
-    in_normalized = False
-    for line in lines:
-        stripped = line.strip()
-        if stripped == "## Normalized forward trace":
-            in_normalized = True
-            continue
-        if stripped == "## Original reverse trace":
-            break
-        if in_normalized and stripped and not stripped.startswith('#'):
-            parts = stripped.split()
-            if len(parts) == 2:
-                normalized.append((ActionKind[parts[0]], Direction[parts[1]]))
-
-    if normalized:
-        actions = normalized
-    else:
-        reverse_entries = []
-        pattern = re.compile(r"^#(\d+)\s+(\S+)(?:\s+(\S+))?")
-        for line in lines:
-            match = pattern.match(line.strip())
-            if not match:
-                continue
-            step = int(match.group(1))
-            action_name = match.group(2)
-            direction_name = match.group(3)
-            if action_name == "None":
-                continue
-            reverse_entries.append((step, ActionKind[action_name], Direction[direction_name]))
-        actions = [(action, direction) for _, action, direction in sorted(reverse_entries)]
-
-    if not actions:
-        raise ValueError("Demo trace did not contain any actions")
-    if any(action != ActionKind.MOVE for action, _ in actions):
-        raise ValueError("Wallmaster demo traces must contain only MOVE actions")
-    return actions
-
-
-def demo_action_to_indices(action, direction):
-    """Convert a demo action to all-items MultiDiscrete indices."""
-    return DEMO_ACTION_TYPE_INDEX[action], DEMO_DIRECTION_INDEX[direction]
-
-
-def is_demo_action_allowed(action_mask, action, direction):
-    """Return whether a demo action is allowed by the joint action mask."""
-    action_type, direction_index = demo_action_to_indices(action, direction)
-    return bool(action_mask[action_type * 4 + direction_index])
-
 
 def _format_location(location):
     return f"{location.level}:0x{location.value:02x}{'c' if location.in_cave else ''}"
@@ -1135,6 +1078,7 @@ def run_demo_trace_report(trace_path, scenario_name, prefix_min, prefix_max, out
             terminal_success = False
             final_location = env.last_reset_state.full_location
             for step, (action, direction) in enumerate(sequence, start=1):
+                _ = demo_action_to_indices(action, direction)
                 action_mask = info.get('action_mask')
                 if action_mask is None or not is_demo_action_allowed(action_mask, action, direction):
                     issue = f"invalid_action_at_step_{step}:{action.name}_{direction.name}"

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -1,0 +1,5 @@
+# Triforce experiments
+
+Tracked experiment records for Triforce training. Keep compact run summaries, metrics, decisions, and next-experiment recommendations here. Do not commit model checkpoints, TensorBoard event files, full status JSON histories, emulator savestates, or raw training logs.
+
+Before starting a new experiment, read `experiment-memory.md` and the most relevant prior summary. After finishing a run, append a compact record to `experiment-memory.md` and add a concise summary file here.

--- a/docs/experiments/baseline-summary.md
+++ b/docs/experiments/baseline-summary.md
@@ -1,0 +1,61 @@
+# Baseline all-items-circuit summary
+
+## Run
+
+- Experiment: `baseline`
+- Local experiment dir: `training/experiments/baseline`
+- Local run dir: `training/experiments/baseline/runs/all-items-circuit/0`
+- Scenario/circuit: `all-items-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Final checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.pt`
+- Final state: `complete`
+
+## Final evaluation
+
+Command:
+
+```bash
+source .venv/bin/activate
+python evaluate.py training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.pt full-game-all-items-finite --episodes 100 --reprocess
+```
+
+Result:
+
+- Success rate: `0/100`
+- Median progress: `13/17`
+- P25/P50/P75/P90: `11 / 13 / 13 / 13`
+- Endings: `failure-terminated-death=0.94`, `failure-no-progress=0.03`, `failure-stuck=0.03`
+- Average reward: `43.1278`
+- Room progress: `12.08`
+
+## Normal baseline behavior
+
+The baseline learned overworld routing and sword/item setup, then reached mid-to-late Dungeon 1 without solving it. The recurring bottleneck is:
+
+`1_43 -> 1_44 -> 1_45 -> 1_35 -> 1_36`
+
+Progress mapping:
+
+- `13`: room `1_43`
+- `14`: room `1_44` Red Goriya room
+- `15`: room `1_45` Wallmaster room
+- `16`: room `1_35` Aquamentus boss
+- `17`: room `1_36` Triforce room
+
+The model usually reaches `1_43`, rarely reaches `1_44`, and never reaches wallmaster/boss/triforce rooms in final eval.
+
+## Lessons
+
+- Hard failure endings needed reward accounting fixes: death/stuck/no-progress/wallmastered could be net-positive under the original reward shape.
+- Wallmastered needed `penalty-wall-master` on the teleport step, not only when the current room still has wallmasters.
+- The wallmaster static danger tile shaping conflicted with objective exit tiles in room `1_45`.
+- Broad polish was too diffuse to repair the late-Dungeon-1 bottleneck.
+
+## Baseline to beat
+
+- Any nonzero `full-game-all-items-finite` success.
+- Fewer than 65/100 episodes stopping at progress `13`.
+- Any episodes reaching progress `15+`.
+- Death rate below `94%`.
+- Wallmastered episodes are negative-return and include `penalty-wall-master`.

--- a/docs/experiments/demos/wallmaster-north-exit.txt
+++ b/docs/experiments/demos/wallmaster-north-exit.txt
@@ -1,0 +1,102 @@
+# Wallmaster north-exit expert trace
+
+Start scenario: `dungeon1-wallmaster-north-exit`
+Start state: `1_45w`
+Goal: reach boss room `1_35` by taking the north exit.
+
+The original trace from `/tmp/movements.txt` was recorded in reverse order. Use the normalized forward trace below for replay, diagnostics, and behavior cloning.
+
+## Normalized forward trace
+
+MOVE E
+MOVE E
+MOVE S
+MOVE S
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE E
+MOVE S
+MOVE S
+MOVE S
+MOVE E
+MOVE E
+MOVE W
+MOVE W
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE W
+MOVE W
+MOVE W
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+MOVE N
+
+## Original reverse trace
+
+#45	MOVE N		+1.000
+#44	MOVE N		+0.050
+#43	MOVE N		+0.050
+#42	MOVE N		+0.050
+#41	MOVE N		+0.340
+#40	MOVE W		+0.000
+#39	MOVE W		+0.000
+#38	MOVE W		+0.000
+#37	MOVE N		+0.000
+#36	MOVE N		+0.050
+#35	MOVE N		+0.050
+#34	MOVE N		+0.050
+#33	MOVE N		+0.050
+#32	MOVE N		+0.050
+#31	MOVE N		+0.050
+#30	MOVE N		+0.050
+#29	MOVE N		+0.050
+#28	MOVE N		+0.050
+#27	MOVE N		+0.050
+#26	MOVE W		+0.050
+#25	MOVE W		+0.050
+#24	MOVE E		-0.050
+#23	MOVE E		+1.000
+#22	MOVE S		+0.050
+#21	MOVE S		+0.050
+#20	MOVE S		+0.050
+#19	MOVE E		+0.050
+#18	MOVE E		+0.050
+#17	MOVE E		+0.050
+#16	MOVE E		+0.050
+#15	MOVE E		+0.050
+#14	MOVE E		+0.050
+#13	MOVE E		+0.050
+#12	MOVE E		+0.050
+#11	MOVE E		+0.050
+#10	MOVE E		+0.050
+#9	MOVE E		+0.050
+#8	MOVE E		+0.050
+#7	MOVE E		+0.050
+#6	MOVE E		+0.090
+#5	MOVE S		+0.000
+#4	MOVE S		+0.000
+#3	MOVE E		+0.000
+#2	MOVE E		+0.000
+#1	None		+0.000

--- a/docs/experiments/dungeon1-completion-plan.md
+++ b/docs/experiments/dungeon1-completion-plan.md
@@ -1,0 +1,1035 @@
+# Dungeon 1 Completion — Master Plan (Living Document)
+
+**Created:** 2026-08-03 by the planning agent. **Repo:** `/home/leculver/work/git/triforce`.
+**This document is the blueprint.** Executor agents pick ONE task, attempt it fully, record the outcome here, and stop.
+
+---
+
+## 0. READ THIS FIRST (always read this section; everything below is read on demand)
+
+### 0.1 Mission and definition of done
+
+A custom-PPO agent plays NES Zelda from game start. Overworld: solved. Dungeon 1 progress stops at the
+Aquamentus boss room. The route that matters (milestone numbers in parens, full-game numbering):
+
+```
+1_43 (13) → 1_44 Red Goriya (14) → 1_45 Wallmaster (15) → 1_35 Aquamentus (16) → 1_36 Triforce (17)
+                                       └ SOLVED 1.0 ┘        └───────── THE GAP ─────────┘
+```
+
+**Definition of done, in order (each gate is a named eval, 100 episodes, via the OMP evaluation plugin):**
+
+- **Gate A (boss):** `dungeon1-aquamentus-east` success-rate ≥ 0.5, sustained (not a single milestone reading).
+- **Gate B (chain):** `dungeon1-late-chain` success-rate > 0 and `progress/max` = 17 (both firsts ever).
+- **Gate C (dungeon):** `dungeon1-all-items` success-rate > 0.
+- **Gate D (game):** `full-game-all-items-finite` success > 0/100, fewer than 65/100 episodes at
+  milestone 13, death rate < 0.94. Baseline to beat:
+  `training/baseline/runs/all-items-circuit/0/…all-items-polish_10719232.eval.json` (0/100, median 13/17).
+
+### 0.2 The root cause, already verified in source (do not re-derive)
+
+The Aquamentus failure (100/100 episodes `failure-left-boss-room`, zero attacks) is a **reward
+specification bug**, verified by direct code reading during planning (evidence in §1):
+
+1. `failure-left-boss-room` is missing from both terminal-penalty sets in `triforce/scenario_wrapper.py:22-27`.
+   Walking out costs ≈ −0.25; dying costs −20; timing out costs −20. Leaving is ~80× cheaper than any
+   other way of not winning. The policy learned the reward function correctly.
+2. In room `1_35`, the objective is `ObjectiveKind.FIGHT` with `next_rooms=[]`
+   (`triforce/objectives.py:231-264` + `:170-177`), so no exit is ever "correct", hints mask exits
+   inconsistently, and no gradient toward `1_36` exists until the boss is dead AND the heart container collected.
+3. Combat economics are thin: melee hit +0.25, Aquamentus has 6 HP, one fireball hit costs −0.5 health
+   penalty −0.25 beam loss and halves the step's positive rewards. No per-damage progress signal; boss
+   hits don't reset the stalling clock.
+
+**Corroboration from the system that actually beat Dungeon 1** (§1.6): the `origin/original-design`
+branch (SB3, one model per area) achieved **68.3% boss kills, zero flee-outs**, using exactly the
+inverse choices: leaving the boss room was terminal AND max-penalized, movement shaping paid ±0.25/step
+toward the boss, and hit:damage economics were 3:1 (+0.75 hit vs −0.25 damage taken).
+
+Fixing this is Phase R. Verifying it empirically first (cheap, no training) is Phase V. Tooling that
+Phase V needs is Phase P. **Do not start a long training run before P1/P2 and the V-phase probes exist.**
+
+### 0.3 How to use this document (executor protocol)
+
+1. Pick the **first OPEN task whose dependencies are met**, top-down in the Task Index (§0.6), unless
+   the user directs otherwise. Blocking tasks (`⛔`) come first.
+2. Read the task's section (line numbers in the index), plus §1 (background) and §10 (reference card)
+   if you haven't. Read `docs/experiments/experiment-memory.md` before any *training* task — it is the
+   experiment ledger and its protocol is mandatory for runs (§10.4).
+3. Do the task **completely**: code, tests, run, numbers.
+4. **Record the outcome in this file:**
+   - In the Task Index, change the status box: `[ ]` open → `[x]` done, `[~]` attempted/inconclusive,
+     `[!]` falsified/abandoned (say why in the task section).
+   - Replace the task's `**Outcome:** _not attempted_` line with a dated outcome block: what you ran,
+     artifact paths, key numbers, verdict, and what the next agent should know.
+   - If your result changes strategy (e.g. falsifies a phase), append a dated entry to §9 Decision Log.
+   - Line numbers drift as the file grows. After editing, refresh the index numbers you invalidated:
+     `grep -n '^#\|^### ' docs/experiments/dungeon1-completion-plan.md`
+5. **Never commit or push to `main`.** Branch from `origin/main`, PR only. Run
+   `pylint triforce/ triforce_debugger/ debug.py evaluate.py train.py record.py` and `pytest tests/ -v`
+   before submitting any PR that touches `triforce/`.
+
+### 0.4 Rules of engagement (non-negotiable, distilled from history)
+
+- **Single-milestone readings are not evidence.** Boss-room metrics regressed 0.58→0.96 within one run
+  (exp5). Any claim of improvement needs ≥3 consecutive milestone readings or a 100-episode eval.
+- **Exit criteria must gate on the thing being taught.** Exp5's boss leg "completed" via the wallmaster
+  metric while `failure-left-boss-room` was 0.91. (Fix = P5.)
+- **Weight-only curricula on a broken reward spec do nothing.** Exp5 proved 60%→80% Aquamentus weighting
+  changes nothing when leaving is optimal. Fix the MDP first (Phase R), then train.
+- **Demo-BC + demo-regularized PPO is the proven retention recipe** (wallmaster 0.0 → 1.0, held two
+  experiments). Its wiring currently supports exactly one MOVE-only trace; Phase B extends it.
+- **Budgets:** micro-scenario eval 3–7 min; BC minutes; a training leg 2+ hours; exp1–5 took a week.
+  Prefer probes (minutes) over runs (hours) whenever a probe can kill an idea.
+
+### 0.5 Key assets (details and paths in §10)
+
+- Checkpoints (all on disk, gitignored): exp5 final `training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.pt` (the model with the boss failure); exp4 final (best late-chain, progress/max=16); clean pre-endgame base `…learn-items_2199552.pt`.
+- Demo: `docs/experiments/demos/wallmaster-north-exit.txt` (44 MOVE actions; format §10.5).
+- The user will hand-play and supply exact button traces on request — that is how the wallmaster demo
+  was made. A **scripted** boss-kill probe (V2) may make that unnecessary.
+- Savestate catalog: `docs/savestates.yml`. Named RAM overrides available in scenario YAML via
+  `per_reset`/`per_frame`, including per-slot enemy HP `obj_health_1`…`obj_health_c` (§10.6).
+- Reference implementation that solved D1: branch `origin/original-design` (read via
+  `git show origin/original-design:<path>`, never check it out). Digest in §1.6.
+
+### 0.6 TASK INDEX
+
+Status: `[ ]` open · `[x]` done · `[~]` attempted, inconclusive · `[!]` falsified/abandoned · `⛔` blocking.
+Line numbers refresh via: `grep -n '^### ' docs/experiments/dungeon1-completion-plan.md`
+
+| # | Task | Phase | Line |
+|---|------|-------|-----:|
+| [ ] ⛔ | P1 Combat/boss trace mode for diagnose.py | P Tooling | 314 |
+| [ ] ⛔ | P2 Fix evaluation hang + silent no-artifact evals | P Tooling | 335 |
+| [ ] | P3 Fix restart crash on completed circuits (train.py:1290) | P Tooling | 358 |
+| [ ] | P4 --compare must compare success-rate | P Tooling | 368 |
+| [ ] ⛔ | P5 Weighted-circuit exit criteria gate on primary scenario | P Tooling | 378 |
+| [ ] | P6 Verify worker metric aggregation under --parallel | P Tooling | 388 |
+| [ ] | P0 Land or discard the experiment5 branch leftovers | P Tooling | 399 |
+| [ ] ⛔ | V1 Empirical root-cause confirmation trace | V Probes | 412 |
+| [ ] ⛔ | V2 Scripted boss-kill probe (beams / bombs / melee) | V Probes | 424 |
+| [ ] | V3 DefeatedBoss false-positive check | V Probes | 447 |
+| [ ] | V4 Trace the hint-mask escape route | V Probes | 459 |
+| [ ] | V5 Fireball dodgeability / beam retention measurement | V Probes | 471 |
+| [ ] | V6 Aquamentus RAM fact sheet | V Probes | 481 |
+| [ ] ⛔ | R1 Terminal parity: leaving the boss room = −20 | R Reward spec | 496 |
+| [ ] ⛔ | R2 Boss-damage rewards, stall reset on hits, boss PBRS scale | R Reward spec | 513 |
+| [ ] ⛔ | R3 FIGHT rooms get route next_rooms (exit semantics) | R Reward spec | 540 |
+| [ ] | R4 Recompute and rebalance the boss-room payoff table | R Reward spec | 562 |
+| [ ] | R5 Split micro-scenarios: kill vs victory-lap | R Reward spec | 576 |
+| [ ] | R6 EXPERIMENT: retrain Aquamentus on the fixed spec | R Reward spec | 590 |
+| [ ] | B1 Demo format: non-MOVE actions | B Demos | 617 |
+| [ ] | B2 Multi-demo support in train.py/ml_ppo.py | B Demos | 631 |
+| [ ] | B3 Acquire a boss-kill demonstration | B Demos | 644 |
+| [ ] | B4 EXPERIMENT: BC + demo-regularized PPO on the boss | B Demos | 656 |
+| [ ] | B5 Value-head warmup after BC | B Demos | 673 |
+| [ ] | C1 Boss-HP reverse curriculum (1hp→2hp→4hp→6hp) | C Curriculum | 687 |
+| [ ] | C2 Mid-fight savestate curriculum | C Curriculum | 705 |
+| [ ] | C3 Invulnerability training wheels (per_frame health) | C Curriculum | 714 |
+| [ ] | C4 Start-state diversity for the boss room | C Curriculum | 730 |
+| [ ] | C5 Victory-lap scenario: post-kill → triforce | C Curriculum | 742 |
+| [ ] | C6 Boss-room action masking of useless items | C Curriculum | 756 |
+| [ ] | S1 Per-head entropy floor / adaptive ent_coef | S Structural | 772 |
+| [ ] | S2 Scope MOVE-only demo-BC loss to the direction head | S Structural | 786 |
+| [ ] | S3 EPOCHS 10→4 and expose LEARNING_RATE | S Structural | 798 |
+| [ ] | S4 Optimizer persistence across circuit legs | S Structural | 808 |
+| [ ] | S5 KL-anchor regularization (fallback to demo-BC) | S Structural | 816 |
+| [ ] | S6 Self-imitation on harvested successes | S Structural | 828 |
+| [ ] | S7 Per-leg ent_coef in circuit YAML | S Structural | 841 |
+| [ ] | S8 Entity distance/vector features (observation) | S Structural | 847 |
+| [ ] | I1 EXPERIMENT: late-chain integration | I Integration | 863 |
+| [ ] | I2 EXPERIMENT: full dungeon 1 | I Integration | 882 |
+| [ ] | I3 EXPERIMENT: full game gate | I Integration | 890 |
+| [ ] | X1 Auto-demo harvesting from scripted policies | X Backlog | 901 |
+| [ ] | X2 Auxiliary boss-HP prediction loss | X Backlog | 906 |
+| [ ] | X3 Sustained-threshold exit criteria | X Backlog | 911 |
+| [ ] | X4 Multi-seed replication harness for micro-scenarios | X Backlog | 916 |
+| [ ] | X5 Beam-alignment shaping (fired-correctly / didn't-fire) | X Backlog | 921 |
+| [ ] | X6 Update stale docs (combat-engagement, nes-mechanics boss section) | X Backlog | 928 |
+| [ ] | X7 Positive-clamp audit for multi-reward kill steps | X Backlog | 934 |
+| [ ] | X8 Fireball danger shaping (danger tiles / wavefront field) | X Backlog | 940 |
+
+**Recommended experiment queue (the spine; everything else supports it):**
+1. **EXP6 (probes, no training):** P1+P2 → V1..V6. Deliverable: empirical root-cause verdict + a scripted boss-kill trace.
+2. **EXP7 (spec fix):** R1+R2+R3(+R4) → R6 training run. Falsifier: agent stops leaving but still never attacks after full budget.
+3. **EXP8 (demos):** B1+B2+B3 → B4 (with C1 as a parallel arm if R6 shows partial engagement).
+4. **EXP9 (integration):** I1 → I2 → I3.
+
+---
+
+## 1. Background: the verified diagnosis (read once; do not re-derive)
+
+Everything in §1.1–§1.5 was verified by direct source reading on 2026-08-03 (branch `experiment5`).
+File:line references are load-bearing — re-check them if the file changed since. §1.6 was read from
+`origin/original-design` via `git show` on the same date.
+
+### 1.1 Terminal accounting
+
+`triforce/scenario_wrapper.py:22-27` defines the two −20 ending sets:
+
+- `HARD_FAILURE_ENDINGS = {failure-terminated-death, failure-stuck, failure-no-progress}` (also strips step rewards)
+- `OTHER_FAILURE_ENDINGS = {failure-left-dungeon, failure-left-room, failure-left-route, failure-left-play-area, failure-left-wallmaster-room, failure-reentered-dungeon, failure-nowhere-to-go, failure-no-key, failure-wrong-exit}`
+
+`failure-left-boss-room` (emitted by `DefeatedBoss`, `triforce/end_conditions.py:200-210`) is in **neither**,
+as are `failure-no-next-room` and `failure-no-sword`. Terminal clamp widening lives in
+`triforce/rewards.py:112-121` (`StepRewards.value`): ±1 normally, +20 on success endings with
+`reward-terminal-success`, −20 on failure endings with `penalty-terminal-failure`/`penalty-wall-master`.
+
+Payoff table for `dungeon1-aquamentus-east` (conditions `[ReachedLocation(0x36), DefeatedBoss, GameOver, Timeout]`):
+
+| Outcome | Ending | Terminal value |
+|---|---|---:|
+| East into 1_36 (needs boss dead — shutter) | success-reached-location | +20 |
+| Boss dies | success-killed-boss | +20 |
+| **South into 1_45** | **failure-left-boss-room** | **≈ −0.25** |
+| Die | failure-terminated-death | −20 |
+| Stand still 50 steps | failure-stuck | −20 |
+| 2000 steps in room | failure-no-progress | −20 |
+
+The exp5 eval (`…/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.dungeon1-aquamentus-east.eval.json`):
+100/100 `failure-left-boss-room`, ~99 stalling penalties/ep, PBRS net −0.003, exactly one attack-miss
+per episode, **zero `reward-hit` / `reward-beam-hit` entries**. The agent enters, oscillates ~250 steps, leaves.
+
+### 1.2 Objectives in the boss room
+
+Room `1_35` (`triforce/game.yaml:1063-1074`): `enemies: {Aquamentus: 1}`, `treasure: heart-container`,
+exits E→0x36 (shutter until boss dead), S→0x45. `_get_dungeon_room_objective`
+(`triforce/objectives.py:231-264`): known undropped treasure + live enemies ⇒ `ObjectiveKind.FIGHT`,
+tile objectives = enemy overlap tiles, `next_rooms` **always** `[]`. `get_current_objectives`
+(`objectives.py:170-177`) skips Dijkstra routing entirely for FIGHT/TREASURE/CAVE. Consequences:
+- `critique_location_change` (`triforce/critics.py:328-349`): any room change scores `penalty-wrong-location`
+  −0.25; `reward-new-location` +1.0 can never fire toward 0x36 until kill+pickup flip the kind to MOVE.
+- `TrainingHintWrapper` (`triforce/training_hints.py:20-42`) masks `(MOVE,dir)` at edge tiles when the
+  adjacent room is not in `next_rooms` — with `next_rooms=[]` **both** E and S get masked at the edge,
+  yet 100% of episodes exit south (mechanism candidates in V4: hint threshold `tile.y >= 0x14` is checked
+  pre-action, multi-tile moves under FrameSkip can cross from y≤0x13; `_handle_empty_mask`
+  `triforce/action_space.py:400-409` unmasks all four MOVE directions if everything is masked; knockback).
+- PBRS targets are the boss's tiles; with γ=1 approach potential is one-shot and empirically cancels.
+
+### 1.3 Combat economics (current constants, `triforce/critics.py`)
+
+`reward-hit` +0.25×decay, `reward-beam-hit` +0.5×decay (+0.05 distance bonus >48px), `reward-bomb-hit`
++0.5 per hit (−0.25 per bomb placed), `penalty-attack-miss` −0.01, `penalty-lost-health` −0.25/half-heart
+(fireball = 1 heart = −0.5), `penalty-lost-beams` −0.25, positives halved on damage steps
+(`critics.py:146-147`). Stalling: −0.01/step after 150 steps ramping to −0.02 over 1850
+(`critics.py:375-383`); resets on room change, enemy **kill**, item pickup — **not on hits**.
+Aquamentus: 6 HP, wood sword/beam = 1 HP dmg, bomb = 4 HP dmg (2 bombs kill; scenario grants 4),
+3×3 tiles (`triforce/enemy.py:25-26`), fireball 1 heart. Note: `DANGER_TILE_PENALTY` from
+`docs/specs/combat-engagement.md` **no longer exists in code** (grep = 0 hits); that spec is partially
+stale. Current wallmaster tile shaping is −0.05/−0.04/+0.04 (`critics.py:33-35`).
+
+Scenario `dungeon1-aquamentus-east` (`triforce/triforce.yaml:769-798`): start `1_35s`, per_reset
+`hearts_and_containers: 34` (= 3 containers, 2 filled) + `partial_hearts: 254` ⇒ beam gate
+(filled==containers−1 AND partial≥0x80, `docs/specs/nes-mechanics.md`) **passes at spawn** — the agent
+starts with beams and loses them on the first fireball hit.
+
+### 1.4 PPO / model facts that matter here
+
+- Two-head `ImpalaMultiHeadAgent` (`triforce/models.py:1041+`): action-type head + direction head;
+  log-prob/entropy = sum; when only one action type is legal, the type head's log-prob AND entropy are
+  excluded per-sample (`models.py:1168-1180`).
+- Exp5 ended with `losses/entropy/action_type = 0.0025` — the type head is deterministic (≈always MOVE).
+  There is **no entropy floor**; tuning.json health ranges only trigger wakes, and every exp4/5 wake
+  loosened them (entropy/action_type min 0.3→0.0 three times).
+- Demo-BC: single MOVE-only trace, full batch re-forwarded every minibatch,
+  `loss += coeff * -demo_logprob.mean()` (`triforce/ml_ppo.py:621-625`). MOVE-only is enforced at
+  `triforce/demo.py:56-58`; `DEMO_ACTION_TYPE_INDEX = {MOVE: 0}` (`demo.py:14`).
+- KL: early-stop per minibatch at approx_kl>0.02; whole-round rollback (weights+optimizer) if the final
+  minibatch approx_kl > 0.08 (`ml_ppo.py:571-579,654-659`).
+- LEARNING_RATE=1e-4 hardcoded in `_setup_optimizer` (`ml_ppo.py:83-97`); EPOCHS=10; only `--ent-coef`
+  and demo flags are CLI-reachable.
+- Observation: model sees per-entity health/15, stun, direction, presence — **no positions/distances**
+  (learned from pixels via CoordConv); info vector has beams-available and fight-objective bits
+  (`triforce/observation_wrapper.py:281-366`).
+- Parallel rollouts: barrier-synchronized workers with **no timeouts** — a hard-dead worker deadlocks
+  training (`triforce/ml_ppo_worker.py`); exp5 run 3 hung exactly this way (16 defunct children).
+
+### 1.5 Experiment history in one table
+
+| Exp | Change | Result |
+|---|---|---|
+| baseline | all-items circuit, 10.7M steps | full-game 0/100, median 13/17, deaths 0.94 |
+| 1 | −20 terminal failures, focused scenarios | accounting fixed; transfer regressed (median 3/17); discard ckpt |
+| 2 | +20 terminal success, room-walk acclimation | wallmaster still 0.0 — reward sign alone insufficient |
+| 3 | behavior cloning (1000 epochs held; 400 destroyed by PPO) | wallmaster 0.24; PPO exit in 78k steps |
+| 4 | demo-BC regularizer in PPO (coeff 0.1) | **wallmaster 1.0** (kept through exp5); late-chain median 10/11, max 16 |
+| 5 | boss-weighted circuit 20/60/20→10/80/10 | FAILURE: aquamentus 0.0, left-boss-room 1.0; late-chain eval hung 124h |
+
+Structural-risk positions taken by this plan (from the planning brief's §5):
+1. **Combat camping** — the observed boss failure is *zero attacks*, not spam-camping; implement
+   boss-scoped R2 now, defer the general combat-engagement spec until diagnosis shows camping.
+2. **Entropy collapse** — treat as a constraint: S1 (floor) and S2 (demo loss scoping) if type-head
+   entropy < 0.1 persists after Phase R.
+3. **PPO erasing BC** — keep demo-reg (proven); add B5 value warmup; S5 KL-anchor only if B4 drifts.
+4. **Demo pipeline narrow** — fix now (B1/B2); prerequisite for any boss demo.
+5. **Two demos coexisting** — B2 makes the wallmaster regularizer and a boss demo coexist; never drop
+   the wallmaster trace without an eval proving retention.
+6. **PBRS urgency** — accept the current design; the only changes are stall-reset-on-hit and a
+   boss-room PBRS scale option (R2). No new global urgency mechanisms (all six prior attempts failed,
+   `2026_03_04_pbrs_movement_tuning.md`).
+
+### 1.6 Evidence from `origin/original-design` — the system that beat Dungeon 1
+
+Read 2026-08-03 via `git show origin/original-design:<path>`. SB3 PPO, one specialist model per area
+(`triforce/triforce.json` + `model_selector.py`), including a dedicated `dungeon1boss` model
+(attack-only action space, rooms 0x35/0x36, 500K iterations, trained exclusively from savestate `1_35s`
+at full health). Shipped eval `models/dungeon1boss.zip.evaluation.json`: **68.3% success-killed-boss,
+remainder deaths, ZERO `failure-left-boss-room`.** The design choices that plausibly produced that:
+
+1. **Leaving was terminal AND max-penalized.** Old `DefeatedBoss` terminated with
+   `failure-left-boss-room` the moment `location != 0x35`, and `Dungeon1Critic` added
+   `penalty-left-early` = −1.0 (their max) for exiting toward a non-objective room. One exit → episode
+   over → worst outcome. The current walk-in/walk-out-for-−0.25 loop was impossible. → validates **R1**.
+2. **The objective WAS the boss, not the door.** Room 0x35 was in `locations_to_kill_enemies`; the
+   navigation objective became `enemies[0].position` and movement shaping paid **±0.25/step**
+   (`Dungeon1BossCritic`: move_closer 0.25 = 5× their base) toward Aquamentus, via A*-path-delta shaping
+   (not potential-based; exploitable in theory, contained by a 50-step stuck truncation). → validates
+   the FIGHT-objective concept; motivates R2's boss-room PBRS scale option.
+3. **Hits were worth 3× the damage taken** in the boss room only: `injure_kill_reward` +0.75 vs
+   `health_lost_penalty` −0.25 (their base elsewhere: +0.5 vs −0.75 with all positives wiped on damage
+   steps). A deliberate per-room "aggression profile" set in `Dungeon1BossCritic.clear()`. → validates
+   **R2/R4**, gives the concrete ratio target.
+4. **Beam discipline was shaped directly:** `didnt_fire_penalty` −0.05 when an enemy was beam-aligned
+   with beams available and the agent moved instead; `fired_correctly_reward` +0.05 for firing while
+   aligned (dot > 0.8). Observation included explicit vectors: objective (→ boss during FIGHT), nearest
+   enemy, nearest projectile, nearest aligned enemy, plus beams-available bit. → motivates **X5** and
+   strengthens **S8**.
+5. **Fireball dodging had a dense gradient:** enemy+projectile tiles stamped DANGER (−0.5 to step on)
+   with a WARNING halo (−0.05), +0.05 for stepping out, and A* routed around them. → motivates **X8**.
+6. **Specialist training regime:** every episode = the fight, from `1_35s`, full health (beams up on
+   step 1), 8-action attack-only space, RNG randomized per reset. No navigation task competing for
+   capacity. → validates **C-phase** start-state design and motivates **C6** (mask useless items).
+
+Caveats before copying anything wholesale: the old system used raw path-delta shaping and per-step
+±0.25 magnitudes that the current PBRS design deliberately rejected as exploitable; it had a separate
+model per area (no retention problem, no shared policy to protect); and its 68% came with 32% deaths —
+the current health-penalty structure exists for the full-game context. Port the *structure* (terminal
+exit, boss-directed gradient, aggression ratio, alignment shaping), not the raw constants.
+
+---
+
+## 2. Phase P — Tooling prerequisites
+
+### P1. Combat/boss trace mode for diagnose.py ⛔
+**Goal:** the capability exp5's post-mortem said was missing: per-step traces of boss-room episodes.
+**Why blocking:** V1/V4/V5 need it; every later training task uses it for debugging.
+**Change (`diagnose.py`):**
+- New `--combat-trace` mode (pattern: mirror `PbrsStepRecord`/`run_pbrs_diagnostic`, `diagnose.py:407-465`).
+  New `CombatStepRecord` per step: action (kind+direction), Link tile/position/health/beams-available,
+  per-enemy (id, index, health, position, distance, is_active, stun), `state_change.hits`,
+  enemies_hit indices, full rewards dict, objective kind, `next_rooms`, and the **action mask summary**
+  (which MOVE directions are masked — read `info['invalid_actions']` / the flat mask).
+- Replace the hardcoded ending filter (`diagnose.py:460-465`, only `stuck`/`no-next-room`) with
+  `--trace-endings SUBSTR[,SUBSTR…]` (default keeps old behavior for back-compat).
+- Report per traced episode: exit attribution (step, tile, direction, mask state at exit), attack count,
+  damage dealt/taken timeline, distance-to-nearest-enemy percentiles.
+- Keep it general-purpose (any room, any enemy) per copilot-instructions; commit separately from any
+  fix it motivates.
+**Acceptance:** `python diagnose.py --model impala-multihead --scenario dungeon1-aquamentus-east
+--model-path training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.pt
+--combat-trace --trace-endings left-boss-room --episodes 10 -o /tmp/boss-trace.txt` produces per-step
+traces for ≥5 episodes with exit attribution.
+**Outcome:** _not attempted_
+
+### P2. Fix evaluation hang + silent no-artifact evals ⛔
+**Goal:** we still have NO exp5 late-chain number; the eval ran 124h before SIGKILL, episode rate
+degraded to ~11.5h/episode, and two other plugin evals "completed" without artifacts.
+**Why blocking:** Gates B/C/D are unmeasurable without it.
+**Hypotheses to test, in order:**
+1. **Livelock via Timeout reset ping-pong:** `Timeout.is_scenario_ended` (`end_conditions.py:41-57`)
+   resets `__last_progress` whenever the agent enters a room in `prev.objectives.next_rooms`. In
+   late-chain, leaving 1_35 south costs only −0.25 (no DefeatedBoss condition there) and re-entering
+   1_35 from 1_45 *is* route progress → the 1_45↔1_35 loop resets the no-progress clock forever.
+   Episode never ends.
+2. Emulator/FrameSkip wedge (FrameSkipWrapper waits for a controllable frame that never comes).
+**Change:**
+- `evaluate.py`: hard per-episode step cap (`--max-steps`, default ~20000), truncating with a distinct
+  recorded ending (`eval-step-cap`) so it is visible in endings metrics.
+- `Timeout`: only reset the no-progress clock on **first** entry into each next-room per episode, or
+  require net milestone progress — pick after confirming hypothesis 1 with P1 traces on a late-chain
+  episode.
+- `_save_results` (`evaluate.py:367-389`): silent no-op when `progress_values is None` or metrics falsy —
+  make both paths loud (warning + nonzero exit), and write the JSON atomically (tmp+rename).
+**Acceptance:** exp4-final and exp5-final both produce `dungeon1-late-chain` eval JSONs (100 eps) in
+bounded time (< 2h); an induced failure (missing MetricTracker) exits nonzero with a clear message.
+**Outcome:** _not attempted_
+
+### P3. Fix restart crash on completed circuits (train.py:1290)
+**Goal:** `--resume` from a checkpoint whose history already covers the final leg leaves `model=None`
+through `_run_sequential_circuit` (skip logic `train.py:1009-1014` `continue`s past the matched leg) and
+crashes at `model.save` (`train.py:1290`). Exp5 run 2 lost a run to this.
+**Change:** detect "nothing left to run" after skip resolution and exit early with a clear message
+(before touching the emulator); guard `model is None` at `train.py:1269-1300`.
+**Acceptance:** functional test: resuming a finished circuit prints "circuit already complete" and
+exits 0 without traceback; resuming a mid-circuit checkpoint still works.
+**Outcome:** _not attempted_
+
+### P4. --compare must compare success-rate
+**Goal:** `compare_models` (`evaluate.py:127-207`) compares only `progress_values`; for ReachedLocation
+micro-scenarios the verdict is blind to the metric that matters (the exp3 lesson — fixed in the report
+headers, never in compare).
+**Change:** when both eval JSONs carry `metrics['success-rate']`, additionally report success counts and
+a two-proportion test (Fisher exact via scipy) with its own verdict line; keep Mann-Whitney on progress.
+**Acceptance:** comparing exp4-vs-exp5 wallmaster JSONs (both 1.0) reports success-rate parity; a
+synthetic 0.2-vs-0.6 pair flags significance.
+**Outcome:** _not attempted_
+
+### P5. Weighted-circuit exit criteria gate on primary scenario ⛔ (before any weighted run)
+**Goal:** exp5's boss-transfer leg exited on wallmaster 0.86 while the boss metric was 0.0 (§0.4).
+**Change:** in weighted circuits (`train.py:_run_weighted_circuit` + `WeightedScenarioSelector`), an
+entry-level `primary: true` flag (`TrainingCircuitEntry`, `scenario_wrapper.py:138-146`): the leg exits
+only when the primary scenario's criterion is met (or all criteria, if none marked). Config validation
+test in `tests/`.
+**Acceptance:** a config test proves a weighted circuit with a primary cannot exit on a non-primary
+metric; existing sequential circuits unaffected.
+**Outcome:** _not attempted_
+
+### P6. Verify worker metric aggregation under --parallel
+**Goal:** `docs/recommendations.md` item 2 claims worker MetricTracker data is not aggregated — exit
+criteria and TensorBoard would then see only the main process's metrics under `--parallel 16` (how all
+of exp5 ran). If true, every exit criterion evaluated during exp5 was computed on a sliver of episodes —
+this changes how much we trust historical leg exits.
+**Change:** read the `ml_ppo_worker.py` metric-pipe path + `MetricTracker` usage; run a small
+instrumented job (2 workers, 20k steps) and compare per-worker episode counts to what the exit-criteria
+metric saw. Fix or document precisely.
+**Acceptance:** a paragraph in the Outcome + (if broken) an issue-sized fix PR.
+**Outcome:** _not attempted_
+
+### P0. Land or discard the experiment5 branch leftovers
+**Goal:** branch `experiment5` holds uncommitted `triforce/triforce.yaml` (exp5 circuits),
+`docs/experiments/experiment-memory.md`, `experiment5-summary.md`, untracked `tests/test_experiment5_config.py`.
+The experiment ledger must be preserved; the exp5 circuit config is referenced by run history.
+**Change:** open a housekeeping PR from a fresh branch off `origin/main` landing the docs + yaml + test
+(experiment-memory records are append-only history). This plan document rides the same PR or its own.
+**Acceptance:** PR open; `main` untouched; nothing force-pushed.
+**Outcome:** _not attempted_
+
+---
+
+## 3. Phase V — Verification probes (cheap, no training)
+
+### V1. Empirical root-cause confirmation trace ⛔ (depends P1)
+**Hypothesis:** the exp5 policy leaves because leaving is optimal, and the episode return for leaving
+(≈ −0.5 total) beats every alternative it knows.
+**Steps:** run P1's combat trace on the exp5 checkpoint, `dungeon1-aquamentus-east`, 20 episodes,
+`--trace-endings left-boss-room`. Extract: (a) attack count (expect ≈0), (b) exit direction/step,
+(c) realized episode returns, (d) action-type distribution, (e) mask state at the exit step.
+**Acceptance:** a table in the Outcome block: mean return of leaving vs the payoff table's prediction;
+verdict sentence "reward-spec bug CONFIRMED/REFUTED as the dominant cause".
+**Falsification:** if traces show the agent *attacking and failing* (hits > 0, dies or times out), the
+spec-bug theory loses primacy → re-weight toward Phase B/C (skill, not incentive) and log in §9.
+**Outcome:** _not attempted_
+
+### V2. Scripted boss-kill probe ⛔ (independent; start anytime)
+**Hypothesis:** Aquamentus is killable from `1_35s` with (a) beams from range at full health, (b) 2
+bomb hits, (c) melee — establishing which strategy a policy must learn, and producing a
+machine-generated demo trace for Phase B. The original-design system's 68% relied heavily on beams
+from a full-health start (§1.6.4), so (a) is the prior favorite.
+**Steps:** write `scripts/boss_probe.py` (or a test using `ZeldaActionReplay` from `tests/utilities.py`,
+savestate `1_35s`): scripted action sequences —
+1. Beam plan: walk N clear of the door, face E, spam BEAMS; count hits until boss HP (obj_health slot,
+   V6) reaches 0. Verify `success-killed-boss` fires with +20, heart container drops, objective flips
+   FIGHT→TREASURE→MOVE, shutter opens, east walk reaches 0x36 with `reward-new-location`.
+2. Bomb plan: approach to bomb range, place 2 bombs timed at the boss.
+3. Melee plan: walk into sword range, swing 6×, log health lost.
+Record every step as `ACTION DIRECTION` lines → save working sequences to
+`docs/experiments/demos/aquamentus-<strategy>.txt` (normalized forward trace format, §10.5).
+**Acceptance:** at least one strategy kills the boss reproducibly; full reward/ending accounting of a
+kill documented in the Outcome; a candidate demo file exists.
+**Falsification:** if no scripted strategy lands hits (e.g. sword blocked by screen-lock bounds near
+the south door — UW blocks sword/items when y>199, `docs/specs/nes-mechanics.md`), document the
+geometry constraint; ask the user for a hand-played trace instead (B3 route b).
+**Note:** also log whether any transient frame during the fight has `state.enemies == []` (feeds V3),
+and snapshot `em.get_state()` at boss HP 4/2/1 and post-kill (feeds C2/C5).
+**Outcome:** _not attempted_
+
+### V3. DefeatedBoss false-positive check (piggybacks on V2)
+**Hypothesis (from the brief, unverified):** `DefeatedBoss` tests `not state.enemies`
+(`end_conditions.py:204`) — a transient empty object list (spawn frames, sparkle→item conversion) would
+yield a spurious +20 `success-killed-boss` — a reward-hacking channel. Mild counter-evidence: the
+original-design branch used the same check and shipped no spurious successes (§1.6).
+**Steps:** during V2 runs, log `len(state.enemies)` and `len(state.active_enemies)` every frame from
+room entry to kill; test the room-entry frames specifically (object slots populate a few frames in).
+**Change if real:** require boss absent for N consecutive controllable frames, or check the dying
+transition explicitly (`Enemy.is_dying`, `enemy.py:30-38`) before declaring the kill.
+**Acceptance:** verdict + (if real) fix PR with a regression test.
+**Outcome:** _not attempted_
+
+### V4. Trace the hint-mask escape route (depends P1)
+**Hypothesis:** hints mask (MOVE,S) at `tile.y >= 0x14` (`training_hints.py:36-37`) but transitions can
+be entered from y≤0x13 with a multi-tile move under FrameSkip; `_handle_empty_mask`
+(`action_space.py:400-409`) is a second candidate.
+**Steps:** in V1's traces, extract Link's tile and the mask at the step where location changes
+0x35→0x45. Determine which mechanism allows the exit.
+**Why it matters:** R3 makes hints coherent in FIGHT rooms; if the exit leaks through the y-threshold,
+hints will *still* leak after R3 — fix the threshold (mask S at y ≥ transition-trigger − max move tiles)
+or accept that R1's −20 handles it economically.
+**Acceptance:** mechanism named with a trace excerpt in the Outcome.
+**Outcome:** _not attempted_
+
+### V5. Fireball dodgeability / beam retention measurement (piggybacks V2)
+**Question:** can a policy plausibly keep full health (and thus beams) for a whole fight? How many
+action-steps does a fireball dodge take, and does frame-skip granularity permit it?
+**Steps:** in V2 beam runs, log fireball spawn→impact windows in *agent steps* (not frames); try a
+scripted dodge (step N/S between shots). Compute: fireball frequency, dodge window, hit rate of
+"stand and shoot" vs "shoot and weave".
+**Deliverable:** a paragraph deciding whether beam-kill is learnable without damage, or whether the
+curriculum must assume melee-after-first-hit. Feeds C3's design, R4's payoff math, X8's priority.
+**Outcome:** _not attempted_
+
+### V6. Aquamentus RAM fact sheet (independent)
+**Goal:** the facts C1 and V2 need, currently undocumented (`docs/specs/nes-mechanics.md` has no boss
+section — X6 later folds this in).
+**Steps:** load `1_35s` in a scratch script; dump object slots: which `obj_health_N` is Aquamentus
+(likely slot 1 → `obj_health_1` @ 0x486, value 0x60 = 6 HP in high nibble — verify), boss position
+(static?), fireball slots/ids, shutter door tile state before/after kill, heart-container drop position.
+Cross-check against `zelda-asm/` if anything surprises.
+**Acceptance:** fact sheet in the Outcome (slot; HP encoding verified by writing 0x10 and confirming a
+1-hit kill; door mechanics; drop tile).
+**Outcome:** _not attempted_
+
+---
+
+## 4. Phase R — Reward & termination specification
+
+### R1. Terminal parity: leaving the boss room = −20 ⛔
+**Hypothesis:** with `failure-left-boss-room` ≈ −0.25, leaving dominates; pricing it at −20 removes the
+degenerate optimum. Original-design evidence (§1.6.1): terminal + max penalty on exit produced zero
+flee-outs. Necessary but NOT sufficient — pair with R2/R3 before training (a policy with no positive
+path may just pick the *fastest* −20).
+**Change:** add `failure-left-boss-room` to `OTHER_FAILURE_ENDINGS` (`scenario_wrapper.py:23-27`).
+Audit the other orphans at the same time: `failure-no-next-room`, `failure-no-sword` — add or document
+why not. Unit test in `tests/` on `apply_terminal_rewards` covering all three.
+**Also:** `dungeon1-late-chain` has no `DefeatedBoss` condition, so leaving 1_35 south there remains a
+−0.25 ordinary step and the episode continues (P2's livelock). After R3, `penalty-wrong-location` still
+prices it; decide in R6 whether late-chain also needs a boss-room-exit condition — default: leave
+late-chain permissive (the room must be re-enterable en route to the triforce) and rely on P2's timeout
+fix.
+**Acceptance:** tests pass; a 10-episode diagnose run on the *old* exp5 checkpoint now shows leaving
+episodes scoring ≈ −20 (accounting check only; behavior unchanged).
+**Outcome:** _not attempted_
+
+### R2. Boss-damage rewards, stall reset on hits, boss PBRS scale ⛔
+**Hypothesis:** 6 melee hits × +0.25 does not pay for the expected fireball damage en route; a per-HP
+damage signal that dominates a hit-trade makes engagement positive-EV; hits must count as "progress"
+for the stalling clock; and the approach gradient toward the boss should be stronger than the generic
+±0.05/tile. Original-design targets (§1.6.2–3): hit:damage ≈ 3:1, approach shaping ±0.25/step.
+**Change (`triforce/critics.py`):**
+1. New `reward-boss-hit`: for boss enemies (set keyed off `ZeldaEnemyKind`, Aquamentus now), replace
+   `reward-hit`/`reward-beam-hit` with a per-HP-damage reward — recommend +0.5 per HP dealt (bombs deal
+   4 HP → +2.0 pre-clamp; the ±1 step clamp caps realized value — X7 audits this). Total kill payout
+   ≈ +3.0 across the fight + 20 terminal. Farming-safe: boss HP is finite, no respawn.
+2. Reset `_room_steps` (stalling clock, `critics.py:372-378`) on `state_change.hits` — damage is
+   progress in a FIGHT room. Currently only kills reset it.
+3. Optional third lever, keep behind a constant: in FIGHT rooms, use a smaller `PBRS_SCALE` (e.g. 20→8)
+   so approaching the boss pays ±0.125/tile instead of ±0.05. Still potential-based (γ=1, telescoping,
+   exploit-proof) — this is the safe analog of the old ±0.25/step directional shaping.
+4. Keep `penalty-lost-health` and `penalty-lost-beams` unchanged for now; R4 decides whether a
+   boss-room "aggression profile" (softened damage penalty à la `Dungeon1BossCritic`) is needed. Note
+   the positives-halved-on-damage rule (`critics.py:146-147`) already softens relative economics — the
+   old system's was harsher (full wipe), yet it still needed 3:1 to engage.
+**Interaction check:** reward-attribution look-ahead (`docs/specs/reward-attribution.md`) already
+credits delayed beam/bomb damage to the firing step — new constants ride the same path; add a unit test
+with a saved fight state asserting the reward dict (pattern: `tests/` + `CriticWrapper`).
+**Acceptance:** unit tests; V2's scripted kill replayed under the new critic shows per-hit rewards and
+no stalling-penalty accumulation while actively dealing damage.
+**Falsification:** none at this stage (spec work); R6 falsifies behaviorally.
+**Outcome:** _not attempted_
+
+### R3. FIGHT rooms get route next_rooms (exit semantics) ⛔
+**Hypothesis:** `next_rooms=[]` in FIGHT rooms makes hints self-defeating and forbids any "correct exit"
+gradient; supplying the route's next rooms even during FIGHT makes location scoring, hints, and
+post-kill routing coherent.
+**Change (`triforce/objectives.py`):** in `get_current_objectives` (`:154-177`), when kind is
+FIGHT/TREASURE, still call `_get_map_objective` for `next_rooms` (routing metadata) but do NOT extend
+`tile_objectives`/`pbrs_targets` with exit tiles — PBRS keeps pointing at enemies/treasure; hints and
+`critique_location_change` get truthful next rooms. CAVE keeps current behavior.
+**Consequences to verify:**
+- Boss room during fight: `next_rooms={0x36}` ⇒ hint masks S (correct); E stays walkable but the
+  shutter physically blocks until kill ⇒ leaving becomes *mechanically* hard, not just penalized
+  (defense in depth with R1).
+- After kill+pickup: kind→MOVE, `reward-new-location` +1.0 fires entering 0x36 (previously impossible).
+- Non-boss FIGHT rooms (key rooms): the agent fighting near a door no longer takes
+  `penalty-wrong-location` for a legitimate route exit — check this doesn't create a "skip the fight"
+  loophole: the room's key stays uncollected and routing may require it later (`Dungeon1DidntGetKey`
+  covers 0x63). Audit key rooms in `game.yaml`; note any where skipping breaks the route.
+**Acceptance:** unit tests on objectives for 1_35 (FIGHT w/ next_rooms), a key room, and a cave;
+existing tests green; a diagnose run confirms hint masks in 1_35 now mask S and only S at the south
+edge.
+**Outcome:** _not attempted_
+
+### R4. Recompute and rebalance the boss-room payoff table (after R1–R3, before R6)
+**Goal:** write the *new* payoff table and sanity-check it end-to-end before spending training budget.
+**Steps:** with R1–R3 applied, compute for each outcome (kill via beams / kill via melee with k
+fireball hits / leave south / die / timeout) the total episode return using real constants; replay V2's
+scripted sequences under the new critic to validate empirically. Table goes in the Outcome block.
+**Decision points this settles:**
+- Is a melee kill with 2 fireball hits net-positive? (Target: yes, comfortably, ≥ +2.)
+- Is "take one hit then leave" still ≤ −19?
+- Does the ±1 per-step clamp swallow the bomb double-hit (X7)?
+- Is a boss-room aggression profile (damage penalty −0.5 → −0.25 while a boss is alive, per §1.6.3)
+  needed to make melee viable, or do beams+bombs carry it?
+**Acceptance:** table + one-line go/no-go for R6.
+**Outcome:** _not attempted_
+
+### R5. Split micro-scenarios: kill vs victory-lap
+**Goal:** `dungeon1-aquamentus-east` conflates two skills: kill the boss AND route to 0x36. Decompose
+for cleaner gates and reverse-chaining. (The original-design boss model trained on exactly the kill
+task with `[GainedTriforce, DefeatedBoss, GameOver, Timeout]`, §1.6.)
+**Change (`triforce/triforce.yaml`):**
+- `dungeon1-aquamentus-kill`: same start, end conditions `[DefeatedBoss, GameOver, Timeout]` — success
+  = `success-killed-boss` only. Metric: success-rate.
+- `dungeon1-victory-lap` (C5 builds the savestate): start post-kill, success = ReachedLocation 0x36 or
+  GainedTriforce.
+Keep `dungeon1-aquamentus-east` unchanged as the Gate-A eval.
+**Acceptance:** config test (mirror `tests/test_experiment5_config.py`); both scenarios load and run 1
+episode headless.
+**Outcome:** _not attempted_
+
+### R6. EXPERIMENT: retrain Aquamentus on the fixed spec (the EXP7 run)
+**Hypothesis:** with R1+R2+R3 in place, PPO from the exp5 (or exp4) checkpoint learns to engage — even
+without demonstrations — because engagement is now the only non-catastrophic option and damage pays.
+The original-design system needed no demos for its 68% (§1.6); its advantages (specialist model,
+attack-only actions, vector obs) are partially compensated by our curriculum options (C-phase).
+**Protocol (full experiment-memory discipline, §10.4):**
+- Load: exp5 final weights (keeps wallmaster demo-reg with the existing trace, coeff 0.05) — fallback
+  arm: exp4 final if exp5's entropy collapse resists retraining.
+- Scenario: `dungeon1-aquamentus-kill` (R5) if available, else `dungeon1-aquamentus-east`; 750k steps;
+  `--parallel 16` only after P6's verdict, else 6.
+- Exit criteria: success-rate ≥ 0.5 **sustained over 3 consecutive milestone wakes** (X3 automates;
+  until then enforce by journal discipline).
+- Watch: `losses/entropy/action_type` (floor 0.1 — if pinned ~0, apply S1/S2 mid-experiment via
+  stop-edit-restart), `failure-left-boss-room` rate, `reward-boss-hit` count/episode, stuck/death rates.
+- Final eval: `dungeon1-aquamentus-east`, 100 eps, P4's compare vs exp5's eval JSON.
+**Success:** Gate A threshold (≥0.5) or any nonzero sustained success — both are firsts.
+**Falsification:** left-boss-room collapses to ~0 (agent stays) but attack count stays ≈0 for the full
+budget → incentive fixed but the *skill* is undiscoverable by exploration → pivot to Phase B (demos)
+and/or C1 (reverse curriculum); record in §9.
+**Failure mode to watch:** agent converts to `failure-stuck`/death farming (both −20, faster). If >30%
+of episodes end stuck-in-place, exploration found no positive path: same pivot.
+**Outcome:** _not attempted_
+
+---
+
+## 5. Phase B — Boss demonstration & behavior cloning
+
+### B1. Demo format: non-MOVE actions
+**Goal:** `parse_demo_trace` raises on non-MOVE (`demo.py:56-58`); `DEMO_ACTION_TYPE_INDEX={MOVE:0}`
+(`demo.py:14`). A boss demo needs SWORD/BEAMS/BOMBS lines.
+**Change (`triforce/demo.py`):**
+- Accept `<ACTIONKIND> <DIRECTION>` lines for any ActionKind in the all-items space; derive the
+  action-type index from the `ActionSpaceDefinition` ordering (do NOT hardcode a second mapping —
+  `collect_demo_batch` already builds the env; take indices from `ZeldaActionSpace`).
+- Keep MOVE-only validation as a per-trace *option* (wallmaster trace unchanged).
+- Generalize `diagnose.py --demo-report`'s hardcoded success check (`diagnose.py:1085` expects the
+  wallmaster target room) to accept the scenario's own success ending.
+**Acceptance:** unit tests: mixed trace parses; replay of a V2-generated boss trace through
+`collect_demo_batch` succeeds (mask-legal at every step, ends `success-*`).
+**Outcome:** _not attempted_
+
+### B2. Multi-demo support in train.py/ml_ppo.py
+**Goal:** wallmaster retention currently rides ONE trace (`--demo-trace` single string, one
+`_demo_batch` tuple). A boss demo must coexist (structural risk #5).
+**Change:** `--demo-trace` → `action='append'`, paired per-trace with scenario/prefix (or a
+`--demo-spec trace:scenario:prefix` syntax); build each batch via `collect_demo_batch`, then
+`torch.cat` obs-dict values/masks/targets into one batch (loss is a mean over examples — weighting by
+trace length is acceptable; document it). Optional per-trace coeff later, only if needed.
+**Cost note:** the whole demo batch is re-forwarded every minibatch (10 epochs × 16 minibatches); with
+~100 total demo steps this stays negligible.
+**Acceptance:** training smoke run (10k steps) with wallmaster+boss traces logs `demo_bc_accuracy`;
+unit test for the concat helper.
+**Outcome:** _not attempted_
+
+### B3. Acquire a boss-kill demonstration
+**Route (a) — scripted (preferred, no human):** V2's successful strategy saved as a normalized forward
+trace. Requirements: every action mask-legal during replay, ends `success-killed-boss` or
+`success-reached-location`. The bomb strategy is attractive (2 damage actions); beams have more steps
+but teach ranged discipline; capture both if both work.
+**Route (b) — human:** ask the user to hand-play `1_35s` → kill → east → 0x36 and supply the button
+sequence (they have offered; that's how wallmaster was made). Convert to trace format (§10.5).
+**Validation:** `diagnose.py --demo-report --demo-trace docs/experiments/demos/aquamentus-<x>.txt
+--demo-scenario dungeon1-aquamentus-east` (after B1's generalization).
+**Acceptance:** ≥1 validated trace in `docs/experiments/demos/`, referenced here.
+**Outcome:** _not attempted_
+
+### B4. EXPERIMENT: BC + demo-regularized PPO on the boss (the EXP8 run)
+**Hypothesis:** the exp3/4 recipe transfers: 1000-epoch BC on the boss trace makes the boss room
+learnable; the demo-BC term retains it; PPO polishes to Gate A.
+**Protocol:**
+- BC: `scripts/behavior_clone.py` from exp4-final (cleaner entropy than exp5) with the boss trace,
+  1000 epochs (the 400-epoch variant was destroyed by PPO in exp3 — do not repeat), min-accuracy 0.95.
+  behavior_clone is policy-only; do B5 first if available.
+- PPO: fixed-spec scenario (R1–R3 required), BOTH demos via B2 (wallmaster coeff 0.05 + boss coeff 0.1
+  starting points), 750k steps, exit success-rate ≥ 0.5 sustained ×3 wakes.
+- Eval: `dungeon1-aquamentus-east` 100 eps vs exp5 baseline JSON; ALSO re-eval
+  `dungeon1-wallmaster-north-exit` 100 eps — retention must stay 1.0 (falsifier for the multi-demo
+  design).
+**Falsification:** BC reaches accuracy ≥0.95 but PPO success collapses to 0 within 200k steps despite
+the demo term (the exp3-run0 signature) → value-head staleness is the suspect → do B5, retry once; if
+it collapses again → S5 (KL anchor).
+**Outcome:** _not attempted_
+
+### B5. Value-head warmup after BC
+**Goal:** `behavior_clone.py` trains policy only; the critic is stale, so early PPO advantages are
+garbage and can destroy the cloned policy (exp3 run 0: 0.447→0.0).
+**Change (`ml_ppo.py` + flag):** `--value-warmup-steps N`: for the first N env steps, collect rollouts
+and update ONLY the value head (freeze policy params or zero pg/entropy losses), then unfreeze. Log the
+phase boundary to TensorBoard.
+**Acceptance:** smoke test showing policy params bit-identical through warmup; explained_variance
+recovers above 0.3 before policy updates begin on a BC checkpoint.
+**Outcome:** _not attempted_
+
+---
+
+## 6. Phase C — Curriculum & environment tricks
+
+### C1. Boss-HP reverse curriculum (1hp→2hp→4hp→6hp)
+**Hypothesis:** with boss HP=1, random exploration finds the kill (+20 dense) quickly; scaffolding HP
+back to 6 transfers engagement without demos. The strongest *demo-free* arm.
+**Mechanism (verified available):** scenario `per_reset` can write any named RAM value
+(`state_change_wrapper.py:335-347,405-417`); `obj_health_1`…`obj_health_c` are named
+(`zelda_game_data.txt:100-111`). V6 confirms Aquamentus's slot and encoding (HP in high nibble:
+0x10 = 1 HP).
+**Change (`triforce/triforce.yaml`):** scenarios `dungeon1-aquamentus-kill-1hp/-2hp/-4hp` = copies of
+`dungeon1-aquamentus-kill` (R5) + `per_reset: {obj_health_1: 0x10 / 0x20 / 0x40}`; sequential circuit
+`aquamentus-reverse-hp` with exit success-rate ≥ 0.8 per leg (sequential legs gate on their own
+scenario, so P5 isn't required), budgets 250k/250k/500k/750k.
+**Caveat:** per_reset fires on the reset frame; verify the write lands after object spawn (V6 checks).
+If spawn timing clobbers it, use `per_room`/`per_frame` with a value-guard instead.
+**Success:** full-HP leg reaches sustained success ≥ 0.5 → feed into Gate A eval.
+**Falsification:** the 1hp leg itself stays at 0 success for 250k steps → exploration never even swings
+→ entropy/masking problem, not curriculum problem → S1/S2 before anything else.
+**Outcome:** _not attempted_
+
+### C2. Mid-fight savestate curriculum
+**Goal:** the reverse-curriculum idea without RAM writes: start episodes *inside* successful fights.
+**Steps:** during V2 scripted kills, `em.get_state()` snapshots at boss HP 4/2/1 with Link positioned
+safely; save as custom integration states (`triforce/custom_integrations/Zelda-NES/`); add to scenario
+`start:` lists (round-robin supports lists). Catalog in `docs/savestates.yml`.
+**Use:** blend into R6/B4/C1 start lists so every rollout batch contains near-success states.
+**Acceptance:** states load and roll; a training smoke run consumes the mixed start list.
+**Outcome:** _not attempted_
+
+### C3. Invulnerability training wheels (per_frame health)
+**Hypothesis:** fear of damage (health penalties + beam loss + reward halving) suppresses engagement
+exploration; a phase where Link cannot effectively lose health lets attack behavior emerge, then the
+wheels come off.
+**Change:** scenario variant `dungeon1-aquamentus-kill-invuln` with
+`per_frame: {hearts_and_containers: 34, partial_hearts: 254}` — health restored every frame (beams
+never lost either — subsumes a "beams-forever" variant). Circuit: invuln → normal, exit ≥0.8 then ≥0.5.
+**Risks (state in the journal):** (1) policy learns to tank hits — the transfer leg must un-learn
+standing in fireballs; (2) `critique_health_change` may see per-frame refills as `health_gained` →
+check the critic doesn't emit spurious `reward-gained-health` every frame (verify where per_frame
+writes land relative to health-delta computation in `StateChangeWrapper._apply_modifications`; exempt
+if needed).
+**Falsification:** transfer leg loses >80% of the invuln leg's success and doesn't recover within 2×
+its budget → abandon (tanking overfit confirmed).
+**Outcome:** _not attempted_
+
+### C4. Start-state diversity for the boss room
+**Goal:** a single deterministic opening (`1_35s`) invites brittle memorized openings; NES RNG is
+partly frame-driven so diversity must come from states. (The old system randomized RNG bytes at reset —
+`zelda_wrapper.py` on original-design; check whether the current reset does; if not, that's a one-line
+addition worth making here.)
+**Steps:** generate 5–10 entry snapshots: vary Link's entry column/row (scripted walk-ins from 1_45
+with different prefixes, snapshot at the door), vary boss/fireball phase by waiting 0–60 frames before
+snapshotting. Add to `start:` lists of the boss scenarios.
+**Acceptance:** states cataloged; R6/B4 journals note whether variance across starts shrinks over
+training.
+**Outcome:** _not attempted_
+
+### C5. Victory-lap scenario: post-kill → triforce
+**Goal:** milestones 16→17 (heart container, east exit, triforce room, GainedTriforce) have literally
+never been executed by any trained policy. Make them independently learnable/verifiable
+(reverse-chaining the tail; pairs with R5).
+**Steps:** V2 produces a post-kill savestate (boss dead, container on floor, shutter open) →
+`dungeon1-victory-lap` scenario: end conditions `[GainedTriforce, CollectedTreasure(triforce),
+ReachedLocation(0x36), GameOver, Timeout]`, success per R5's design. Short PPO run (≤250k) from
+exp4/exp5 checkpoint; this should be an *easy* MOVE/TREASURE task.
+**Acceptance:** sustained success ≥ 0.8 in ≤250k steps; verifies triforce accounting end-to-end
+(GainedTriforce, equipment reward, no `failure-*` mispricing on the pickup cutscene).
+**Falsification:** if even this stalls, something is broken in triforce-room accounting — diagnose
+before ANY boss work continues; it would poison late-chain too.
+**Outcome:** _not attempted_
+
+### C6. Boss-room action masking of useless items
+**Goal:** the old system's boss model had 8 actions (move + sword only, §1.6.6); ours explores over the
+full all-items space (whistle, food, candle, potion…), diluting exploration exactly where the type head
+is already collapsed. Masking useless actions in the boss room narrows the search without a new model.
+**Change:** extend `TrainingHintWrapper._disable_actions` to append `invalid_actions` for item kinds
+that are provably useless in the current room (boss rooms: allow MOVE/SWORD/BEAMS/BOMBS only). Gate it
+on `use_hints` so eval-with-hints matches training. Keep the list data-driven (room → allowed kinds) in
+the wrapper, not hardcoded deep in action_space.
+**Acceptance:** unit test: in 1_35 with hints, mask allows only the four kinds; R6/B4 journals note
+whether exploration finds attacks faster with C6 on (A/B if cheap).
+**Outcome:** _not attempted_
+
+---
+
+## 7. Phase S — Structural PPO/model work
+
+### S1. Per-head entropy floor / adaptive ent_coef
+**Problem:** action-type entropy 0.0025 at exp5 end; guardrails only *observe*. A deterministic type
+head cannot explore "attack".
+**Change (`ml_ppo.py::_optimize`):** compute per-head entropies in the update (expose from
+`get_action_and_value` or recompute per-head); apply an adaptive coefficient:
+`ent_coef_type = base * (1 + k * max(0, floor − H_type))` with floor ≈ 0.2, k ≈ 10 — pressure grows as
+the head collapses (SAC-style target-entropy flavor without the dual variable). CLI `--ent-floor-type`.
+Log both head entropies + effective coefficients.
+**Acceptance:** on a 100k-step boss-scenario run from the exp5 checkpoint, `entropy/action_type`
+recovers to >0.1 without wallmaster success dropping below 0.9 (40-ep eval).
+**Falsification:** wallmaster retention breaks (<0.8) at any floor that also restores exploration →
+retire S1 in favor of S2.
+**Outcome:** _not attempted_
+
+### S2. Scope MOVE-only demo-BC loss to the direction head
+**Problem:** the wallmaster demo is MOVE-only; its NLL term pushes the *type* head toward MOVE on demo
+states, and generalization plausibly suppresses ATTACK everywhere (the exp5 journal repeatedly
+justified type-entropy ≈ 0 by "MOVE-only demo regularizer" — that's the tell).
+**Change:** in the demo loss (`ml_ppo.py:621-625`), decompose per-head log-probs (the multihead model
+computes both; expose them) and, per demo trace, include the type-head term only if the trace contains
+non-MOVE actions. Boss demos (B1) include attacks → their type-head term stays.
+**Acceptance:** A/B 100k-step runs (with/without scoping) from the exp5 checkpoint: scoped variant
+shows higher type entropy with equal demo accuracy (accuracy is both-heads — for MOVE-only traces also
+report direction-head-only accuracy).
+**Outcome:** _not attempted_
+
+### S3. EPOCHS 10→4 and expose LEARNING_RATE
+**Problem:** EPOCHS=10 is 2.5× the PPO norm (recommendations item 1, HIGH); LR is hardcoded
+(`ml_ppo.py:83-97`). High epoch counts amplify the demo-BC term and per-rollout overfitting — a
+plausible contributor to BC destruction and entropy collapse.
+**Change:** make both `PPO.__init__` kwargs + CLI flags (`--epochs`, `--lr`); defaults unchanged until
+A/B'd. A/B on the R6 setup: epochs 10 vs 4 at equal env steps.
+**Acceptance:** A/B table (success trajectory, approx_kl, rollback count, wall-clock). Adopt the
+dominant setting; record in §9.
+**Outcome:** _not attempted_
+
+### S4. Optimizer persistence across circuit legs
+**Problem:** Adam state is rebuilt each `train()` call (recommendations item 4) — every leg transition
+spikes; multi-leg curricula (C1!) pay it repeatedly.
+**Change:** thread `ppo.optimizer.state_dict()` through leg transitions in `_run_sequential_circuit`
+(train.py already restores optimizer from checkpoints on `--load`; reuse that path in-process).
+**Acceptance:** TensorBoard shows no grad-norm/KL spike at a leg boundary in a 2-leg smoke circuit.
+**Outcome:** _not attempted_
+
+### S5. KL-anchor regularization (fallback if demo-BC retention fails on the boss)
+**Idea:** instead of NLL on demo *states only*, anchor the policy to the BC checkpoint with
+`β·KL(π_anchor‖π)` computed on **rollout** states — protects behavior on the whole visited manifold,
+annealing β over training. The KL-rollback code already snapshots full state dicts
+(`ml_ppo.py:571-576`); the anchor is a frozen second network (`Network.load`); analytic per-head
+categorical KL must replicate the masking (−1e9 fill, type-conditioned direction mask, single-type
+exclusion).
+**When:** only if B4's falsification path triggers twice. Not before — demo-BC is proven; this is not.
+**Acceptance:** B4 retry with anchor holds boss success without freezing learning (β anneals to ~0 and
+success persists).
+**Outcome:** _not attempted_
+
+### S6. Self-imitation on harvested successes
+**Idea:** generalize the demo mechanism: keep a rolling buffer of the agent's OWN successful episodes
+(ending `success-*`) and add a BC/SIL term over samples from it (advantage-clipped: positive-advantage
+actions only). Turns the first lucky boss kill into a persistent teacher — directly attacks the
+non-monotonicity problem (0.58→0.96 regressions), because success behavior stops being forgettable.
+**Sketch:** collect (obs, mask, action) tuples in the rollout worker when an episode ends in success;
+FIFO cap (~50 episodes); each optimize round samples ≤1024 steps into a demo-batch-shaped tensor and
+reuses the demo-BC code path (B2's concat makes this nearly free).
+**Order:** build after B2; try after (or alongside) B4. Highest-upside structural item.
+**Acceptance:** on the R6 setup, the success-rate trajectory becomes monotone-ish (no >50% relative
+regression between consecutive milestone wakes once success > 0.2).
+**Outcome:** _not attempted_
+
+### S7. Per-leg ent_coef in circuit YAML
+**Goal:** exploration needs differ per leg (boss legs need more). `TrainingCircuitEntry` gets an
+optional `ent_coef` field, threaded into PPO kwargs per leg (`train_once`).
+**Acceptance:** config test + a smoke circuit logging different `ent_coef` per leg.
+**Outcome:** _not attempted_
+
+### S8. Entity distance/vector features (observation)
+**Goal:** add per-entity distance-to-Link (and Δx,Δy direction) to the 8-dim entity features so
+dodge/approach doesn't have to be inferred from pixels. The old system fed explicit objective/enemy/
+projectile/aligned-enemy vectors and beat the boss (§1.6.4); the current design deliberately dropped
+positions in favor of CoordConv (`observation_wrapper.py:293-294`) — this task re-tests that bet in
+the one room where it matters most.
+**Cost:** observation-space change invalidates all checkpoints (obs shape mismatch) — forks the model
+lineage. Do it only if V5 shows dodging is the bottleneck AND B4/C1 both underperform; if done, train
+the boss micro-scenario from BC-of-demos rather than old checkpoints.
+**Acceptance:** A/B on `dungeon1-aquamentus-kill` from-BC: hit-taken rate per episode drops materially.
+**Outcome:** _not attempted_
+
+---
+
+## 8. Phase I — Integration to the gates
+
+### I1. EXPERIMENT: late-chain integration (Gate B)
+**Precondition:** Gate A reached by any arm (R6, B4, or C1). P2 fixed (evals must terminate).
+**Protocol:**
+- Circuit: weighted with P5's `primary` gating — `dungeon1-late-chain` (primary, exit success ≥ 0.1) +
+  `dungeon1-wallmaster-north-exit` (retention, small weight) + `dungeon1-aquamentus-kill` (rehearsal).
+  All demos active (B2). Budget 1.5M steps.
+- Watch for the exp5 regression signature (late-chain progress/max dropping 16→14): if boss rehearsal
+  steals capacity, rebalance ONCE, with ≥3 wakes of journal evidence.
+- Late-chain semantics check before launch: with R3, leaving 1_35 south mid-chain is priced
+  (`penalty-wrong-location`) and hints mask it; confirm `NowhereToGoCondition` can't fire spuriously in
+  FIGHT rooms (it's MOVE-gated, `end_conditions.py:266-274` — stays true after R3).
+- Final eval: `dungeon1-late-chain` 100 eps vs exp4's eval JSON (median 10/11, max 16, success 0.0).
+**Success:** Gate B: success > 0, progress/max = 17.
+**Falsification:** boss solved in isolation but never inside the chain after 1.5M steps → context
+transfer failure → C4 start diversity + C2 states harvested *from chain prefixes* (enter 1_35 via a
+real 1_45 playthrough — health/beam state on entry differs from the 1_35s savestate). Iterate once
+before rethinking.
+**Outcome:** _not attempted_
+
+### I2. EXPERIMENT: full dungeon 1 (Gate C)
+**Precondition:** Gate B.
+**Protocol:** `dungeon1-all-items` (start 1_73s) — the key/locked-door/bomb routing segment plus the
+solved late chain. Weighted circuit: all-items (primary) + late-chain + retention scenarios. Budget 2M.
+Final eval 100 eps. Watch `failure-no-key` and the milestone-13 pileup (the baseline's wall).
+**Success:** Gate C: success > 0.
+**Outcome:** _not attempted_
+
+### I3. EXPERIMENT: full game gate (Gate D)
+**Precondition:** Gate C.
+**Protocol:** `full-game-all-items-finite` fine-tune (or straight eval if I2's model generalizes),
+100-ep eval vs the baseline JSON. Success = Gate D (§0.1). This closes the plan's scope — do NOT widen
+into dungeon 2+ here; write the follow-on plan as a new document.
+**Outcome:** _not attempted_
+
+---
+
+## 9. Backlog (X) and Decision Log
+
+### X1. Auto-demo harvesting from scripted policies
+Generalize V2: parameterized scripted policies (jittered timings, varied paths) → many validated traces
+→ BC on a *distribution* instead of one trajectory (mitigates single-trace overfit; complements S6).
+**Outcome:** _not attempted_
+
+### X2. Auxiliary boss-HP prediction loss
+Auxiliary head predicting nearest-enemy HP next step; forces combat-relevant representations before
+rewards flow. Cheap once S-phase infra exists; obs already exposes enemy HP as a target.
+**Outcome:** _not attempted_
+
+### X3. Sustained-threshold exit criteria
+Implement `exit-criteria: {metric, threshold, consecutive: 3}` in train.py so legs can't exit on one
+lucky window (codifies §0.4 rule 1). Small change that R6/B4/C1/I1 all want.
+**Outcome:** _not attempted_
+
+### X4. Multi-seed replication harness for micro-scenarios
+Micro-scenarios are cheap; non-monotonicity is the enemy. A wrapper running N=3 seeds of a
+micro-scenario config and reporting the success-rate band makes single-run claims honest.
+**Outcome:** _not attempted_
+
+### X5. Beam-alignment shaping (fired-correctly / didn't-fire)
+Port the original-design pair (§1.6.4): small penalty (−0.05) for moving instead of firing when an
+enemy is beam-aligned and beams are available; small reward (+0.05) for firing while aligned. Needs an
+alignment computation (row/col overlap with Link) — cheap from existing state. Guarded: only in FIGHT
+rooms; cap per episode to prevent farming alignment without commitment.
+**Outcome:** _not attempted_
+
+### X6. Update stale docs
+`docs/specs/combat-engagement.md` references the removed `DANGER_TILE_PENALTY`;
+`docs/specs/nes-mechanics.md` lacks an Aquamentus/boss-room/shutter section (V6/V2 produce the facts).
+Fold V-phase findings in; also record the §1.6 original-design digest pointers.
+**Outcome:** _not attempted_
+
+### X7. Positive-clamp audit for multi-reward kill steps
+Step totals clamp to ±1 pre-terminal (`rewards.py:121`). A bomb double-hit (+2.0 boss damage under R2)
+or kill+pickup steps saturate — decide whether FIGHT-room damage steps deserve a widened clamp like
+terminals got, or whether saturation is acceptable. Analysis task; pairs with R4.
+**Outcome:** _not attempted_
+
+### X8. Fireball danger shaping (danger tiles / wavefront field)
+If V5 shows dodging matters: transient danger field around in-flight fireballs (predictable
+trajectories) — either a small step-on penalty à la original-design's DANGER/WARNING stamping (§1.6.5)
+or a wavefront potential term. Significant machinery; evaluate S8's simpler fix first.
+**Outcome:** _not attempted_
+
+### Decision Log
+_Append dated entries when outcomes change strategy._
+
+- **2026-08-03 (planning):** Root cause assessed as reward-spec bug (§1.1) with high confidence from
+  source verification; empirical confirmation assigned to V1. Chosen spine: probes → spec fix → retrain
+  → demos/curriculum as second wave → integration. General combat-engagement spec deferred: observed
+  failure is zero-attacks, not camping; `DANGER_TILE_PENALTY` no longer exists in code.
+- **2026-08-03 (planning, addendum):** `origin/original-design` archaeology (§1.6) confirms the design
+  direction independently: the system that beat D1 used terminal+max-penalty exits, boss-directed
+  movement shaping, 3:1 hit:damage economics, full-health boss-room starts, and beam-alignment shaping
+  — and recorded 68.3% boss kills with zero flee-outs. Added C6, X5; strengthened R1/R2/R4/S8/X8
+  rationale. Port structure, not constants (their shaping was non-potential-based and per-area models
+  had no retention constraint).
+
+---
+
+## 10. Reference card
+
+### 10.1 Commands
+```bash
+source .venv/bin/activate
+pytest tests/ -v                          # standard tests (slow PPO tests excluded)
+pylint triforce/ triforce_debugger/ debug.py evaluate.py train.py record.py
+
+python train.py <scenario|circuit> [all-items] [impala-multihead] \
+  --output DIR --iterations N --load MODEL.pt --parallel N \
+  --demo-trace T.txt --demo-scenario S --demo-prefix-east N --demo-bc-coeff 0.1
+python evaluate.py <model.pt|dir> <scenario> --episodes 100      # prefer the OMP eval plugin for real runs
+python evaluate.py --compare a.eval.json b.eval.json
+python diagnose.py --model impala-multihead --scenario S --model-path P --episodes 20 [-o out.txt]
+python scripts/behavior_clone.py --model-path P --scenario S --demo-trace T --prefix-east 0 \
+  --output OUT.pt --epochs 1000 --min-accuracy 0.95
+
+# read the original-design branch WITHOUT checking it out:
+git ls-tree -r origin/original-design --name-only
+git show origin/original-design:triforce/critics.py
+```
+
+### 10.2 Checkpoints (gitignored, verified on disk at planning time)
+```
+training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.pt        # exp5 final (boss failure model)
+training/experiments/experiment5/runs/experiment5-circuit/4/checkpoints/impala-multihead_all-items_dungeon1-late-chain_8335360.pt   # +optimizer
+training/experiments/experiment5/runs/experiment5-circuit/3/checkpoints/impala-multihead_all-items_experiment5-boss-transfer_7331840.pt
+training/experiments/experiment4/runs/experiment4-circuit/0/impala-multihead_all-items.pt        # exp4 final — best late-chain (max 16)
+training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt
+training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_learn-items_2199552.pt  # clean pre-endgame base
+```
+
+### 10.3 Baseline eval JSONs to compare against
+```
+…experiment4…/impala-multihead_all-items.dungeon1-late-chain.eval.json        # 100 eps, median 10/11, max 16
+…experiment5…/4/impala-multihead_all-items.dungeon1-aquamentus-east.eval.json # 100 eps, left-boss-room 1.0
+…baseline…/impala-multihead_all-items_all-items-polish_10719232.eval.json     # 100 eps, median 13/17
+models/dungeon1boss.zip.evaluation.json @ origin/original-design              # 68.3% kill (old system, context only)
+```
+
+### 10.4 Experiment protocol (mandatory for training tasks)
+Read `docs/experiments/experiment-memory.md` + the most relevant `docs/experiments/<id>-summary.md`.
+Write `training/experiments/<id>/journal.md` BEFORE starting (baseline checkpoint/eval, metric that must
+improve, load-vs-scratch, scenario/circuit, changes, success criteria, final eval plan). Every milestone
+wake: exactly one run action + per-metric tuning decision recorded as a journal table. Finish: final
+eval via the OMP evaluation plugin, `summary.md`, append to `experiment-memory.md`, tracked
+`docs/experiments/<id>-summary.md`. Never edit `.omp/extensions` mid-experiment. Treat the entropy
+floor as a constraint, not a nuisance wake (exp5's loosening spiral is the anti-pattern).
+
+### 10.5 Demo trace format (`docs/experiments/demos/*.txt`)
+Header prose (start scenario/state/goal), then `## Normalized forward trace` — one `ACTION DIRECTION`
+per line (currently `MOVE E` etc.; B1 extends to `SWORD N`, `BEAMS E`, `BOMBS E`). Optional
+`## Original reverse trace` provenance. Validate with `diagnose.py --demo-report`.
+
+### 10.6 RAM override cheat sheet (scenario YAML)
+`per_reset` (once at reset) / `per_room` (each room change) / `per_frame` (every frame) — dicts of
+named values from `triforce/zelda_game_data.txt` (`custom_integrations/Zelda-NES/data.json`), applied in
+`StateChangeWrapper._apply_modifications` (`state_change_wrapper.py:405-417`). Relevant names:
+`hearts_and_containers` (0x22 = 3 containers/2 filled), `partial_hearts` (≥0x80 for the beam gate),
+`obj_health_1`…`obj_health_c` (per-slot enemy HP, high nibble = HP units: 0x10 = 1), `bombs`, `keys`,
+`regular_boomerang`. Safe: inventory/health/equipment/RNG. NOT safe: Link position, object states.
+
+### 10.7 Constant map (current values, `triforce/critics.py` unless noted)
+```
+reward-hit +0.25·decay | reward-beam-hit +0.5·decay | reward-bomb-hit +0.5/hit | penalty-bomb-used −0.25
+penalty-attack-miss −0.01 | penalty-lost-health −0.25/half-heart | penalty-lost-beams −0.25
+positives halved on damage steps (critics.py:146-147, equipment pickups exempt)
+penalty-wrong-location −0.25 | reward-new-location +1.0 | reward-revisit-location +0.05
+PBRS ±Δdist/20 (γ=1) | stalling −0.01→−0.02 after 150 steps, ramp 1850, reset on room/kill/pickup
+terminal: ±20 via clamp exemption (rewards.py:112-121); sets in scenario_wrapper.py:22-27
+Aquamentus: 6 HP · wood sword/beam 1 dmg · bomb 4 dmg · fireball 1 heart · 3×3 tiles · slot HP obj_health_N
+combat decay: 0.5^(events−8) per room (anti-farming; irrelevant for a 6-HP boss)
+original-design boss profile (context): hit +0.75 · damage −0.25 · move-to-boss ±0.25/step · exit terminal −1.0
+```

--- a/docs/experiments/experiment-memory.md
+++ b/docs/experiments/experiment-memory.md
@@ -187,3 +187,40 @@ Do not continue from Experiment 2 final checkpoint. Before more PPO training, ru
 2. Confirm `ReachedLocation` fires success and `reward-terminal-success` appears.
 3. If reachable, create an easier wallmaster variant starting closer to the north exit or reducing wallmaster pressure.
 4. If not reachable or success does not fire, fix objective/end-condition detection first.
+
+## Experiment 3: wallmaster behavior cloning, 2026-06
+
+### Artifacts
+
+- Local experiment dir: `training/experiments/experiment3`
+- Valid run dir: `training/experiments/experiment3/runs/experiment3-circuit/1`
+- Tracked summary: `docs/experiments/experiment3-summary.md`
+- Expert demo: `docs/experiments/demos/wallmaster-north-exit.txt`
+- Strong BC checkpoint: `training/experiments/experiment3/wallmaster-bc-1000.pt`
+- Final checkpoint: `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt`
+
+### Changes tested
+
+- Validated expert trace with `diagnose.py --demo-report`.
+- Added behavior cloning from the expert wallmaster movement sequence.
+- Ran PPO on `dungeon1-wallmaster-north-exit` from the BC checkpoint.
+
+### Training outcome
+
+- 400-epoch BC reached exact action accuracy `1.0`, but PPO later destroyed the behavior.
+- 1000-epoch BC reached exact action accuracy `1.0` and was used for final run.
+- Final run completed by exit criterion: `success-rate=0.568353 >= 0.5` after 77,824 steps.
+- Final training sample had `success-reached-location=0.607923`, `reward-terminal-success=17.9167`, and `penalty-wall-master=-16.25`.
+
+### Final eval
+
+- `dungeon1-wallmaster-north-exit`: scenario metric `success-rate=0.24` over 100 episodes; generic Markdown header incorrectly reported `0/100` because it only counted progress-histogram success.
+- `dungeon1-late-chain`: `0/40` success; median progress `9/11`; JSON metrics reached `room-progress=14.75`, `progress/max=16`.
+
+### Classification
+
+Partial success. Behavior cloning made the wallmaster room learnable and produced nonzero final wallmaster success, but robustness and late-chain transfer are not solved.
+
+### Next recommended experiment
+
+Start from `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt`. Add demo regularization during PPO or periodic BC rehearsal so PPO keeps the safe wallmaster route. Train a late-chain curriculum alternating demo rehearsal, `dungeon1-wallmaster-north-exit`, and `dungeon1-late-chain`. Also fix `evaluate.py` reporting so `ReachedLocation` micro-scenarios use scenario `success-rate` in the header.

--- a/docs/experiments/experiment-memory.md
+++ b/docs/experiments/experiment-memory.md
@@ -264,3 +264,45 @@ Partial success. Demo-regularized PPO retained and improved the wallmaster route
 ### Next recommended experiment
 
 Keep demo-regularized PPO and the reporting fix. Do not use the Experiment 4 final model as a dungeon-solving checkpoint except for wallmaster-retention evidence. Add a late-chain/boss/triforce demonstration or separate rehearsal signal after the wallmaster north exit; the wallmaster-only demo is too narrow to teach Aquamentus and Triforce completion.
+
+## Experiment 5: boss-transfer curriculum, 2026-06
+
+### Artifacts
+
+- Local experiment dir: `training/experiments/experiment5`
+- Final run dir: `training/experiments/experiment5/runs/experiment5-circuit/4`
+- Tracked summary: `docs/experiments/experiment5-summary.md`
+- Initial load model: `training/experiments/experiment4/runs/experiment4-circuit/0/impala-multihead_all-items.pt`
+- Recovery checkpoint used for final run: `training/experiments/experiment5/runs/experiment5-circuit/3/checkpoints/impala-multihead_all-items_experiment5-boss-transfer_7331840.pt`
+- Final model: `training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment5/runs/experiment5-circuit/4/checkpoints/impala-multihead_all-items_dungeon1-late-chain_8335360.pt`
+- Wallmaster demo trace: `docs/experiments/demos/wallmaster-north-exit.txt`
+
+### Changes tested
+
+- Added `experiment5-boss-transfer` and `experiment5-circuit`.
+- Initial boss-transfer weights were `20 / 60 / 20` for wallmaster / Aquamentus / late-chain.
+- After the planned reweight trigger fired, changed weights to `10 / 80 / 10` because wallmaster retention was healthy but Aquamentus success remained `0.0` after more than 1,000,000 steps.
+- Continued wallmaster demo regularization with `--demo-bc-coeff 0.05`.
+
+### Training outcome
+
+- `[circuit] experiment5-boss-transfer`: completed from run `3` checkpoint, wallmaster exit metric `0.860073 >= 0.8`.
+- `dungeon1-late-chain`: budget exhausted in run `4`, `success-rate=0.0 < 0.1`.
+- Final late-chain training sample: `progress/max=14`, `room-progress=14.0`, `endings/failure-no-progress=0.75`, `endings/failure-stuck=0.5`, `endings/failure-terminated-death=1.0`, `endings/failure-wallmastered=1.0`.
+- Demo retention remained active at completion: `charts/demo_bc_accuracy=1.0`, `losses/demo_bc_loss=0.0010404533240944147`.
+
+### Final eval
+
+- `dungeon1-wallmaster-north-exit`: OMP evaluation plugin completed 100 episodes, `success-rate=1.0`, progress max `10/11`, P25/P50/P75/P90 `10 / 10 / 10 / 10`.
+- `dungeon1-aquamentus-east`: OMP evaluation plugin completed 100 episodes, `success-rate=0.0`, progress max `10/11`, P25/P50/P75/P90 `10 / 10 / 10 / 10`, `endings/failure-left-boss-room=1.0`.
+- `dungeon1-late-chain`: OMP evaluation plugin reported completion twice, but after stale artifacts were removed it produced no `.eval.json` or `.eval.md`. No direct `evaluate.py` fallback was run.
+- Late-chain compare was not run because the plugin did not produce a candidate late-chain JSON.
+
+### Classification
+
+Failure. Wallmaster retention remained solved, but boss transfer failed completely and final late-chain training regressed to `progress/max=14`. The `dungeon1-aquamentus-east` final eval shows a clear failure mode: every episode left the boss room.
+
+### Next recommended experiment
+
+Do not keep `experiment5-circuit` as a useful curriculum. Before another long run, diagnose `dungeon1-aquamentus-east` with action/reward traces around `failure-left-boss-room`; likely fix objective/end-condition/reward shaping for boss engagement before trying another curriculum.

--- a/docs/experiments/experiment-memory.md
+++ b/docs/experiments/experiment-memory.md
@@ -141,3 +141,49 @@ The reward-accounting bug is fixed, but success is still not attractive/learnabl
 ### Next recommended experiment
 
 Keep the reward-accounting fixes. Do not continue from the Experiment 1 final checkpoint. Start from `impala-multihead_all-items_learn-items_2199552.pt`, add an explicit terminal success reward, run `dungeon1-room-walk` briefly to expose dungeon geometry, then train `dungeon1-wallmaster-north-exit` as a single micro-scenario.
+
+## Experiment 2: wallmaster micro-scenario with success reward, 2026-06
+
+### Artifacts
+
+- Local experiment dir: `training/experiments/experiment2`
+- Valid local run dir: `training/experiments/experiment2/runs/experiment2-circuit/3`
+- Tracked summary: `docs/experiments/experiment2-summary.md`
+- Load checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_learn-items_2199552.pt`
+- Final model: `training/experiments/experiment2/runs/experiment2-circuit/3/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment2/runs/experiment2-circuit/3/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_3203072.pt`
+
+### Changes tested
+
+- Added tracked docs under `docs/experiments/`.
+- Added `reward-terminal-success`, allowing terminal success reward up to `+20.0`.
+- Kept terminal failure and wallmaster penalties from Experiment 1.
+- Ran `dungeon1-room-walk` before wallmaster training because the load checkpoint was pre-dungeon.
+- Added/fixed `experiment2-circuit` and `RoomWalk` fallback crash.
+
+### Training outcome
+
+- `dungeon1-room-walk`: passed early with `room-result/correct-exit=0.816667 >= 0.8`.
+- `dungeon1-wallmaster-north-exit`: failed by budget with `success-rate=0.0 < 0.5`.
+- Wallmaster failures were negative: final sample had `penalty-wall-master=-1.04167`, `penalty-terminal-failure=-2.08333`, `rewards=-43.5498`.
+
+### Final eval
+
+Final eval used 40 episodes due wallmaster runtime.
+
+- `dungeon1-wallmaster-north-exit`: `0/40`, median `9/11`, P25/P50/P75/P90 `9 / 9 / 9 / 9`.
+- `dungeon1-late-chain`: `0/40`, median `9/11`, P25/P50/P75/P90 `8 / 9 / 9 / 10`.
+- `dungeon1-room-walk`: eval command was run, but copied artifact appears overwritten/incorrectly labeled; treat room-walk final eval as inconclusive.
+
+### Current bottleneck after Experiment 2
+
+Reward penalties and success reward are mechanically present, and generic dungeon room walking can train. The wallmaster north-exit scenario still fails completely. The issue is now likely scenario reachability/objective detection or the wallmaster room setup being too hard/sparse, not reward sign alone.
+
+### Next recommended experiment
+
+Do not continue from Experiment 2 final checkpoint. Before more PPO training, run a scripted/manual reachability diagnostic from `1_45w` to `1_35`:
+
+1. Confirm controller actions can reach room `1_35` from `1_45w`.
+2. Confirm `ReachedLocation` fires success and `reward-terminal-success` appears.
+3. If reachable, create an easier wallmaster variant starting closer to the north exit or reducing wallmaster pressure.
+4. If not reachable or success does not fire, fix objective/end-condition detection first.

--- a/docs/experiments/experiment-memory.md
+++ b/docs/experiments/experiment-memory.md
@@ -224,3 +224,43 @@ Partial success. Behavior cloning made the wallmaster room learnable and produce
 ### Next recommended experiment
 
 Start from `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt`. Add demo regularization during PPO or periodic BC rehearsal so PPO keeps the safe wallmaster route. Train a late-chain curriculum alternating demo rehearsal, `dungeon1-wallmaster-north-exit`, and `dungeon1-late-chain`. Also fix `evaluate.py` reporting so `ReachedLocation` micro-scenarios use scenario `success-rate` in the header.
+
+## Experiment 4: demo-regularized late-chain transfer, 2026-06
+
+### Artifacts
+
+- Local experiment dir: `training/experiments/experiment4`
+- Run dir: `training/experiments/experiment4/runs/experiment4-circuit/0`
+- Tracked summary: `docs/experiments/experiment4-summary.md`
+- Load checkpoint: `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt`
+- Final model: `training/experiments/experiment4/runs/experiment4-circuit/0/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment4/runs/experiment4-circuit/0/checkpoints/impala-multihead_all-items_dungeon1-finite-bombs_4280320.pt`
+- Demo trace: `docs/experiments/demos/wallmaster-north-exit.txt`
+
+### Changes tested
+
+- Fixed `evaluate.py` to report scenario `metrics.success-rate` for micro-scenarios.
+- Added shared demo helpers in `triforce/demo.py`.
+- Refactored `diagnose.py` and `scripts/behavior_clone.py` to use shared demo helpers.
+- Added policy-only demo BC regularization to PPO with `--demo-trace`, `--demo-scenario`, `--demo-prefix-east`, and `--demo-bc-coeff`.
+- Added `experiment4-late-chain-demo` weighted circuit and `experiment4-circuit`.
+
+### Training outcome
+
+- `[circuit] experiment4-late-chain-demo`: budget exhausted, wallmaster exit metric `0.292806 < 0.5`.
+- `dungeon1-finite-bombs`: budget exhausted, `success-rate=0.0 < 0.1`.
+- Demo retention stayed active through the run: final stats `charts/demo_bc_accuracy=1.0`, `losses/demo_bc_loss=0.002919394988566637`.
+
+### Final eval
+
+- `dungeon1-wallmaster-north-exit`: `success-rate=1.0` over 100 episodes, median progress `10/11`, P25/P50/P75/P90 `10 / 10 / 10 / 10`.
+- `dungeon1-late-chain`: `success-rate=0.0` over 100 episodes, median progress `10/11`, P25/P50/P75/P90 `8 / 10 / 10 / 10`, JSON metrics `room-progress=14.77`, `progress/max=16`.
+- `dungeon1-finite-bombs`: `success-rate=0.0` over 40 episodes, progress values all `7/7`, JSON metrics `room-progress=9.875`, `progress/max=10`.
+
+### Classification
+
+Partial success. Demo-regularized PPO retained and improved the wallmaster route, raising final wallmaster eval from Experiment 3 `0.24` to `1.0`. Late-chain transfer improved only by partial criteria: median progress improved from `9/11` to `10/11` and progress `16` remained reachable, but no late-chain or finite-bombs completions occurred.
+
+### Next recommended experiment
+
+Keep demo-regularized PPO and the reporting fix. Do not use the Experiment 4 final model as a dungeon-solving checkpoint except for wallmaster-retention evidence. Add a late-chain/boss/triforce demonstration or separate rehearsal signal after the wallmaster north exit; the wallmaster-only demo is too narrow to teach Aquamentus and Triforce completion.

--- a/docs/experiments/experiment-memory.md
+++ b/docs/experiments/experiment-memory.md
@@ -1,0 +1,143 @@
+# Triforce experiment memory
+
+Purpose: tracked, compact context for future Triforce training experiments. Read this before scoping a new experiment; append one similarly terse record after each completed run. Keep raw checkpoints, TensorBoard events, full status histories, and logs out of git.
+
+## Protocol for future runs
+
+Before starting a new experiment:
+
+1. Read this file.
+2. Pick a baseline checkpoint/eval from the most recent relevant record.
+3. State what “better than baseline” means using concrete metrics.
+4. Write the experiment journal with load checkpoint, scenario/circuit, code/config changes, success criteria, and final eval scenario/episode count.
+
+After finishing a run:
+
+1. Run final evaluation on the agreed eval scenario.
+2. Append a compact record here.
+3. Link the full tracked summary file in `docs/experiments/` plus local run artifacts under `training/experiments/`.
+4. Do not paste full journals, full status JSON, TensorBoard event dumps, or raw logs.
+
+## Baseline: all-items-circuit, 2026-06
+
+### Artifacts
+
+- Local experiment dir: `training/experiments/baseline`
+- Local run dir: `training/experiments/baseline/runs/all-items-circuit/0`
+- Tracked summary: `docs/experiments/baseline-summary.md`
+- Harness monitoring notes: `docs/experiments/harness-monitoring-followup.md`
+- Scenario/circuit: `all-items-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Final checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.pt`
+- Best pre-dungeon checkpoint candidate: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_learn-items_2199552.pt`
+- Final eval JSON: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.eval.json`
+- Final eval report: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.eval.md`
+
+### Final eval baseline
+
+Command:
+
+```bash
+source .venv/bin/activate
+python evaluate.py training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.pt full-game-all-items-finite --episodes 100 --reprocess
+```
+
+Result:
+
+- Success rate: `0/100`
+- Median progress: `13/17`
+- P25/P50/P75/P90: `11 / 13 / 13 / 13`
+- Milestone histogram: 65 episodes at progress `13`, 3 episodes at `14`, none at `15-17`
+- Final eval metrics: `room-progress=12.08`, `rewards=43.1278`
+- Endings: `failure-terminated-death=0.94`, `failure-no-progress=0.03`, `failure-stuck=0.03`
+
+This is “normal” until beaten: the model reaches mid-late Dungeon 1 but does not clear the late route or survive.
+
+### What worked
+
+- Overworld navigation works: `overworld-room-walk` exited early with `room-result/correct-exit=0.801587 >= 0.8`.
+- Sword acquisition works: `overworld-sword` exited early with `success-rate=1.0 >= 0.8`.
+- Item/overworld route training partially works: `[circuit] learn-items` ended with `overworld-skip-sword-all-items/success-rate=0.6875`, `room-result/correct-exit=0.881808`, `room-progress=4.8125`, `rewards=13.3107`.
+- Full-game training learned partial progress: `full-game-all-items` reached `room-progress=12.4504`, `progress/max=14`, `rewards=42.6121`, but `success-rate=0.0`.
+
+### Where normal fails
+
+Recurring blocker: late Dungeon 1 route `1_43 -> 1_44 -> 1_45 -> 1_35 -> 1_36`.
+
+Progress map:
+
+- `13`: room `1_43`
+- `14`: room `1_44` Red Goriya room
+- `15`: room `1_45` Wallmaster room
+- `16`: room `1_35` Aquamentus boss
+- `17`: room `1_36` Triforce room
+
+Final eval piles up at progress `13`. The model usually reaches `1_43`, rarely reaches `1_44`, and never reaches `1_45+` in final evaluation.
+
+First clear training derail:
+
+- `dungeon1-all-items` ended with `success-rate=0.0`, `failure-terminated-death=1.0`, `failure-stuck=0.972222`, `failure-no-progress=0.96875`.
+- `dungeon1-wallmaster` then showed severe policy/update collapse: entropy near zero, clipfrac near zero, KL near zero, value loss near zero, success `0.0`.
+
+### Root-cause hypotheses carried into Experiment 1
+
+1. Hard failures were underpriced: death/stuck/no-progress/wallmastered could be net-positive after progress/PBRS/combat rewards.
+2. `penalty-wall-master` was likely skipped when wallmaster teleport moved Link to a non-wallmaster room before critic evaluation.
+3. Wallmaster static danger tile shaping conflicted with the intended north exit from room `1_45`.
+4. Key/locked-door routing is a complexity spike around progress `13`.
+5. Baseline polish was too broad to repair the bottleneck.
+
+### Baseline metrics to beat
+
+Minimum improvement:
+
+- Final eval `full-game-all-items-finite`: success rate > `0/100`.
+- Fewer than 65/100 episodes stuck at milestone `13`.
+- Any episodes reach milestones `15`, `16`, or `17`.
+- Death rate below `94%`.
+- Wallmastered episodes include `penalty-wall-master` and are not net positive.
+
+## Experiment 1: focused late-Dungeon-1 curriculum, 2026-06
+
+### Artifacts
+
+- Local experiment dir: `training/experiments/experiment1`
+- Local run dir: `training/experiments/experiment1/runs/experiment1-circuit/0`
+- Tracked summary: `docs/experiments/experiment1-summary.md`
+- Load checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_learn-items_2199552.pt`
+- Final model: `training/experiments/experiment1/runs/experiment1-circuit/0/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment1/runs/experiment1-circuit/0/checkpoints/impala-multihead_all-items_full-game-all-items-finite_6709248.pt`
+
+### Changes tested
+
+- Terminal hard failures can return down to `-20.0` while normal rewards still clamp to `[-1, 1]`.
+- `failure-wallmastered` gets `penalty-wall-master` even when wallmaster grab teleports Link to a non-wallmaster room.
+- Wallmaster static danger tile shaping skips objective/exit tiles.
+- Added focused late-Dungeon-1 scenarios and `experiment1-circuit`.
+
+### Training outcome
+
+- `[circuit] dungeon1-endgame-skills`: budget exhausted, exit metric `0.05 < 0.7`.
+- `dungeon1-finite-bombs`: budget exhausted, exit metric `0.0 < 0.2`.
+- `full-game-all-items-finite`: budget exhausted, exit metric `0.0 < 0.1`.
+- Reward accounting worked: hard failures were negative throughout and wallmaster penalties appeared.
+- Training quality failed: focused skills did not transfer to full-game finite.
+
+### Final eval comparison
+
+Final eval used 40 episodes due runtime constraints.
+
+- `full-game-all-items-finite`: `0/40`, median `3/17`, P25/P50/P75/P90 `3 / 3 / 4 / 4`.
+- Baseline was `0/100`, median `13/17`; Experiment 1 regressed full-game progress.
+- `dungeon1-wallmaster-north-exit`: `0/40`, median `9/11`.
+- `dungeon1-aquamentus-east`: `0/40`, median `10/11`.
+- `dungeon1-late-chain`: `0/40`, median `9/11`.
+
+### Current bottleneck after Experiment 1
+
+The reward-accounting bug is fixed, but success is still not attractive/learnable enough in focused `ReachLocation` scenarios. The model often approaches targets but does not complete them, then terminal penalties dominate and full-game transfer collapses early.
+
+### Next recommended experiment
+
+Keep the reward-accounting fixes. Do not continue from the Experiment 1 final checkpoint. Start from `impala-multihead_all-items_learn-items_2199552.pt`, add an explicit terminal success reward, run `dungeon1-room-walk` briefly to expose dungeon geometry, then train `dungeon1-wallmaster-north-exit` as a single micro-scenario.

--- a/docs/experiments/experiment1-summary.md
+++ b/docs/experiments/experiment1-summary.md
@@ -1,0 +1,74 @@
+# Experiment 1 summary
+
+## Run
+
+- Experiment: `experiment1`
+- Local run dir: `training/experiments/experiment1/runs/experiment1-circuit/0`
+- Scenario/circuit: `experiment1-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Load checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_learn-items_2199552.pt`
+- Final model: `training/experiments/experiment1/runs/experiment1-circuit/0/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment1/runs/experiment1-circuit/0/checkpoints/impala-multihead_all-items_full-game-all-items-finite_6709248.pt`
+- Final state: `complete`
+
+## Changes tested
+
+- Terminal hard failures can return down to `-20.0` while ordinary rewards still clamp to `[-1, 1]`.
+- `failure-wallmastered` gets `penalty-wall-master` even when wallmaster grab teleports Link to a non-wallmaster room.
+- Wallmaster danger tile shaping skips objective/exit tiles.
+- Added focused late-Dungeon-1 scenarios and circuits:
+  - `dungeon1-red-goriya-east`
+  - `dungeon1-wallmaster-north-exit`
+  - `dungeon1-aquamentus-east`
+  - `dungeon1-late-chain`
+  - `dungeon1-endgame-skills`
+  - `experiment1-circuit`
+
+## Verification before training
+
+- `pytest tests/reward_test.py -v`: passed, 11 tests.
+- `pytest tests/test_multihead_config.py tests/test_weighted_circuits.py tests/test_experiment1_config.py -v`: passed, 36 tests.
+- Scenario smoke check reset and stepped all four focused scenarios.
+
+## Training result
+
+All legs completed by budget, not exit criterion:
+
+| Leg | Final metric | Threshold | Result |
+|---|---:|---:|---|
+| `[circuit] dungeon1-endgame-skills` | `success-rate=0.05` | `0.7` | missed |
+| `dungeon1-finite-bombs` | `success-rate=0.0` | `0.2` | missed |
+| `full-game-all-items-finite` | `success-rate=0.0` | `0.1` | missed |
+
+Useful findings:
+
+- Reward accounting worked: hard terminal failures became negative-return throughout the run.
+- Wallmastered failures showed `penalty-wall-master` when present.
+- Focused skills produced some targeted signal but not enough:
+  - `dungeon1-red-goriya-east` reached nonzero success during training, peaking around `success-reached-location=0.120833` in milestone summaries.
+  - `dungeon1-late-chain` reached `progress/max=15` in training windows but did not produce stable success.
+  - `dungeon1-aquamentus-east` often reached high `room-progress` but did not complete.
+- Transfer to `dungeon1-finite-bombs` failed: final training sample had `success-rate=0.0`, `room-progress=11.3`, `progress/max=13`, and hard failures remained negative.
+- Transfer to `full-game-all-items-finite` failed badly: final training sample had `success-rate=0.0`, `room-progress=3.08333`, `progress/max=4`, and all main endings showed failure.
+
+## Final evaluation
+
+Final eval used 40 episodes due runtime constraints.
+
+| Eval scenario | Success | Median progress | P25/P50/P75/P90 | Notes |
+|---|---:|---:|---|---|
+| `full-game-all-items-finite` | `0/40` | `3/17` | `3 / 3 / 4 / 4` | worse than baseline median `13/17` |
+| `dungeon1-wallmaster-north-exit` | `0/40` | `9/11` | `9 / 9 / 9 / 9` | never reached objective |
+| `dungeon1-aquamentus-east` | `0/40` | `10/11` | `10 / 10 / 10 / 10` | reaches near objective but does not complete |
+| `dungeon1-late-chain` | `0/40` | `9/11` | `8 / 9 / 9 / 10` | partial route progress, no success |
+
+## Classification
+
+Experiment 1 result: `failure`.
+
+The reward-accounting fix worked, but the focused curriculum did not teach completion and damaged full-game transfer.
+
+## Next direction
+
+Keep reward-accounting fixes. Do not continue from the Experiment 1 final checkpoint. Start again from `impala-multihead_all-items_learn-items_2199552.pt`, add explicit success reward for `ReachedLocation`/terminal success, briefly acclimate with `dungeon1-room-walk`, then train one micro-scenario: `dungeon1-wallmaster-north-exit`.

--- a/docs/experiments/experiment2-summary.md
+++ b/docs/experiments/experiment2-summary.md
@@ -1,0 +1,60 @@
+# Experiment 2 summary
+
+## Run
+
+- Experiment: `experiment2`
+- Valid local run dir: `training/experiments/experiment2/runs/experiment2-circuit/3`
+- Scenario/circuit: `experiment2-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Load checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_learn-items_2199552.pt`
+- Final model: `training/experiments/experiment2/runs/experiment2-circuit/3/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment2/runs/experiment2-circuit/3/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_3203072.pt`
+
+## Changes tested
+
+- Moved compact experiment records into tracked `docs/experiments/`.
+- Added `reward-terminal-success` so successful terminal steps can return up to `+20.0`.
+- Kept Experiment 1 hard-failure accounting: hard terminal failures can return down to `-20.0`; ordinary rewards still clamp to `[-1, 1]`.
+- Added `experiment2-circuit`:
+  1. `dungeon1-room-walk`, 500k, exit `room-result/correct-exit >= 0.8`
+  2. `dungeon1-wallmaster-north-exit`, 750k, exit `success-rate >= 0.5`
+- Fixed `RoomWalk._handle_room_change` fallback crash discovered during this run.
+- Changed default anomaly check interval to `125,000` steps.
+
+## Training result
+
+- `dungeon1-room-walk`: completed by exit criterion at 253,952 / 503,808 steps with `room-result/correct-exit=0.816667`.
+- `dungeon1-wallmaster-north-exit`: budget exhausted at 753,664 / 753,664 steps with `success-rate=0.0`.
+- Wallmaster final training sample: `failure-wallmastered=1.0`, `failure-stuck=1.0`, `failure-no-progress=1.0`, `room-progress=9.0`, `rewards=-43.5498`.
+- Reward accounting worked: final wallmaster sample included `penalty-wall-master=-1.04167` and `penalty-terminal-failure=-2.08333`.
+
+## Final evaluation
+
+Final eval used 40 episodes for each requested scenario because 100-episode wallmaster evaluation exceeded a one-hour command window.
+
+| Eval scenario | Success | Median progress | P25/P50/P75/P90 | Notes |
+|---|---:|---:|---|---|
+| `dungeon1-wallmaster-north-exit` | `0/40` | `9/11` | `9 / 9 / 9 / 9` | unchanged from Experiment 1 wallmaster eval |
+| `dungeon1-room-walk` | `0/40` | `9/11` | `9 / 9 / 9 / 9` | eval artifact appears overwritten/incorrectly labeled; treat as inconclusive |
+| `dungeon1-late-chain` | `0/40` | `9/11` | `8 / 9 / 9 / 10` | partial route progress, no success |
+
+## Classification
+
+Experiment 2 result: `failure`.
+
+- Wallmaster north-exit eval success remained `0/40`.
+- Median wallmaster progress stayed `9/11`.
+- Wallmaster failures were correctly negative, but learning did not improve.
+
+## Interpretation
+
+Explicit terminal success reward and room-walk acclimation were not enough. The model can reacquire generic dungeon room exits, but `1_45w -> 1_35` remains unsolved. This points to a wallmaster scenario/objective/reachability issue rather than simply missing success reward.
+
+## Next direction
+
+Do not continue from Experiment 2 final checkpoint. Keep reward-accounting and success-reward changes. Before more training:
+
+1. Verify by scripted/manual controller actions that `1_45w -> 1_35` is reachable and that `ReachedLocation` fires success.
+2. If reachability works, create an easier wallmaster variant: start closer to the north exit or reduce wallmaster pressure if a safe RAM/state setup exists.
+3. If reachability or success detection fails, fix `ReachedLocation`/objective detection before rerunning.

--- a/docs/experiments/experiment3-summary.md
+++ b/docs/experiments/experiment3-summary.md
@@ -1,0 +1,63 @@
+# Experiment 3 summary
+
+## Run
+
+- Experiment: `experiment3`
+- Valid run dir: `training/experiments/experiment3/runs/experiment3-circuit/1`
+- Circuit: `experiment3-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Behavior-cloned checkpoint: `training/experiments/experiment3/wallmaster-bc-1000.pt`
+- Final model: `training/experiments/experiment3/runs/experiment3-circuit/1/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt`
+
+## Changes tested
+
+- Added tracked expert demo: `docs/experiments/demos/wallmaster-north-exit.txt`.
+- Added demo reachability validation to `diagnose.py`.
+- Added behavior cloning script: `scripts/behavior_clone.py`.
+- Added `experiment3-circuit`, a single `dungeon1-wallmaster-north-exit` fine-tune leg.
+
+## Demo and behavior cloning
+
+- Demo validation succeeded with `prefix_east=0`.
+- Demo final room: `1:0x35`.
+- Demo ending: `success-reached-location`.
+- Demo had `reward-terminal-success=True`.
+- 400-epoch BC achieved exact action accuracy `1.0`, but PPO later destroyed the behavior.
+- 1000-epoch BC achieved exact action accuracy `1.0` and was used for the final valid run.
+
+## Training result
+
+Run `1` completed by exit criterion:
+
+- `success-rate=0.568353 >= 0.5`
+- steps: `77,824 / 753,664`
+- `success-reached-location=0.607923`
+- `room-progress=9.56835`
+- `rewards=4.64348`
+- `failure-wallmastered=0.460524`
+- `failure-stuck=0.270833`
+- `reward-terminal-success=17.9167`
+- `penalty-wall-master=-16.25`
+
+## Final evaluation
+
+| Eval scenario | Scenario metric success | Generic report success | Median progress | P25/P50/P75/P90 | Notes |
+|---|---:|---:|---:|---|---|
+| `dungeon1-wallmaster-north-exit` | `0.24` | `0/100` | `9/11` | `9 / 9 / 9 / 10` | scenario metric is authoritative for this `ReachedLocation` micro-scenario |
+| `dungeon1-late-chain` | `0.0` | `0/40` | `9/11` | `8 / 9 / 10 / 10` | no completion, but JSON metrics reached `room-progress=14.75`, `progress/max=16` |
+
+The wallmaster eval Markdown reports `0/100` because the generic progress histogram does not count micro-scenario `success-rate`. The JSON metrics record `success-rate=0.24`, `reward-terminal-success=20.0`, and `endings/success-reached-location=0.24`; use the JSON metric for this scenario.
+
+## Classification
+
+Experiment 3 result: `partial success`.
+
+- Final wallmaster eval success improved from Experiment 2 `0.0` to `0.24`.
+- Training hit the `0.5` threshold and exited early.
+- Late-chain still did not complete.
+
+## Next direction
+
+Behavior cloning works and should be retained. Next experiment should start from `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt` and add demo regularization during PPO or periodic BC rehearsal so PPO does not drift away from the safe wallmaster route. Then train a late-chain curriculum that alternates demo rehearsal, wallmaster-north-exit, and `dungeon1-late-chain`.

--- a/docs/experiments/experiment4-summary.md
+++ b/docs/experiments/experiment4-summary.md
@@ -1,0 +1,65 @@
+# Experiment 4 summary
+
+## Run
+
+- Experiment: `experiment4`
+- Run dir: `training/experiments/experiment4/runs/experiment4-circuit/0`
+- Circuit: `experiment4-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Load checkpoint: `training/experiments/experiment3/runs/experiment3-circuit/1/checkpoints/impala-multihead_all-items_dungeon1-wallmaster-north-exit_2273280.pt`
+- Demo trace: `docs/experiments/demos/wallmaster-north-exit.txt`
+- Demo coefficient: `0.1`
+- Final model: `training/experiments/experiment4/runs/experiment4-circuit/0/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment4/runs/experiment4-circuit/0/checkpoints/impala-multihead_all-items_dungeon1-finite-bombs_4280320.pt`
+
+## Changes tested
+
+- Fixed `evaluate.py` Markdown/console reporting for micro-scenarios by using JSON `metrics.success-rate` when present.
+- Added shared demo utilities in `triforce/demo.py`.
+- Refactored `diagnose.py` and `scripts/behavior_clone.py` to use shared demo helpers.
+- Added optional policy-only demo behavior-cloning loss to PPO updates.
+- Added train CLI flags for demo regularization.
+- Added `experiment4-late-chain-demo` and `experiment4-circuit`.
+
+## Training result
+
+Run `0` completed both planned legs by budget exhaustion:
+
+| Leg | Result | Steps | Exit metric |
+|---|---|---:|---:|
+| `[circuit] experiment4-late-chain-demo` | budget exhausted | `1,503,232 / 1,503,232` | wallmaster `success-rate=0.292806 < 0.5` |
+| `dungeon1-finite-bombs` | budget exhausted | `503,808 / 503,808` | `success-rate=0.0 < 0.1` |
+
+Final training sample retained demo behavior but did not solve the final leg:
+
+- `success-rate=0.0` on `dungeon1-finite-bombs`.
+- `room-progress=9.1875`.
+- `progress/max=10`.
+- `endings/failure-no-progress=1.0`.
+- `endings/failure-stuck=0.916667`.
+- `endings/failure-terminated-death=0.75`.
+- Demo retention remained active: `charts/demo_bc_accuracy=1.0`, `losses/demo_bc_loss=0.002919394988566637`.
+
+## Final evaluation
+
+| Eval scenario | Scenario metric success | Report success | Median progress | P25/P50/P75/P90 | Notes |
+|---|---:|---:|---:|---|---|
+| `dungeon1-wallmaster-north-exit` | `1.0` | `100/100` | `10/11` | `10 / 10 / 10 / 10` | wallmaster retention improved from Experiment 3 `0.24` |
+| `dungeon1-late-chain` | `0.0` | `0/100` | `10/11` | `8 / 10 / 10 / 10` | no completion; JSON metrics reached `room-progress=14.77`, `progress/max=16` |
+| `dungeon1-finite-bombs` | `0.0` | `0/40` | `7/7` | `7 / 7 / 7 / 7` | no completion; all episodes reached reported max progress but scenario success stayed `0.0` |
+
+## Classification
+
+Experiment 4 result: `partial success`.
+
+- Demo-regularized PPO solved retention: final wallmaster eval improved from Experiment 3 `success-rate=0.24` to `1.0`.
+- Late-chain transfer met only the partial-success bar: wallmaster eval stayed above `0.2`, late-chain median progress improved from `9/11` to `10/11`, and `progress/max=16` remained reachable.
+- Late-chain completion stayed `0.0`.
+- Finite-bombs completion stayed `0.0`.
+
+## Next direction
+
+Keep the demo-regularized PPO machinery and evaluation reporting fix. Do not use the Experiment 4 final model as a dungeon-solving checkpoint except for wallmaster-retention evidence.
+
+Next experiment should add late-chain demonstration coverage or a separate rehearsal signal after `1_45 -> 1_35`. The wallmaster-only demo regularizer preserves the route into Aquamentus but does not teach boss/triforce completion.

--- a/docs/experiments/experiment5-summary.md
+++ b/docs/experiments/experiment5-summary.md
@@ -1,0 +1,69 @@
+# Experiment 5 summary
+
+## Run
+
+- Experiment: `experiment5`
+- Final run dir: `training/experiments/experiment5/runs/experiment5-circuit/4`
+- Circuit: `experiment5-circuit`
+- Action space: `all-items`
+- Model kind: `impala-multihead`
+- Initial load model: `training/experiments/experiment4/runs/experiment4-circuit/0/impala-multihead_all-items.pt`
+- Recovery load checkpoint: `training/experiments/experiment5/runs/experiment5-circuit/3/checkpoints/impala-multihead_all-items_experiment5-boss-transfer_7331840.pt`
+- Demo trace: `docs/experiments/demos/wallmaster-north-exit.txt`
+- Demo coefficient: `0.05`
+- Final model: `training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.pt`
+- Final checkpoint: `training/experiments/experiment5/runs/experiment5-circuit/4/checkpoints/impala-multihead_all-items_dungeon1-late-chain_8335360.pt`
+
+## Changes tested
+
+- Added `experiment5-boss-transfer`, initially weighted `20 / 60 / 20` across wallmaster, Aquamentus, and late-chain scenarios.
+- Added `experiment5-circuit`, with boss-transfer followed by a focused `dungeon1-late-chain` leg.
+- Added `tests/test_experiment5_config.py`.
+- Reweighted `experiment5-boss-transfer` to `10 / 80 / 10` after wallmaster retention stayed healthy and Aquamentus success remained `0.0` after more than 1,000,000 steps.
+
+## Training outcome
+
+Final run leg outcome:
+
+| Leg | Result | Steps | Exit metric |
+|---|---|---:|---:|
+| `[circuit] experiment5-boss-transfer` | inherited complete from run `3` checkpoint | `2,002,944 / 2,000,000` | wallmaster `success-rate=0.860073 >= 0.8` |
+| `dungeon1-late-chain` | budget exhausted | `1,003,520 / 1,003,520` | `success-rate=0.0 < 0.1` |
+
+Final training sample on `dungeon1-late-chain`:
+
+- `success-rate=0.0`
+- `progress/max=14`
+- `room-progress=14.0`
+- `endings/failure-no-progress=0.75`
+- `endings/failure-stuck=0.5`
+- `endings/failure-terminated-death=1.0`
+- `endings/failure-wallmastered=1.0`
+- demo retention stats remained present: `charts/demo_bc_accuracy=1.0`, `losses/demo_bc_loss=0.0010404533240944147`, `charts/demo_bc_coeff=0.05`
+
+## Final evaluation
+
+Evaluations used the OMP evaluation plugin.
+
+| Eval scenario | Plugin result | JSON path | Scenario success | Report progress | P25/P50/P75/P90 | Notes |
+|---|---|---|---:|---:|---|---|
+| `dungeon1-wallmaster-north-exit` | completed | `training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.dungeon1-wallmaster-north-exit.eval.json` | `1.0` | max `10/11` | `10 / 10 / 10 / 10` | wallmaster retention preserved |
+| `dungeon1-aquamentus-east` | completed | `training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.dungeon1-aquamentus-east.eval.json` | `0.0` | max `10/11` | `10 / 10 / 10 / 10` | all episodes ended `failure-left-boss-room` |
+| `dungeon1-late-chain` | plugin reported completion but produced no JSON/Markdown after stale artifacts were removed | none | unavailable | unavailable | unavailable | recorded as evaluation-plugin failure; no direct `evaluate.py` fallback was run |
+
+No late-chain comparison was run because the plugin did not produce a candidate late-chain `.eval.json`.
+
+## Classification
+
+Experiment 5 result: `failure`.
+
+- Wallmaster retention stayed solved: final wallmaster eval `success-rate=1.0`.
+- Boss transfer failed: final Aquamentus eval `success-rate=0.0`, `endings/failure-left-boss-room=1.0`.
+- Late-chain training regressed in the final sample: `progress/max=14`, below Experiment 4's final eval `progress/max=16`, with `success-rate=0.0`.
+- Final late-chain plugin evaluation failed to produce artifacts, so no final late-chain eval metric or statistical comparison is available.
+
+## Decision
+
+Do not keep `experiment5-circuit` as a useful curriculum. Heavier Aquamentus weighting did not teach boss completion and appears to bias the policy toward leaving the boss room.
+
+Next experiment should diagnose `dungeon1-aquamentus-east` before another long run: inspect action/reward traces around `failure-left-boss-room`, then adjust objective/end-condition/reward shaping for boss engagement. Do not add another weight-only curriculum until that failure mode is understood.

--- a/docs/experiments/harness-monitoring-followup.md
+++ b/docs/experiments/harness-monitoring-followup.md
@@ -1,0 +1,75 @@
+# Triforce harness monitoring follow-up
+
+Audience: next agent working on the Oh My Pi Triforce experiment harness.
+
+Question answered: how can the next run be more successful from a monitoring/supervision standpoint?
+
+## Baseline evidence
+
+Run: `training/experiments/baseline/runs/all-items-circuit/0`
+
+The baseline completed end-to-end:
+
+- Final state in `status.json`: `complete`
+- Final checkpoint: `training/experiments/baseline/runs/all-items-circuit/0/checkpoints/impala-multihead_all-items_all-items-polish_10719232.pt`
+- Final eval: `0/100` successes, median progress `13/17`
+- Eval outputs are local under the final checkpoint path.
+
+Harness verdict: pass overall. The issues below are monitoring/reporting improvements, not blockers observed during training.
+
+## Fixes needed before future runs
+
+### Suppress `process_disappeared` after normal completion
+
+A post-completion wake reported `process_disappeared`, but `status.json` already had `state: complete` and stdout showed normal final output. If the pid disappears and latest status is complete, emit a terminal completion wake or no failure. Do not classify normal process exit as failure.
+
+### Add terminal `complete` wake
+
+Completion should be distinct from `leg_end` and should include final model path, final checkpoint path, run dir, final status, final eval command, and baseline comparison config.
+
+### Make final progress and ETA unambiguous
+
+When `state: complete`, status should report `pct: 100.0` and `eta_seconds: 0` or `null`. Keep planned-vs-actual counters separately if useful.
+
+### Record leg completion reason as structured data
+
+Each leg should state `completion_reason`, `exit_metric_value`, `exit_metric_threshold`, and `exit_metric_met`. Leg-end wakes should say whether the leg ended by exit criterion or budget.
+
+### Add final evaluation metadata to circuits
+
+Circuit config or run metadata should expose `final_eval_scenario`, `final_eval_episodes`, and optional `baseline_eval_json`. Completion wake should print the exact final eval command.
+
+### Reduce anomaly wake noise with trend-aware grouping
+
+Repeated mild health misses should be grouped as `persistent_anomaly` unless a severity/trend threshold changes. Keep hard wakes for process, checkpoint, log, status, or control failures.
+
+### Separate harness health from training health
+
+Every wake should show process/state/checkpoint/control/log freshness separately from PPO/model metrics so agents can distinguish harness failures from training-health issues quickly.
+
+### Link logs robustly
+
+Only link logs that exist. If stderr was never created, say so explicitly. Include final stdout line in process-exit wakes.
+
+### Mark stale/queued wakes
+
+Every wake should include monotonic `milestone_id`, `status_updated_at`, and `status_hash`. Stale queued wakes should say they are stale and point at newest status.
+
+### Compact metric reporting
+
+Top-level wake should show key exit-owner metric, progress, reward, endings, and health anomalies. Full nested scenario metrics should be linked as JSON instead of flooding the prompt.
+
+## Monitoring success criteria
+
+A better next run from a monitoring standpoint satisfies:
+
+1. No false process-failure wake after normal completion.
+2. Clear terminal completion wake with final checkpoint and eval instructions.
+3. Final status shows `state: complete`, `pct: 100`, and no nonzero ETA.
+4. Every leg-end milestone states whether it ended by metric or budget.
+5. Final eval scenario and command are discoverable.
+6. Repeated model-health threshold misses are grouped or trend-gated.
+7. Harness-health failures remain immediate and actionable.
+8. Wakes never link missing log files.
+9. Queued/stale wake status is explicit.
+10. Metric-heavy reports link full detail instead of flooding the prompt.

--- a/docs/experiments/triforce-experiment-skill-addendum.md
+++ b/docs/experiments/triforce-experiment-skill-addendum.md
@@ -1,0 +1,46 @@
+# Triforce experiment skill addendum
+
+This repo-local addendum captures Triforce experiment-memory protocol that should be folded into the `triforce-experiment` skill when skill files are editable.
+
+## Before starting any Triforce training experiment
+
+Read:
+
+1. `docs/experiments/experiment-memory.md`
+2. The most relevant prior `docs/experiments/<experiment-id>-summary.md`
+3. Any referenced eval `.md`/`.json` files for the baseline checkpoint being compared against, if available locally
+
+Then state in `training/experiments/<experiment-id>/journal.md`:
+
+- baseline checkpoint/eval path
+- what metric must improve
+- whether the experiment starts from scratch or a checkpoint
+- final eval scenario and episode count
+
+## After finishing any Triforce training experiment
+
+Append a compact record to `docs/experiments/experiment-memory.md` with:
+
+- experiment id and run path
+- final checkpoint
+- final eval command and artifacts
+- success rate and progress distribution
+- what improved or regressed versus the prior baseline
+- current bottleneck
+- next recommended experiment
+
+Do not paste the full journal. Link full artifacts instead. Keep large artifacts under gitignored `training/experiments/`.
+
+## Current baseline pointer
+
+Current baseline record:
+
+`docs/experiments/experiment-memory.md#baseline-all-items-circuit-2026-06`
+
+Key baseline to beat:
+
+- Eval scenario: `full-game-all-items-finite`
+- Eval episodes: `100`
+- Success: `0/100`
+- Median progress: `13/17`
+- Main bottleneck: late Dungeon 1, especially `1_43 -> 1_44 -> 1_45 -> 1_35 -> 1_36`

--- a/evaluate.py
+++ b/evaluate.py
@@ -13,7 +13,8 @@ from triforce import ActionSpaceDefinition, ModelKindDefinition, make_zelda_env,
     TrainingScenarioDefinition, MetricTracker
 
 
-def write_progress_markdown(md_path, progress_values, max_progress, episodes, scenario_name, model_name=None, *, metrics=None):
+def write_progress_markdown(md_path, progress_values, max_progress, episodes, scenario_name,
+                            model_name=None, *, metrics=None):
     """Writes a progress report as a markdown file."""
     if not progress_values:
         return

--- a/evaluate.py
+++ b/evaluate.py
@@ -13,7 +13,7 @@ from triforce import ActionSpaceDefinition, ModelKindDefinition, make_zelda_env,
     TrainingScenarioDefinition, MetricTracker
 
 
-def write_progress_markdown(md_path, progress_values, max_progress, episodes, scenario_name, model_name=None):
+def write_progress_markdown(md_path, progress_values, max_progress, episodes, scenario_name, model_name=None, *, metrics=None):
     """Writes a progress report as a markdown file."""
     if not progress_values:
         return
@@ -21,6 +21,12 @@ def write_progress_markdown(md_path, progress_values, max_progress, episodes, sc
     sorted_vals = sorted(progress_values)
     n = len(sorted_vals)
     success_count = sum(1 for v in sorted_vals if v >= max_progress)
+    metric_success_rate = metrics.get("success-rate") if metrics else None
+    if metric_success_rate is not None:
+        success_count = round(metric_success_rate * n)
+        success_suffix = f" (scenario success-rate; reached milestone {max_progress})"
+    else:
+        success_suffix = f" (reached milestone {max_progress})"
     counts = Counter(sorted_vals)
     max_count = max(counts.values()) if counts else 1
 
@@ -31,7 +37,7 @@ def write_progress_markdown(md_path, progress_values, max_progress, episodes, sc
         f.write(f"# {title}\n\n")
         f.write(f"- **Episodes**: {episodes}\n")
         f.write(f"- **Success rate**: {success_count}/{n} ({100*success_count/n:.0f}%)"
-                f" (reached milestone {max_progress})\n")
+                f"{success_suffix}\n")
         f.write(f"- **Median progress**: {sorted_vals[n//2]}/{max_progress}\n")
         f.write(f"- **P25**: {sorted_vals[max(0, ceil(n*0.25)-1)]}  "
                 f"**P50**: {sorted_vals[n//2]}  "
@@ -62,12 +68,13 @@ def convert_eval_json_to_md(json_path):
         data['episodes'],
         data['scenario'],
         model_name=model_name,
+        metrics=data.get('metrics'),
     )
     return md_path
 
 
 def print_progress_report(progress_values : List[int], max_progress : int,
-                          episodes : int, scenario_name : str):
+                          episodes : int, scenario_name : str, metrics=None):
     """Prints a progress-focused evaluation report with percentiles and histogram."""
     if not progress_values:
         print("No progress data collected.")
@@ -76,12 +83,18 @@ def print_progress_report(progress_values : List[int], max_progress : int,
     sorted_vals = sorted(progress_values)
     n = len(sorted_vals)
     success_count = sum(1 for v in sorted_vals if v >= max_progress)
+    metric_success_rate = metrics.get("success-rate") if metrics else None
+    if metric_success_rate is not None:
+        success_count = round(metric_success_rate * n)
+        success_suffix = f"  (scenario success-rate; reached milestone {max_progress})"
+    else:
+        success_suffix = f"  (reached milestone {max_progress})"
 
     print(f"\n{'='*60}")
     print(f"  Evaluation: {episodes} episodes of {scenario_name}")
     print(f"{'='*60}")
     print(f"  Success rate: {success_count}/{n} ({100*success_count/n:.0f}%)"
-          f"  (reached milestone {max_progress})")
+          f"{success_suffix}")
     print(f"  Median progress: {sorted_vals[n//2]}/{max_progress}")
     print(f"  P25: {sorted_vals[max(0, ceil(n*0.25)-1)]:>3}  "
           f"P50: {sorted_vals[n//2]:>3}  "
@@ -347,7 +360,7 @@ def main():
             with open(json_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             print_progress_report(data['progress_values'], data['max_progress'],
-                                  data['episodes'], args.scenario)
+                                  data['episodes'], args.scenario, data.get('metrics'))
 
 
 def _save_results(path, metrics, progress_values, max_progress, episodes, scenario):

--- a/scripts/behavior_clone.py
+++ b/scripts/behavior_clone.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Behavior-clone a Triforce policy from a short expert movement trace."""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from diagnose import demo_action_to_indices, is_demo_action_allowed, parse_demo_trace
+from triforce import ActionSpaceDefinition, ModelKindDefinition, Network, TrainingScenarioDefinition, make_zelda_env
+from triforce.observation_wrapper import infer_obs_kind
+from triforce.zelda_enums import ActionKind, Direction
+
+
+def compute_demo_accuracy(pred_actions, target_actions):
+    """Return exact two-head action accuracy."""
+    return (pred_actions.long() == target_actions.long()).all(dim=-1).float().mean().item()
+
+
+def _stack_observations(observations, device):
+    keys = observations[0].keys()
+    return {key: torch.stack([torch.as_tensor(obs[key]) for obs in observations]).to(device) for key in keys}
+
+
+def _collect_demo(model_path, scenario_name, trace_path, prefix_east, device):
+    metadata = Network.load_metadata(model_path)
+    obs_kind, frame_stack = infer_obs_kind(metadata["obs_space"])
+    scenario_def = TrainingScenarioDefinition.get(scenario_name)
+    action_space_def = ActionSpaceDefinition.get("all-items")
+    env = make_zelda_env(scenario_def, action_space_def.actions, multihead=True,
+                         translation=True, obs_kind=obs_kind, frame_stack=frame_stack)
+
+    observations = []
+    masks = []
+    targets = []
+    actions = [(ActionKind.MOVE, Direction.E)] * prefix_east + parse_demo_trace(trace_path)
+    try:
+        obs, info = env.reset()
+        ending = ""
+        final_location = None
+        total_reward = 0.0
+        for step, (action, direction) in enumerate(actions, start=1):
+            action_mask = info.get('action_mask')
+            if action_mask is None:
+                raise RuntimeError(f"Missing action mask at demo step {step}")
+            if not is_demo_action_allowed(action_mask, action, direction):
+                raise RuntimeError(f"Invalid demo action at step {step}: {action.name} {direction.name}")
+            action_indices = demo_action_to_indices(action, direction)
+            observations.append(obs)
+            masks.append(torch.as_tensor(action_mask, dtype=torch.bool))
+            targets.append(torch.as_tensor(action_indices, dtype=torch.long))
+            obs, reward, terminated, truncated, info = env.step(np.asarray(action_indices, dtype=np.int64))
+            total_reward += float(reward)
+            if terminated or truncated:
+                ending = info.get('rewards', {}).get('ending') or info.get('ending') or "unknown"
+                break
+        # If the translated info did not carry ending, infer success from the final reset-free trace state where possible.
+        success = ending.startswith("success-") or total_reward > 1.0
+        if not success:
+            raise RuntimeError(f"Demo did not appear to reach success; ending={ending}, total_reward={total_reward:.3f}")
+    finally:
+        env.close()
+
+    return _stack_observations(observations, device), torch.stack(masks).to(device), torch.stack(targets).to(device)
+
+
+def behavior_clone(args):
+    """Run behavior cloning."""
+    device = torch.device(args.device)
+    metadata = Network.load_metadata(args.model_path)
+    model_kind = ModelKindDefinition.get(metadata["model_kind"] or "impala-multihead")
+    obs_space, act_space = Network.load_spaces(args.model_path)
+    network = model_kind.network_class(obs_space, act_space).to(device)
+    network.load(args.model_path)
+    network.train()
+
+    obs, masks, targets = _collect_demo(args.model_path, args.scenario, args.demo_trace, args.prefix_east, device)
+    optimizer = torch.optim.Adam(network.parameters(), lr=args.lr)
+    first_loss = None
+    final_loss = None
+    for epoch in range(args.epochs):
+        optimizer.zero_grad(set_to_none=True)
+        _, logprob, _, _ = network.get_action_and_value(obs, masks, targets)
+        loss = -logprob.mean()
+        loss.backward()
+        optimizer.step()
+        if first_loss is None:
+            first_loss = loss.item()
+        final_loss = loss.item()
+        if (epoch + 1) % max(args.epochs // 10, 1) == 0:
+            print(f"epoch={epoch + 1} loss={final_loss:.6f}")
+
+    network.eval()
+    with torch.no_grad():
+        pred = network.get_action(obs, masks, deterministic=True)
+        accuracy = compute_demo_accuracy(pred, targets)
+    print(f"examples={targets.shape[0]} first_loss={first_loss:.6f} final_loss={final_loss:.6f} accuracy={accuracy:.6f}")
+    if accuracy < args.min_accuracy:
+        raise SystemExit(f"Accuracy {accuracy:.6f} below required {args.min_accuracy:.6f}")
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    network.save(args.output)
+    print(f"Saved behavior-cloned checkpoint: {args.output}")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Behavior-clone a Triforce policy from a movement demo")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--demo-trace", required=True)
+    parser.add_argument("--prefix-east", type=int, required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--epochs", type=int, default=400)
+    parser.add_argument("--lr", type=float, default=0.0001)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--min-accuracy", type=float, default=0.95)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    behavior_clone(parse_args())

--- a/scripts/behavior_clone.py
+++ b/scripts/behavior_clone.py
@@ -7,67 +7,14 @@ import sys
 from pathlib import Path
 
 
-import numpy as np
 import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from diagnose import demo_action_to_indices, is_demo_action_allowed, parse_demo_trace
-from triforce import ActionSpaceDefinition, ModelKindDefinition, Network, TrainingScenarioDefinition, make_zelda_env
-from triforce.observation_wrapper import infer_obs_kind
-from triforce.zelda_enums import ActionKind, Direction
+from triforce import ModelKindDefinition, Network
+from triforce.demo import collect_demo_batch, compute_demo_accuracy, parse_demo_trace
 
 
-def compute_demo_accuracy(pred_actions, target_actions):
-    """Return exact two-head action accuracy."""
-    return (pred_actions.long() == target_actions.long()).all(dim=-1).float().mean().item()
-
-
-def _stack_observations(observations, device):
-    keys = observations[0].keys()
-    return {key: torch.stack([torch.as_tensor(obs[key]) for obs in observations]).to(device) for key in keys}
-
-
-def _collect_demo(model_path, scenario_name, trace_path, prefix_east, device):
-    metadata = Network.load_metadata(model_path)
-    obs_kind, frame_stack = infer_obs_kind(metadata["obs_space"])
-    scenario_def = TrainingScenarioDefinition.get(scenario_name)
-    action_space_def = ActionSpaceDefinition.get("all-items")
-    env = make_zelda_env(scenario_def, action_space_def.actions, multihead=True,
-                         translation=True, obs_kind=obs_kind, frame_stack=frame_stack)
-
-    observations = []
-    masks = []
-    targets = []
-    actions = [(ActionKind.MOVE, Direction.E)] * prefix_east + parse_demo_trace(trace_path)
-    try:
-        obs, info = env.reset()
-        ending = ""
-        final_location = None
-        total_reward = 0.0
-        for step, (action, direction) in enumerate(actions, start=1):
-            action_mask = info.get('action_mask')
-            if action_mask is None:
-                raise RuntimeError(f"Missing action mask at demo step {step}")
-            if not is_demo_action_allowed(action_mask, action, direction):
-                raise RuntimeError(f"Invalid demo action at step {step}: {action.name} {direction.name}")
-            action_indices = demo_action_to_indices(action, direction)
-            observations.append(obs)
-            masks.append(torch.as_tensor(action_mask, dtype=torch.bool))
-            targets.append(torch.as_tensor(action_indices, dtype=torch.long))
-            obs, reward, terminated, truncated, info = env.step(np.asarray(action_indices, dtype=np.int64))
-            total_reward += float(reward)
-            if terminated or truncated:
-                ending = info.get('rewards', {}).get('ending') or info.get('ending') or "unknown"
-                break
-        # If the translated info did not carry ending, infer success from the final reset-free trace state where possible.
-        success = ending.startswith("success-") or total_reward > 1.0
-        if not success:
-            raise RuntimeError(f"Demo did not appear to reach success; ending={ending}, total_reward={total_reward:.3f}")
-    finally:
-        env.close()
-
-    return _stack_observations(observations, device), torch.stack(masks).to(device), torch.stack(targets).to(device)
 
 
 def behavior_clone(args):
@@ -80,7 +27,7 @@ def behavior_clone(args):
     network.load(args.model_path)
     network.train()
 
-    obs, masks, targets = _collect_demo(args.model_path, args.scenario, args.demo_trace, args.prefix_east, device)
+    obs, masks, targets = collect_demo_batch(args.model_path, args.scenario, args.demo_trace, args.prefix_east, device)
     optimizer = torch.optim.Adam(network.parameters(), lr=args.lr)
     first_loss = None
     final_loss = None

--- a/tests/reward_test.py
+++ b/tests/reward_test.py
@@ -3,10 +3,15 @@
 import os
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from types import SimpleNamespace
+
 
 from triforce.action_space import ActionKind
 from triforce.critics import GameplayCritic
+from triforce.rewards import REWARD_MAXIMUM, Reward, StepRewards
+from triforce.scenario_wrapper import apply_terminal_penalty
 from triforce.zelda_enums import BoomerangKind, Direction, SelectedEquipmentKind, SwordKind
+from triforce.zelda_enums import MapLocation, TileIndex, ZeldaEnemyKind
 from utilities import CriticWrapper, ZeldaActionReplay
 
 def test_wall_movement_masked():
@@ -145,3 +150,81 @@ def test_bomb_hit_reward_adjusted():
     assert 'reward-bomb-hit' in rewards
     expected = min(0.50 * state_change.hits, 1.0)
     assert rewards['reward-bomb-hit'].value == expected
+
+
+def _synthetic_wallmaster_change(prev_location, curr_location, prev_tile=None, curr_tile=None, objectives=None):
+    prev_tile = prev_tile or TileIndex(0x05, 0x05)
+    curr_tile = curr_tile or TileIndex(0x05, 0x05)
+    objectives = objectives or SimpleNamespace(targets=set(), pbrs_targets=set())
+    prev = SimpleNamespace(
+        enemies={ZeldaEnemyKind.Wallmaster},
+        full_location=prev_location,
+        link=SimpleNamespace(tile=prev_tile),
+        objectives=objectives,
+    )
+    curr = SimpleNamespace(
+        enemies={ZeldaEnemyKind.Wallmaster},
+        full_location=curr_location,
+        link=SimpleNamespace(tile=curr_tile),
+        objectives=objectives,
+    )
+    return SimpleNamespace(previous=prev, state=curr, action=SimpleNamespace(kind=ActionKind.MOVE))
+
+
+def test_wallmastered_adds_wallmaster_penalty():
+    critic = GameplayCritic()
+    rewards = StepRewards()
+    prev_location = MapLocation(1, 0x45, False)
+    curr_location = MapLocation(1, 0x73, False)
+
+    critic.critique_wallmaster(_synthetic_wallmaster_change(prev_location, curr_location), rewards)
+
+    assert 'penalty-wall-master' in rewards
+    assert rewards['penalty-wall-master'].value == -20.0
+
+
+def test_terminal_failure_removes_positive_rewards_for_death():
+    rewards = StepRewards()
+    rewards.add(Reward("reward-new-location", REWARD_MAXIMUM))
+    rewards.ending = "failure-terminated-death"
+
+    apply_terminal_penalty(rewards)
+
+    assert rewards.value == -20.0
+    assert 'reward-new-location' not in rewards
+    assert 'penalty-terminal-failure' in rewards
+
+
+def test_nonterminal_rewards_keep_normal_clamp():
+    rewards = StepRewards()
+    rewards.add(Reward("reward-new-location", REWARD_MAXIMUM))
+    rewards.add(Reward("reward-gained-keys", REWARD_MAXIMUM))
+
+    assert rewards.value == 1.0
+
+
+def test_wallmastered_terminal_uses_wallmaster_penalty_name():
+    rewards = StepRewards()
+    rewards.add(Reward("reward-new-location", REWARD_MAXIMUM))
+    rewards.ending = "failure-wallmastered"
+
+    apply_terminal_penalty(rewards)
+
+    assert rewards.value == -20.0
+    assert 'reward-new-location' not in rewards
+    assert 'penalty-wall-master' in rewards
+    assert 'penalty-terminal-failure' not in rewards
+
+
+def test_objective_exit_tile_not_punished_as_wallmaster_tile():
+    critic = GameplayCritic()
+    rewards = StepRewards()
+    location = MapLocation(1, 0x45, False)
+    exit_tile = TileIndex(0x0F, 0x04)
+    objectives = SimpleNamespace(targets={exit_tile}, pbrs_targets={exit_tile})
+
+    critic.critique_wallmaster(
+        _synthetic_wallmaster_change(location, location, curr_tile=exit_tile, objectives=objectives), rewards)
+
+    assert 'penalty-fighting-wallmaster' not in rewards
+    assert 'penalty-moved-onto-wallmaster' not in rewards

--- a/tests/reward_test.py
+++ b/tests/reward_test.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from triforce.action_space import ActionKind
 from triforce.critics import GameplayCritic
 from triforce.rewards import REWARD_MAXIMUM, Reward, StepRewards
-from triforce.scenario_wrapper import apply_terminal_penalty
+from triforce.scenario_wrapper import apply_terminal_rewards
 from triforce.zelda_enums import BoomerangKind, Direction, SelectedEquipmentKind, SwordKind
 from triforce.zelda_enums import MapLocation, TileIndex, ZeldaEnemyKind
 from utilities import CriticWrapper, ZeldaActionReplay
@@ -188,7 +188,7 @@ def test_terminal_failure_removes_positive_rewards_for_death():
     rewards.add(Reward("reward-new-location", REWARD_MAXIMUM))
     rewards.ending = "failure-terminated-death"
 
-    apply_terminal_penalty(rewards)
+    apply_terminal_rewards(rewards)
 
     assert rewards.value == -20.0
     assert 'reward-new-location' not in rewards
@@ -208,12 +208,24 @@ def test_wallmastered_terminal_uses_wallmaster_penalty_name():
     rewards.add(Reward("reward-new-location", REWARD_MAXIMUM))
     rewards.ending = "failure-wallmastered"
 
-    apply_terminal_penalty(rewards)
+    apply_terminal_rewards(rewards)
 
     assert rewards.value == -20.0
     assert 'reward-new-location' not in rewards
     assert 'penalty-wall-master' in rewards
     assert 'penalty-terminal-failure' not in rewards
+
+
+def test_terminal_success_adds_success_reward():
+    rewards = StepRewards()
+    rewards.add(Reward("reward-new-location", REWARD_MAXIMUM))
+    rewards.ending = "success-reached-location"
+
+    apply_terminal_rewards(rewards)
+
+    assert rewards.value == 20.0
+    assert 'reward-new-location' in rewards
+    assert 'reward-terminal-success' in rewards
 
 
 def test_objective_exit_tile_not_punished_as_wallmaster_tile():

--- a/tests/test_demo_regularization.py
+++ b/tests/test_demo_regularization.py
@@ -1,0 +1,19 @@
+# pylint: disable=all
+"""Demo-regularization helper tests."""
+
+import torch
+
+from triforce.demo import stack_demo_observations
+
+
+def test_stack_demo_observations_batches_dict_tensors():
+    observations = [
+        {"image": torch.tensor([[1, 2], [3, 4]]), "vector": torch.tensor([1.0, 2.0])},
+        {"image": torch.tensor([[5, 6], [7, 8]]), "vector": torch.tensor([3.0, 4.0])},
+    ]
+
+    stacked = stack_demo_observations(observations, torch.device("cpu"))
+
+    assert stacked["image"].shape == (2, 2, 2)
+    assert stacked["vector"].shape == (2, 2)
+    assert torch.equal(stacked["image"][1], torch.tensor([[5, 6], [7, 8]]))

--- a/tests/test_evaluate_plugin_contract.py
+++ b/tests/test_evaluate_plugin_contract.py
@@ -31,6 +31,16 @@ def test_training_skill_uses_evaluation_plugin():
     assert "python evaluate.py <final_model_or_run_dir>" not in skill
 
 
+def test_evaluation_skills_forbid_sleep_poll_wait_loop():
+    evaluation_skill = (ROOT / ".agents/skills/triforce-evaluation/SKILL.md").read_text(encoding="utf-8")
+    training_skill = (ROOT / ".agents/skills/triforce-experiment/SKILL.md").read_text(encoding="utf-8")
+
+    for skill in (evaluation_skill, training_skill):
+        assert "Do not sleep, poll, wait" in skill
+        assert "sleep to wait" not in skill
+        assert "call status in a loop" in skill or "call evaluation status in a loop" in skill
+
+
 def test_evaluate_default_remains_100_for_cli_backcompat(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["evaluate.py", "model.pt", "scenario-name"])
 

--- a/tests/test_evaluate_plugin_contract.py
+++ b/tests/test_evaluate_plugin_contract.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+from evaluate import parse_args
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_evaluation_plugin_defaults_to_50_episodes():
+    extension = (ROOT / ".omp/extensions/triforce-evaluation/index.ts").read_text(encoding="utf-8")
+
+    assert "episodes: z.number().int().positive().default(50)" in extension
+    assert '"evaluate.py"' in extension
+    assert '"--episodes"' in extension
+
+
+def test_evaluation_plugin_forbids_direct_fallback_guidance():
+    extension = (ROOT / ".omp/extensions/triforce-evaluation/index.ts").read_text(encoding="utf-8")
+    skill = (ROOT / ".agents/skills/triforce-evaluation/SKILL.md").read_text(encoding="utf-8")
+
+    assert "Do not run evaluate.py directly" in extension
+    assert "Do not call evaluate.py directly" in skill
+
+
+def test_training_skill_uses_evaluation_plugin():
+    skill = (ROOT / ".agents/skills/triforce-experiment/SKILL.md").read_text(encoding="utf-8")
+
+    assert "triforce_evaluation_start" in skill
+    assert "triforce_evaluation_compare" in skill
+    assert "python evaluate.py <final_model_or_run_dir>" not in skill
+
+
+def test_evaluate_default_remains_100_for_cli_backcompat(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["evaluate.py", "model.pt", "scenario-name"])
+
+    args = parse_args()
+
+    assert args.episodes == 100

--- a/tests/test_evaluate_reporting.py
+++ b/tests/test_evaluate_reporting.py
@@ -1,0 +1,38 @@
+# pylint: disable=all
+"""Evaluation reporting tests."""
+
+import json
+
+from evaluate import convert_eval_json_to_md
+
+
+def _write_eval_json(path, metrics=None):
+    data = {
+        "episodes": 100,
+        "scenario": "dungeon1-wallmaster-north-exit",
+        "progress_values": [9] * 76 + [10] * 24,
+        "max_progress": 11,
+        "metrics": metrics,
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_eval_markdown_uses_scenario_success_rate(tmp_path):
+    json_path = tmp_path / "wallmaster.eval.json"
+    _write_eval_json(json_path, {"success-rate": 0.24})
+
+    md_path = convert_eval_json_to_md(str(json_path))
+
+    markdown = (tmp_path / "wallmaster.eval.md").read_text(encoding="utf-8")
+    assert md_path == str(tmp_path / "wallmaster.eval.md")
+    assert "Success rate**: 24/100 (24%) (scenario success-rate; reached milestone 11)" in markdown
+
+
+def test_eval_markdown_keeps_progress_success_without_metric(tmp_path):
+    json_path = tmp_path / "wallmaster.eval.json"
+    _write_eval_json(json_path)
+
+    convert_eval_json_to_md(str(json_path))
+
+    markdown = (tmp_path / "wallmaster.eval.md").read_text(encoding="utf-8")
+    assert "Success rate**: 0/100 (0%) (reached milestone 11)" in markdown

--- a/tests/test_experiment1_config.py
+++ b/tests/test_experiment1_config.py
@@ -1,0 +1,55 @@
+# pylint: disable=all
+"""Experiment 1 scenario and circuit configuration tests."""
+
+from triforce.scenario_wrapper import TrainingCircuitDefinition, TrainingScenarioDefinition
+
+
+def test_experiment1_scenarios_load():
+    expected = {
+        "dungeon1-red-goriya-east",
+        "dungeon1-wallmaster-north-exit",
+        "dungeon1-aquamentus-east",
+        "dungeon1-late-chain",
+    }
+
+    for name in expected:
+        assert TrainingScenarioDefinition.get(name) is not None
+
+
+def test_experiment1_starts_are_exact():
+    assert TrainingScenarioDefinition.get("dungeon1-red-goriya-east").start == ["1_44w"]
+    assert TrainingScenarioDefinition.get("dungeon1-wallmaster-north-exit").start == ["1_45w"]
+    assert TrainingScenarioDefinition.get("dungeon1-aquamentus-east").start == ["1_35s"]
+    assert TrainingScenarioDefinition.get("dungeon1-late-chain").start == ["1_43e", "1_44w", "1_45w", "1_35s"]
+
+    for name in (
+            "dungeon1-red-goriya-east", "dungeon1-wallmaster-north-exit",
+            "dungeon1-aquamentus-east", "dungeon1-late-chain"):
+        starts = TrainingScenarioDefinition.get(name).start
+        assert not any(start.endswith("c") for start in starts)
+        assert not any(start.startswith("debug_") for start in starts)
+
+
+def test_experiment1_weighted_circuit():
+    circuit = TrainingCircuitDefinition.get("dungeon1-endgame-skills")
+
+    assert circuit.kind == "weighted"
+    assert [(entry.scenario, entry.weight) for entry in circuit.scenarios] == [
+        ("dungeon1-red-goriya-east", 25),
+        ("dungeon1-wallmaster-north-exit", 35),
+        ("dungeon1-aquamentus-east", 25),
+        ("dungeon1-late-chain", 15),
+    ]
+    assert [entry.exit_criteria.threshold for entry in circuit.scenarios] == [0.7, 0.7, 0.5, 0.2]
+
+
+def test_experiment1_circuit_final_eval_metadata():
+    circuit = TrainingCircuitDefinition.get("experiment1-circuit")
+
+    assert circuit.final_eval_scenario == "full-game-all-items-finite"
+    assert circuit.final_eval_episodes == 100
+    assert [(entry.circuit, entry.scenario, entry.iterations) for entry in circuit.scenarios] == [
+        ("dungeon1-endgame-skills", None, 2500000),
+        (None, "dungeon1-finite-bombs", 1000000),
+        (None, "full-game-all-items-finite", 1000000),
+    ]

--- a/tests/test_experiment2_config.py
+++ b/tests/test_experiment2_config.py
@@ -1,0 +1,25 @@
+# pylint: disable=all
+"""Experiment 2 scenario and circuit configuration tests."""
+
+from triforce.scenario_wrapper import TrainingCircuitDefinition
+
+
+def test_experiment2_circuit_loads():
+    circuit = TrainingCircuitDefinition.get("experiment2-circuit")
+
+    assert circuit.name == "experiment2-circuit"
+    assert circuit.final_eval_scenario == "dungeon1-wallmaster-north-exit"
+    assert circuit.final_eval_episodes == 100
+
+
+def test_experiment2_circuit_entries():
+    circuit = TrainingCircuitDefinition.get("experiment2-circuit")
+
+    assert [(entry.scenario, entry.iterations) for entry in circuit.scenarios] == [
+        ("dungeon1-room-walk", 500000),
+        ("dungeon1-wallmaster-north-exit", 750000),
+    ]
+    assert circuit.scenarios[0].exit_criteria.metric == "room-result/correct-exit"
+    assert circuit.scenarios[0].exit_criteria.threshold == 0.8
+    assert circuit.scenarios[1].exit_criteria.metric == "success-rate"
+    assert circuit.scenarios[1].exit_criteria.threshold == 0.5

--- a/tests/test_experiment3_config.py
+++ b/tests/test_experiment3_config.py
@@ -1,0 +1,23 @@
+# pylint: disable=all
+"""Experiment 3 circuit configuration tests."""
+
+from triforce.scenario_wrapper import TrainingCircuitDefinition
+
+
+def test_experiment3_circuit_loads():
+    circuit = TrainingCircuitDefinition.get("experiment3-circuit")
+
+    assert circuit.name == "experiment3-circuit"
+    assert circuit.final_eval_scenario == "dungeon1-wallmaster-north-exit"
+    assert circuit.final_eval_episodes == 100
+
+
+def test_experiment3_circuit_entries():
+    circuit = TrainingCircuitDefinition.get("experiment3-circuit")
+
+    assert len(circuit.scenarios) == 1
+    entry = circuit.scenarios[0]
+    assert entry.scenario == "dungeon1-wallmaster-north-exit"
+    assert entry.iterations == 750000
+    assert entry.exit_criteria.metric == "success-rate"
+    assert entry.exit_criteria.threshold == 0.5

--- a/tests/test_experiment3_demo.py
+++ b/tests/test_experiment3_demo.py
@@ -3,10 +3,8 @@
 
 import pytest
 
-from diagnose import parse_demo_trace
+from triforce.demo import compute_demo_accuracy, parse_demo_trace
 import torch
-
-from scripts.behavior_clone import compute_demo_accuracy
 from triforce.action_space import ActionKind
 from triforce.zelda_enums import Direction
 

--- a/tests/test_experiment3_demo.py
+++ b/tests/test_experiment3_demo.py
@@ -1,0 +1,75 @@
+# pylint: disable=all
+"""Experiment 3 demo trace tests."""
+
+import pytest
+
+from diagnose import parse_demo_trace
+import torch
+
+from scripts.behavior_clone import compute_demo_accuracy
+from triforce.action_space import ActionKind
+from triforce.zelda_enums import Direction
+
+EXPECTED_DIRECTIONS = [
+    Direction.E, Direction.E, Direction.S, Direction.S,
+    Direction.E, Direction.E, Direction.E, Direction.E, Direction.E, Direction.E, Direction.E,
+    Direction.E, Direction.E, Direction.E, Direction.E, Direction.E, Direction.E, Direction.E,
+    Direction.S, Direction.S, Direction.S,
+    Direction.E, Direction.E, Direction.W, Direction.W,
+    Direction.N, Direction.N, Direction.N, Direction.N, Direction.N, Direction.N,
+    Direction.N, Direction.N, Direction.N, Direction.N, Direction.N,
+    Direction.W, Direction.W, Direction.W,
+    Direction.N, Direction.N, Direction.N, Direction.N, Direction.N,
+]
+
+
+def test_parse_reverse_demo_trace(tmp_path):
+    trace = tmp_path / "trace.txt"
+    trace.write_text("""
+#3\tMOVE S\t\t+0.000
+#2\tMOVE E\t\t+0.000
+#1\tNone\t\t+0.000
+""", encoding="utf-8")
+
+    actions = parse_demo_trace(str(trace))
+
+    assert actions == [(ActionKind.MOVE, Direction.E), (ActionKind.MOVE, Direction.S)]
+
+
+def test_parse_normalized_demo_trace_takes_precedence(tmp_path):
+    trace = tmp_path / "trace.txt"
+    trace.write_text("""
+## Normalized forward trace
+MOVE N
+MOVE E
+## Original reverse trace
+#2\tMOVE S\t\t+0.000
+#1\tNone\t\t+0.000
+""", encoding="utf-8")
+
+    actions = parse_demo_trace(str(trace))
+
+    assert actions == [(ActionKind.MOVE, Direction.N), (ActionKind.MOVE, Direction.E)]
+
+
+def test_parse_full_demo_trace():
+    actions = parse_demo_trace("docs/experiments/demos/wallmaster-north-exit.txt")
+
+    assert len(actions) == 44
+    assert all(action == ActionKind.MOVE for action, _ in actions)
+    assert [direction for _, direction in actions] == EXPECTED_DIRECTIONS
+
+
+def test_parse_empty_demo_trace_raises(tmp_path):
+    trace = tmp_path / "trace.txt"
+    trace.write_text("#1\tNone\t\t+0.000\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        parse_demo_trace(str(trace))
+
+
+def test_compute_demo_accuracy():
+    pred = torch.tensor([[0, 3], [0, 0], [0, 1]])
+    target = torch.tensor([[0, 3], [0, 2], [0, 1]])
+
+    assert compute_demo_accuracy(pred, target) == pytest.approx(2 / 3)

--- a/tests/test_experiment4_config.py
+++ b/tests/test_experiment4_config.py
@@ -1,0 +1,36 @@
+# pylint: disable=all
+"""Experiment 4 circuit configuration tests."""
+
+from triforce.scenario_wrapper import TrainingCircuitDefinition
+
+
+def test_experiment4_weighted_circuit_loads():
+    circuit = TrainingCircuitDefinition.get("experiment4-late-chain-demo")
+
+    assert circuit.name == "experiment4-late-chain-demo"
+    assert circuit.kind == "weighted"
+    assert [entry.scenario for entry in circuit.scenarios] == [
+        "dungeon1-wallmaster-north-exit",
+        "dungeon1-late-chain",
+        "dungeon1-aquamentus-east",
+    ]
+    assert [entry.weight for entry in circuit.scenarios] == [30, 50, 20]
+    assert [entry.exit_criteria.metric for entry in circuit.scenarios] == ["success-rate"] * 3
+    assert [entry.exit_criteria.threshold for entry in circuit.scenarios] == [0.5, 0.1, 0.2]
+
+
+def test_experiment4_sequential_circuit_loads():
+    circuit = TrainingCircuitDefinition.get("experiment4-circuit")
+
+    assert circuit.name == "experiment4-circuit"
+    assert circuit.final_eval_scenario == "dungeon1-late-chain"
+    assert circuit.final_eval_episodes == 100
+    assert len(circuit.scenarios) == 2
+
+    late_chain, finite_bombs = circuit.scenarios
+    assert late_chain.circuit == "experiment4-late-chain-demo"
+    assert late_chain.iterations == 1500000
+    assert finite_bombs.scenario == "dungeon1-finite-bombs"
+    assert finite_bombs.iterations == 500000
+    assert finite_bombs.exit_criteria.metric == "success-rate"
+    assert finite_bombs.exit_criteria.threshold == 0.1

--- a/tests/test_experiment5_config.py
+++ b/tests/test_experiment5_config.py
@@ -1,0 +1,36 @@
+# pylint: disable=all
+"""Experiment 5 circuit configuration tests."""
+
+from triforce.scenario_wrapper import TrainingCircuitDefinition
+
+
+def test_experiment5_weighted_circuit_loads():
+    circuit = TrainingCircuitDefinition.get("experiment5-boss-transfer")
+
+    assert circuit.name == "experiment5-boss-transfer"
+    assert circuit.kind == "weighted"
+    assert [entry.scenario for entry in circuit.scenarios] == [
+        "dungeon1-wallmaster-north-exit",
+        "dungeon1-aquamentus-east",
+        "dungeon1-late-chain",
+    ]
+    assert [entry.weight for entry in circuit.scenarios] == [10, 80, 10]
+    assert [entry.exit_criteria.metric for entry in circuit.scenarios] == ["success-rate"] * 3
+    assert [entry.exit_criteria.threshold for entry in circuit.scenarios] == [0.8, 0.6, 0.1]
+
+
+def test_experiment5_sequential_circuit_loads():
+    circuit = TrainingCircuitDefinition.get("experiment5-circuit")
+
+    assert circuit.name == "experiment5-circuit"
+    assert circuit.final_eval_scenario == "dungeon1-late-chain"
+    assert circuit.final_eval_episodes == 100
+    assert len(circuit.scenarios) == 2
+
+    boss_transfer, late_chain = circuit.scenarios
+    assert boss_transfer.circuit == "experiment5-boss-transfer"
+    assert boss_transfer.iterations == 2000000
+    assert late_chain.scenario == "dungeon1-late-chain"
+    assert late_chain.iterations == 1000000
+    assert late_chain.exit_criteria.metric == "success-rate"
+    assert late_chain.exit_criteria.threshold == 0.1

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -4,7 +4,7 @@ import sys
 
 from triforce.objectives import GameCompletion
 from triforce.rewards import StepRewards
-from triforce.scenario_wrapper import apply_terminal_penalty
+from triforce.scenario_wrapper import apply_terminal_rewards
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
@@ -52,7 +52,7 @@ class CriticWrapper(gym.Wrapper):
             if terminated_result or truncated_result:
                 rewards.ending = reason
                 break
-        apply_terminal_penalty(rewards)
+        apply_terminal_rewards(rewards)
         return obs, rewards, terminated, truncated, change
 
 class TestScenario:

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -4,6 +4,7 @@ import sys
 
 from triforce.objectives import GameCompletion
 from triforce.rewards import StepRewards
+from triforce.scenario_wrapper import apply_terminal_penalty
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
@@ -47,7 +48,11 @@ class CriticWrapper(gym.Wrapper):
         end = [x.is_scenario_ended(change) for x in self.end_conditions]
         terminated = terminated or any((x[0] for x in end))
         truncated = truncated or any((x[1] for x in end))
-
+        for terminated_result, truncated_result, reason in end:
+            if terminated_result or truncated_result:
+                rewards.ending = reason
+                break
+        apply_terminal_penalty(rewards)
         return obs, rewards, terminated, truncated, change
 
 class TestScenario:

--- a/train.py
+++ b/train.py
@@ -21,8 +21,10 @@ from rich.console import Console, Group
 from rich.live import Live
 from rich.text import Text
 from rich.table import Table
+import torch
 from torch.utils.tensorboard import SummaryWriter
 from triforce.experiment_report import DEFAULT_HEALTH_RANGES, flatten_metrics, is_metric_healthy
+from triforce.demo import collect_demo_batch
 
 from triforce import (ActionSpaceDefinition, ModelKindDefinition, TrainingScenarioDefinition,
                       TrainingCallback, make_zelda_env)
@@ -849,6 +851,18 @@ def _get_kwargs_from_args(args, model_kind, action_space_def):
     if args.device is not None:
         kwargs['device'] = args.device
 
+    if args.demo_trace is not None:
+        if args.load is None:
+            print("Error: --demo-trace requires --load")
+            sys.exit(1)
+        demo_device = torch.device(args.device or 'cpu')
+        kwargs["demo_batch"] = collect_demo_batch(args.load, args.demo_scenario, args.demo_trace,
+                                                    args.demo_prefix_east, demo_device)
+        kwargs["demo_bc_coeff"] = args.demo_bc_coeff
+        kwargs["demo_trace"] = args.demo_trace
+        kwargs["demo_scenario"] = args.demo_scenario
+        kwargs["demo_prefix_east"] = args.demo_prefix_east
+
     if args.parallel > 1:
         kwargs['envs'] = args.parallel
 
@@ -1309,7 +1323,7 @@ def _run_post_training_eval(model, action_space_def, model_kind, scenario_def, e
             create_eval_env, model, episodes, update)
 
     if progress_values is not None:
-        print_progress_report(progress_values, max_progress, episodes, scenario_def.name)
+        print_progress_report(progress_values, max_progress, episodes, scenario_def.name, metrics=None)
 
 def parse_args():
     """Parse command line arguments."""
@@ -1347,6 +1361,14 @@ def parse_args():
                         help="Experiment directory for journal and summary files.")
     parser.add_argument("--baseline-eval-json", type=str, default=None,
                         help="Optional baseline .eval.json for milestone reports.")
+    parser.add_argument("--demo-trace", type=str, default=None,
+                        help="Expert movement trace to regularize PPO updates.")
+    parser.add_argument("--demo-scenario", type=str, default="dungeon1-wallmaster-north-exit",
+                        help="Scenario used to collect expert demo observations.")
+    parser.add_argument("--demo-prefix-east", type=int, default=0,
+                        help="Number of MOVE E actions to prepend before the demo trace.")
+    parser.add_argument("--demo-bc-coeff", type=float, default=0.0,
+                        help="Behavior-cloning loss coefficient for demo-regularized PPO.")
 
     try:
         args = parser.parse_args()

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -224,8 +224,10 @@ class GameplayCritic(ZeldaCritic):
         if ZeldaEnemyKind.Wallmaster not in curr.enemies:
             return
 
-        curr_on_wallmaster = self._is_wallmaster_tile(curr.link.tile) and not self._is_objective_tile(curr, curr.link.tile)
-        prev_on_wallmaster = self._is_wallmaster_tile(prev.link.tile) and not self._is_objective_tile(curr, curr.link.tile)
+        curr_on_wallmaster = (self._is_wallmaster_tile(curr.link.tile)
+                              and not self._is_objective_tile(curr, curr.link.tile))
+        prev_on_wallmaster = (self._is_wallmaster_tile(prev.link.tile)
+                              and not self._is_objective_tile(curr, curr.link.tile))
 
         # Are we on a tile which could be wallmastered?  If so, push away from it.
         if curr_on_wallmaster:

--- a/triforce/critics.py
+++ b/triforce/critics.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from triforce.action_space import ActionKind
 from triforce.rewards import REWARD_LARGE, REWARD_MAXIMUM, REWARD_MEDIUM, REWARD_MINIMUM, REWARD_SMALL, REWARD_TINY, \
-    Penalty, Reward, StepRewards
+    TERMINAL_FAILURE_PENALTY_VALUE, Penalty, Reward, StepRewards
 
 from .zelda_enums import SwordKind, ZeldaAnimationKind, AnimationState, ZeldaEnemyKind
 from .state_change_wrapper import StateChange
@@ -29,7 +29,7 @@ PENALTY_CAVE_ATTACK = Penalty("penalty-attack-cave", -REWARD_MAXIMUM)
 USED_BOMB_PENALTY = Penalty("penalty-bomb-used", -REWARD_SMALL)
 BOMB_HIT_REWARD = Reward("reward-bomb-hit", REWARD_MEDIUM)
 PENALTY_WRONG_LOCATION = Penalty("penalty-wrong-location", -REWARD_SMALL)
-PENALTY_WALL_MASTER = Penalty("penalty-wall-master", -REWARD_MAXIMUM)
+PENALTY_WALL_MASTER = Penalty("penalty-wall-master", -TERMINAL_FAILURE_PENALTY_VALUE)
 FIGHTING_WALLMASTER_PENALTY = Penalty("penalty-fighting-wallmaster", -REWARD_TINY)
 MOVED_OFF_OF_WALLMASTER_REWARD = Reward("reward-moved-off-wallmaster", REWARD_TINY - REWARD_MINIMUM)
 MOVED_ONTO_WALLMASTER_PENALTY = Penalty("penalty-moved-onto-wallmaster", -REWARD_TINY)
@@ -215,28 +215,37 @@ class GameplayCritic(ZeldaCritic):
         """Special handling for rooms with a wallmaster."""
         prev, curr = state_change.previous, state_change.state
 
+        prev_had_wallmaster = ZeldaEnemyKind.Wallmaster in prev.enemies
+        if prev_had_wallmaster and prev.full_location != curr.full_location \
+                and prev.full_location.manhattan_distance(curr.full_location) > 1:
+            rewards.add(PENALTY_WALL_MASTER)
+            return
+
         if ZeldaEnemyKind.Wallmaster not in curr.enemies:
             return
 
-        # Did we get wallmastered?
-        if prev.full_location != curr.full_location:
-            if prev.full_location.manhattan_distance(curr.full_location) > 1:
-                rewards.add(PENALTY_WALL_MASTER)
+        curr_on_wallmaster = self._is_wallmaster_tile(curr.link.tile) and not self._is_objective_tile(curr, curr.link.tile)
+        prev_on_wallmaster = self._is_wallmaster_tile(prev.link.tile) and not self._is_objective_tile(curr, curr.link.tile)
 
         # Are we on a tile which could be wallmastered?  If so, push away from it.
-        elif self._is_wallmaster_tile(curr.link.tile):
+        if curr_on_wallmaster:
             if state_change.action.kind != ActionKind.MOVE:
                 rewards.add(FIGHTING_WALLMASTER_PENALTY)
             else:
                 rewards.add(MOVED_ONTO_WALLMASTER_PENALTY)
 
-        elif self._is_wallmaster_tile(prev.link.tile):
+        elif prev_on_wallmaster:
             # If we moved off the wallmaster tile, reward the agent
             if state_change.action.kind == ActionKind.MOVE:
                 rewards.add(MOVED_OFF_OF_WALLMASTER_REWARD)
 
     def _is_wallmaster_tile(self, tile):
         return tile.x in (0x4, 0x1a) or tile.y in (0x4, 0x10)
+
+    @staticmethod
+    def _is_objective_tile(state, tile):
+        objectives = state.objectives
+        return tile in objectives.targets or tile in objectives.pbrs_targets
 
 
     def critique_block(self, state_change : StateChange, rewards):

--- a/triforce/demo.py
+++ b/triforce/demo.py
@@ -1,0 +1,122 @@
+"""Reusable expert demonstration helpers for Triforce training tools."""
+
+import re
+
+import numpy as np
+import torch
+
+from triforce import ActionSpaceDefinition, Network, TrainingScenarioDefinition, make_zelda_env
+from triforce.action_space import ActionKind
+from triforce.observation_wrapper import infer_obs_kind
+from triforce.zelda_enums import Direction
+
+
+DEMO_ACTION_TYPE_INDEX = {ActionKind.MOVE: 0}
+DEMO_DIRECTION_INDEX = {Direction.N: 0, Direction.S: 1, Direction.W: 2, Direction.E: 3}
+
+
+def parse_demo_trace(path: str) -> list[tuple[ActionKind, Direction]]:
+    """Parse a movement trace from normalized or original reverse-trace format."""
+    with open(path, 'r', encoding='utf-8') as file:
+        lines = file.readlines()
+
+    normalized = []
+    in_normalized = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Normalized forward trace":
+            in_normalized = True
+            continue
+        if stripped == "## Original reverse trace":
+            break
+        if in_normalized and stripped and not stripped.startswith('#'):
+            parts = stripped.split()
+            if len(parts) == 2:
+                normalized.append((ActionKind[parts[0]], Direction[parts[1]]))
+
+    if normalized:
+        actions = normalized
+    else:
+        reverse_entries = []
+        pattern = re.compile(r"^#(\d+)\s+(\S+)(?:\s+(\S+))?")
+        for line in lines:
+            match = pattern.match(line.strip())
+            if not match:
+                continue
+            step = int(match.group(1))
+            action_name = match.group(2)
+            direction_name = match.group(3)
+            if action_name == "None":
+                continue
+            reverse_entries.append((step, ActionKind[action_name], Direction[direction_name]))
+        actions = [(action, direction) for _, action, direction in sorted(reverse_entries)]
+
+    if not actions:
+        raise ValueError("Demo trace did not contain any actions")
+    if any(action != ActionKind.MOVE for action, _ in actions):
+        raise ValueError("Wallmaster demo traces must contain only MOVE actions")
+    return actions
+
+
+def demo_action_to_indices(action: ActionKind, direction: Direction) -> tuple[int, int]:
+    """Convert a demo action to all-items MultiDiscrete indices."""
+    return DEMO_ACTION_TYPE_INDEX[action], DEMO_DIRECTION_INDEX[direction]
+
+
+def is_demo_action_allowed(action_mask, action: ActionKind, direction: Direction) -> bool:
+    """Return whether a demo action is allowed by the joint action mask."""
+    action_type, direction_index = demo_action_to_indices(action, direction)
+    return bool(action_mask[action_type * 4 + direction_index])
+
+
+def stack_demo_observations(observations: list[dict], device: torch.device) -> dict[str, torch.Tensor]:
+    """Stack observation dictionaries into one batched tensor dictionary."""
+    keys = observations[0].keys()
+    return {key: torch.stack([torch.as_tensor(obs[key]) for obs in observations]).to(device) for key in keys}
+
+
+def compute_demo_accuracy(pred_actions: torch.Tensor, target_actions: torch.Tensor) -> float:
+    """Return exact two-head action accuracy."""
+    return (pred_actions.long() == target_actions.long()).all(dim=-1).float().mean().item()
+
+
+def collect_demo_batch(model_path: str, scenario_name: str, trace_path: str, prefix_east: int,
+                       device: torch.device, *, translation: bool = True):
+    """Replay an expert trace and return observations, masks, and MultiDiscrete target actions."""
+    metadata = Network.load_metadata(model_path)
+    obs_kind, frame_stack = infer_obs_kind(metadata["obs_space"])
+    scenario_def = TrainingScenarioDefinition.get(scenario_name)
+    action_space_def = ActionSpaceDefinition.get("all-items")
+    env = make_zelda_env(scenario_def, action_space_def.actions, multihead=True,
+                         translation=translation, obs_kind=obs_kind, frame_stack=frame_stack)
+
+    observations = []
+    masks = []
+    targets = []
+    actions = [(ActionKind.MOVE, Direction.E)] * prefix_east + parse_demo_trace(trace_path)
+    try:
+        obs, info = env.reset()
+        ending = ""
+        total_reward = 0.0
+        for step, (action, direction) in enumerate(actions, start=1):
+            action_mask = info.get('action_mask')
+            if action_mask is None:
+                raise RuntimeError(f"Missing action mask at demo step {step}")
+            if not is_demo_action_allowed(action_mask, action, direction):
+                raise RuntimeError(f"Invalid demo action at step {step}: {action.name} {direction.name}")
+            action_indices = demo_action_to_indices(action, direction)
+            observations.append(obs)
+            masks.append(torch.as_tensor(action_mask, dtype=torch.bool))
+            targets.append(torch.as_tensor(action_indices, dtype=torch.long))
+            obs, reward, terminated, truncated, info = env.step(np.asarray(action_indices, dtype=np.int64))
+            total_reward += float(reward)
+            if terminated or truncated:
+                ending = info.get('rewards', {}).get('ending') or info.get('ending') or "unknown"
+                break
+        success = ending.startswith("success-") or (translation and total_reward > 1.0)
+        if not success:
+            raise RuntimeError(f"Demo did not appear to reach success; ending={ending}, total_reward={total_reward:.3f}")
+    finally:
+        env.close()
+
+    return stack_demo_observations(observations, device), torch.stack(masks).to(device), torch.stack(targets).to(device)

--- a/triforce/demo.py
+++ b/triforce/demo.py
@@ -115,7 +115,8 @@ def collect_demo_batch(model_path: str, scenario_name: str, trace_path: str, pre
                 break
         success = ending.startswith("success-") or (translation and total_reward > 1.0)
         if not success:
-            raise RuntimeError(f"Demo did not appear to reach success; ending={ending}, total_reward={total_reward:.3f}")
+            raise RuntimeError(
+                f"Demo did not appear to reach success; ending={ending}, total_reward={total_reward:.3f}")
     finally:
         env.close()
 

--- a/triforce/experiment_report.py
+++ b/triforce/experiment_report.py
@@ -25,7 +25,7 @@ DEFAULT_TUNING = {
     "schema_version": 1,
     "wake_interval_steps": 1_000_000,
     "wake_dedup_steps": 100_000,
-    "anomaly_check_interval_steps": 100_000,
+    "anomaly_check_interval_steps": 125_000,
     "wall_clock_limit_seconds": 604_800,
     "health_ranges": deepcopy(DEFAULT_HEALTH_RANGES),
     "reward_hacking": {

--- a/triforce/ml_ppo.py
+++ b/triforce/ml_ppo.py
@@ -8,6 +8,7 @@ from .metrics import MetricTracker
 from .ml_ppo_callback import NullCallback
 from .ml_ppo_rollout_buffer import PPORolloutBuffer
 from .models import Network, create_network
+from .demo import compute_demo_accuracy
 
 # default hyperparameters
 LEARNING_RATE = 0.0001
@@ -65,6 +66,8 @@ class PPO:
         self._kl_rollback = kwargs.get('kl_rollback', KL_ROLLBACK_MULTIPLIER)
         self.optimizer = None
         self._pending_optimizer_state = kwargs.get('optimizer_state', None)
+        self._demo_bc_coeff = kwargs.get("demo_bc_coeff", 0.0)
+        self._demo_batch = kwargs.get("demo_batch", None)
 
         self.kwargs = kwargs
 
@@ -534,6 +537,17 @@ class PPO:
 
         network = network.to(self.device)
         optimizer = self.optimizer
+        demo_obs = demo_masks = demo_targets = None
+        demo_bc_loss = torch.tensor(0.0, device=self.device)
+        demo_bc_accuracy = None
+        if self._demo_batch is not None:
+            raw_demo_obs, raw_demo_masks, raw_demo_targets = self._demo_batch
+            if isinstance(raw_demo_obs, dict):
+                demo_obs = {key: value.to(self.device) for key, value in raw_demo_obs.items()}
+            else:
+                demo_obs = raw_demo_obs.to(self.device)
+            demo_masks = raw_demo_masks.to(self.device)
+            demo_targets = raw_demo_targets.to(self.device)
 
         # Snapshot weights for KL rollback
         kl_rollback_threshold = None
@@ -605,6 +619,10 @@ class PPO:
 
                 entropy_loss = entropy.mean()
                 loss = pg_loss - self._ent_coeff * entropy_loss + self._vf_coeff * v_loss
+                if demo_obs is not None and self._demo_bc_coeff > 0:
+                    _, demo_logprob, _, _ = network.get_action_and_value(demo_obs, demo_masks, demo_targets)
+                    demo_bc_loss = -demo_logprob.mean()
+                    loss = loss + self._demo_bc_coeff * demo_bc_loss
 
                 optimizer.zero_grad()
                 loss.backward()
@@ -621,6 +639,11 @@ class PPO:
             network.load_state_dict(saved_state)
             optimizer.load_state_dict(saved_optimizer)
             kl_rolled_back = True
+
+        if demo_obs is not None:
+            with torch.no_grad():
+                demo_pred = network.get_action(demo_obs, demo_masks, deterministic=True)
+                demo_bc_accuracy = compute_demo_accuracy(demo_pred, demo_targets)
 
         network = network.to("cpu")
 
@@ -655,6 +678,11 @@ class PPO:
             "losses/explained_variance": explained_var,
             "losses/kl_rollback": 1.0 if kl_rolled_back else 0.0,
         }
+
+        if demo_obs is not None:
+            stats["losses/demo_bc_loss"] = demo_bc_loss.item()
+            stats["charts/demo_bc_accuracy"] = demo_bc_accuracy
+            stats["charts/demo_bc_coeff"] = self._demo_bc_coeff
 
         if self.start_time is not None:
             steps_this_run = iterations - self._steps_at_start

--- a/triforce/objectives.py
+++ b/triforce/objectives.py
@@ -483,7 +483,8 @@ class RoomWalk(ObjectiveSelector):
             cave_south_exit = [TileIndex(x, 0x15) for x in range(0xe, 0x12)]
             self._sequence.append(Objective(ObjectiveKind.MOVE, cave_south_exit, [state.full_location]))
 
-        exits = [x for x in room.exits if isinstance(x, Direction) if state.is_door_open(x) and room.exits[x]]
+        valid_exits = [x for x in room.exits if isinstance(x, Direction) if state.is_door_open(x) and room.exits[x]]
+        exits = list(valid_exits)
         came_from = self._came_from(prev, state)
         if came_from in exits:
             exits.remove(came_from)
@@ -491,7 +492,13 @@ class RoomWalk(ObjectiveSelector):
         exits = self._get_reachable(exits, state)
 
         if len(exits) == 0:
-            exits.append(came_from)
+            if came_from in valid_exits:
+                exits.append(came_from)
+            elif valid_exits:
+                exits.append(random.choice(valid_exits))
+            else:
+                self._sequence.append(Objective(ObjectiveKind.MOVE, set(), set()))
+                return
 
         if len(exits) == 1:
             self._target_exits = [exits[0]]

--- a/triforce/rewards.py
+++ b/triforce/rewards.py
@@ -7,6 +7,8 @@ REWARD_SMALL = 0.25
 REWARD_MEDIUM = 0.5
 REWARD_LARGE = 0.75
 REWARD_MAXIMUM = 1.0
+TERMINAL_REWARD_MIN = -20.0
+TERMINAL_FAILURE_PENALTY_VALUE = 20.0
 
 @dataclass(frozen=True)
 class Outcome:
@@ -109,7 +111,11 @@ class StepRewards:
     @property
     def value(self):
         """The total reward value."""
-        return max(min(sum(self._outcomes.values()), REWARD_MAXIMUM), -REWARD_MAXIMUM)
+        total = sum(self._outcomes.values())
+        if self.ending and self.ending.startswith("failure-") and (
+                "penalty-terminal-failure" in self._outcomes or "penalty-wall-master" in self._outcomes):
+            return max(min(total, REWARD_MAXIMUM), TERMINAL_REWARD_MIN)
+        return max(min(total, REWARD_MAXIMUM), -REWARD_MAXIMUM)
 
     def add(self, outcome: Outcome, scale=None):
         """Add an outcome to the rewards."""

--- a/triforce/rewards.py
+++ b/triforce/rewards.py
@@ -9,6 +9,7 @@ REWARD_LARGE = 0.75
 REWARD_MAXIMUM = 1.0
 TERMINAL_REWARD_MIN = -20.0
 TERMINAL_FAILURE_PENALTY_VALUE = 20.0
+TERMINAL_SUCCESS_REWARD_VALUE = 20.0
 
 @dataclass(frozen=True)
 class Outcome:
@@ -112,6 +113,8 @@ class StepRewards:
     def value(self):
         """The total reward value."""
         total = sum(self._outcomes.values())
+        if self.ending and self.ending.startswith("success-") and "reward-terminal-success" in self._outcomes:
+            return max(min(total, TERMINAL_SUCCESS_REWARD_VALUE), -REWARD_MAXIMUM)
         if self.ending and self.ending.startswith("failure-") and (
                 "penalty-terminal-failure" in self._outcomes or "penalty-wall-master" in self._outcomes):
             return max(min(total, REWARD_MAXIMUM), TERMINAL_REWARD_MIN)

--- a/triforce/scenario_wrapper.py
+++ b/triforce/scenario_wrapper.py
@@ -12,10 +12,38 @@ import yaml
 
 from .metrics import MetricTracker
 from .objectives import get_objective_selector
-from .rewards import StepRewards
+from .rewards import Penalty, StepRewards, TERMINAL_FAILURE_PENALTY_VALUE
 from .zelda_enums import Direction, MapLocation
 from . import critics
 from . import end_conditions
+
+PENALTY_FAILURE_TERMINAL = Penalty("penalty-terminal-failure", -TERMINAL_FAILURE_PENALTY_VALUE)
+HARD_FAILURE_ENDINGS = frozenset({"failure-terminated-death", "failure-stuck", "failure-no-progress"})
+OTHER_FAILURE_ENDINGS = frozenset({
+    "failure-left-dungeon", "failure-left-room", "failure-left-route", "failure-left-play-area",
+    "failure-left-wallmaster-room", "failure-reentered-dungeon", "failure-nowhere-to-go", "failure-no-key",
+    "failure-wrong-exit",
+})
+
+def apply_terminal_penalty(rewards: StepRewards) -> None:
+    """Adds terminal failure penalties after end conditions set rewards.ending."""
+    if rewards.ending is None or rewards.ending.startswith("success-"):
+        return
+
+    if rewards.ending == "failure-wallmastered":
+        rewards.remove_rewards()
+        if "penalty-wall-master" not in rewards:
+            rewards.add(Penalty("penalty-wall-master", -TERMINAL_FAILURE_PENALTY_VALUE))
+        return
+
+    if rewards.ending in HARD_FAILURE_ENDINGS:
+        rewards.remove_rewards()
+        if "penalty-terminal-failure" not in rewards:
+            rewards.add(PENALTY_FAILURE_TERMINAL)
+        return
+
+    if rewards.ending in OTHER_FAILURE_ENDINGS and "penalty-terminal-failure" not in rewards:
+        rewards.add(PENALTY_FAILURE_TERMINAL)
 
 class TrainingScenarioDefinition(BaseModel):
     """A scenario in the game to train on.  This is a combination of critics and end conditions."""
@@ -509,6 +537,8 @@ class ScenarioWrapper(gym.Wrapper):
                     rewards.ending = end_reason
                     break
 
+        self._apply_terminal_penalty(rewards)
+
         # Update metrics
         self._metrics.step(state_change, rewards)
         if terminated or truncated:
@@ -518,6 +548,9 @@ class ScenarioWrapper(gym.Wrapper):
         self.room_selector.step(state_change, rewards.ending)
 
         return obs, rewards, terminated, truncated, state_change
+
+    def _apply_terminal_penalty(self, rewards: StepRewards) -> None:
+        apply_terminal_penalty(rewards)
 
     def _try_save_state(self, state_change):
         state = state_change.state

--- a/triforce/scenario_wrapper.py
+++ b/triforce/scenario_wrapper.py
@@ -12,11 +12,12 @@ import yaml
 
 from .metrics import MetricTracker
 from .objectives import get_objective_selector
-from .rewards import Penalty, StepRewards, TERMINAL_FAILURE_PENALTY_VALUE
+from .rewards import Penalty, Reward, StepRewards, TERMINAL_FAILURE_PENALTY_VALUE, TERMINAL_SUCCESS_REWARD_VALUE
 from .zelda_enums import Direction, MapLocation
 from . import critics
 from . import end_conditions
 
+REWARD_TERMINAL_SUCCESS = Reward("reward-terminal-success", TERMINAL_SUCCESS_REWARD_VALUE)
 PENALTY_FAILURE_TERMINAL = Penalty("penalty-terminal-failure", -TERMINAL_FAILURE_PENALTY_VALUE)
 HARD_FAILURE_ENDINGS = frozenset({"failure-terminated-death", "failure-stuck", "failure-no-progress"})
 OTHER_FAILURE_ENDINGS = frozenset({
@@ -25,9 +26,14 @@ OTHER_FAILURE_ENDINGS = frozenset({
     "failure-wrong-exit",
 })
 
-def apply_terminal_penalty(rewards: StepRewards) -> None:
-    """Adds terminal failure penalties after end conditions set rewards.ending."""
-    if rewards.ending is None or rewards.ending.startswith("success-"):
+def apply_terminal_rewards(rewards: StepRewards) -> None:
+    """Adds terminal success or failure rewards after end conditions set rewards.ending."""
+    if rewards.ending is None:
+        return
+
+    if rewards.ending.startswith("success-"):
+        if "reward-terminal-success" not in rewards:
+            rewards.add(REWARD_TERMINAL_SUCCESS)
         return
 
     if rewards.ending == "failure-wallmastered":
@@ -537,7 +543,7 @@ class ScenarioWrapper(gym.Wrapper):
                     rewards.ending = end_reason
                     break
 
-        self._apply_terminal_penalty(rewards)
+        self._apply_terminal_rewards(rewards)
 
         # Update metrics
         self._metrics.step(state_change, rewards)
@@ -549,8 +555,8 @@ class ScenarioWrapper(gym.Wrapper):
 
         return obs, rewards, terminated, truncated, state_change
 
-    def _apply_terminal_penalty(self, rewards: StepRewards) -> None:
-        apply_terminal_penalty(rewards)
+    def _apply_terminal_rewards(self, rewards: StepRewards) -> None:
+        apply_terminal_rewards(rewards)
 
     def _try_save_state(self, state_change):
         state = state_change.state

--- a/triforce/triforce.yaml
+++ b/triforce/triforce.yaml
@@ -236,6 +236,37 @@ training-circuits:
     exit-criteria:
       metric: success-rate
       threshold: 0.1
+- name: experiment5-boss-transfer
+  description: Late Dungeon 1 boss transfer with wallmaster demo retention.
+  kind: weighted
+  scenarios:
+  - scenario: dungeon1-wallmaster-north-exit
+    weight: 10
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.8
+  - scenario: dungeon1-aquamentus-east
+    weight: 80
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.6
+  - scenario: dungeon1-late-chain
+    weight: 10
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.1
+- name: experiment5-circuit
+  description: Boss-transfer curriculum after Experiment 4 wallmaster retention.
+  final-eval-scenario: dungeon1-late-chain
+  final-eval-episodes: 100
+  scenarios:
+  - circuit: experiment5-boss-transfer
+    iterations: 2000000
+  - scenario: dungeon1-late-chain
+    iterations: 1000000
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.1
 - name: all-items-circuit
   description: 'Full curriculum: sword-only basics, item training with finite/infinite
     bombs, dungeon with wallmasters, overworld2 route, full game, and polish phase.'

--- a/triforce/triforce.yaml
+++ b/triforce/triforce.yaml
@@ -180,6 +180,21 @@ training-circuits:
     exit-criteria:
       metric: success-rate
       threshold: 0.1
+- name: experiment2-circuit
+  description: Dungeon room acclimation followed by wallmaster north-exit experiment with explicit terminal success reward.
+  final-eval-scenario: dungeon1-wallmaster-north-exit
+  final-eval-episodes: 100
+  scenarios:
+  - scenario: dungeon1-room-walk
+    iterations: 500000
+    exit-criteria:
+      metric: room-result/correct-exit
+      threshold: 0.8
+  - scenario: dungeon1-wallmaster-north-exit
+    iterations: 750000
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.5
 - name: all-items-circuit
   description: 'Full curriculum: sword-only basics, item training with finite/infinite
     bombs, dungeon with wallmasters, overworld2 route, full game, and polish phase.'

--- a/triforce/triforce.yaml
+++ b/triforce/triforce.yaml
@@ -205,6 +205,37 @@ training-circuits:
     exit-criteria:
       metric: success-rate
       threshold: 0.5
+- name: experiment4-late-chain-demo
+  description: Late Dungeon 1 transfer with wallmaster demo regularization.
+  kind: weighted
+  scenarios:
+  - scenario: dungeon1-wallmaster-north-exit
+    weight: 30
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.5
+  - scenario: dungeon1-late-chain
+    weight: 50
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.1
+  - scenario: dungeon1-aquamentus-east
+    weight: 20
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.2
+- name: experiment4-circuit
+  description: Demo-regularized late-chain transfer after Experiment 3 wallmaster success.
+  final-eval-scenario: dungeon1-late-chain
+  final-eval-episodes: 100
+  scenarios:
+  - circuit: experiment4-late-chain-demo
+    iterations: 1500000
+  - scenario: dungeon1-finite-bombs
+    iterations: 500000
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.1
 - name: all-items-circuit
   description: 'Full curriculum: sword-only basics, item training with finite/infinite
     bombs, dungeon with wallmasters, overworld2 route, full game, and polish phase.'

--- a/triforce/triforce.yaml
+++ b/triforce/triforce.yaml
@@ -195,6 +195,16 @@ training-circuits:
     exit-criteria:
       metric: success-rate
       threshold: 0.5
+- name: experiment3-circuit
+  description: PPO fine-tuning for wallmaster north exit after behavior-cloning warm start.
+  final-eval-scenario: dungeon1-wallmaster-north-exit
+  final-eval-episodes: 100
+  scenarios:
+  - scenario: dungeon1-wallmaster-north-exit
+    iterations: 750000
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.5
 - name: all-items-circuit
   description: 'Full curriculum: sword-only basics, item training with finite/infinite
     bombs, dungeon with wallmasters, overworld2 route, full game, and polish phase.'

--- a/triforce/triforce.yaml
+++ b/triforce/triforce.yaml
@@ -139,6 +139,47 @@ training-circuits:
     weight: 1
   - scenario: overworld-sword
     weight: 1
+- name: dungeon1-endgame-skills
+  description: 'Focused late Dungeon 1 endgame skills: Red Goriya, Wallmaster, Aquamentus, and late-chain integration.'
+  kind: weighted
+  scenarios:
+  - scenario: dungeon1-red-goriya-east
+    weight: 25
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.7
+  - scenario: dungeon1-wallmaster-north-exit
+    weight: 35
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.7
+  - scenario: dungeon1-aquamentus-east
+    weight: 25
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.5
+  - scenario: dungeon1-late-chain
+    weight: 15
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.2
+- name: experiment1-circuit
+  description: Focused Experiment 1 late-Dungeon-1 curriculum after reward accounting fixes.
+  final-eval-scenario: full-game-all-items-finite
+  final-eval-episodes: 100
+  scenarios:
+  - circuit: dungeon1-endgame-skills
+    iterations: 2500000
+  - scenario: dungeon1-finite-bombs
+    iterations: 1000000
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.2
+  - scenario: full-game-all-items-finite
+    iterations: 1000000
+    exit-criteria:
+      metric: success-rate
+      threshold: 0.1
 - name: all-items-circuit
   description: 'Full curriculum: sword-only basics, item training with finite/infinite
     bombs, dungeon with wallmasters, overworld2 route, full game, and polish phase.'
@@ -577,6 +618,132 @@ scenarios:
   per_frame:
     bombs: 4
     rupees: 100
+- name: dungeon1-red-goriya-east
+  description: 'Red Goriya room: enter from west and reach the wallmaster room.'
+  iterations: 500000
+  scenario_selector: round-robin
+  objective: ReachLocation
+  objective_params:
+    level: 1
+    location: '0x45'
+  critic: GameplayCritic
+  end_conditions:
+  - ReachedLocation
+  - LeftRoute
+  - GameOver
+  - Timeout
+  metrics:
+  - success-rate
+  - dungeon1-progress
+  - room-health
+  - ending
+  - reward-average
+  - reward-details
+  start:
+  - 1_44w
+  use_hints: true
+  per_reset:
+    regular_boomerang: 1
+    bombs: 4
+    keys: 1
+    hearts_and_containers: 34
+    partial_hearts: 254
+- name: dungeon1-wallmaster-north-exit
+  description: 'Wallmaster room: enter from west and reach the boss room north exit.'
+  iterations: 750000
+  scenario_selector: round-robin
+  objective: ReachLocation
+  objective_params:
+    level: 1
+    location: '0x35'
+  critic: GameplayCritic
+  end_conditions:
+  - ReachedLocation
+  - LeftWallmasterRoom
+  - LeftDungeon
+  - GameOver
+  - Timeout
+  metrics:
+  - success-rate
+  - dungeon1-progress
+  - room-health
+  - ending
+  - reward-average
+  - reward-details
+  start:
+  - 1_45w
+  use_hints: true
+  per_reset:
+    regular_boomerang: 1
+    bombs: 4
+    keys: 1
+    hearts_and_containers: 34
+    partial_hearts: 254
+- name: dungeon1-aquamentus-east
+  description: 'Aquamentus room: defeat or survive boss room and reach the triforce room.'
+  iterations: 750000
+  scenario_selector: round-robin
+  objective: ReachLocation
+  objective_params:
+    level: 1
+    location: '0x36'
+  critic: GameplayCritic
+  end_conditions:
+  - ReachedLocation
+  - DefeatedBoss
+  - GameOver
+  - Timeout
+  metrics:
+  - success-rate
+  - dungeon1-progress
+  - room-health
+  - ending
+  - reward-average
+  - reward-details
+  start:
+  - 1_35s
+  use_hints: true
+  per_reset:
+    regular_boomerang: 1
+    bombs: 4
+    keys: 1
+    hearts_and_containers: 34
+    partial_hearts: 254
+- name: dungeon1-late-chain
+  description: 'Late Dungeon 1 route from the locked-door branch through Red Goriya, Wallmaster, Aquamentus, and Triforce.'
+  iterations: 1000000
+  scenario_selector: round-robin
+  objective: TreasureObjective
+  objective_params:
+    treasure: triforce
+  critic: GameplayCritic
+  end_conditions:
+  - LeftDungeon
+  - GainedTriforce
+  - CollectedTreasure
+  - GameOver
+  - Timeout
+  - NowhereToGoCondition
+  metrics:
+  - success-rate
+  - dungeon1-progress
+  - game-progress
+  - room-health
+  - ending
+  - reward-average
+  - reward-details
+  start:
+  - 1_43e
+  - 1_44w
+  - 1_45w
+  - 1_35s
+  use_hints: true
+  per_reset:
+    regular_boomerang: 1
+    bombs: 4
+    keys: 2
+    hearts_and_containers: 34
+    partial_hearts: 254
 - name: dungeon1-all-items
   description: Full dungeon 1 with all items equipped.
   iterations: 5000000


### PR DESCRIPTION
## What this lands

Documentation and experiment-record only. No training code or curriculum is recommended for reuse.

### experiment5 record (495dd24)
Experiment 5 (boss-transfer curriculum) is **complete** and classified **failure**:
- Wallmaster retention held (eval success-rate 1.0).
- Boss transfer failed: Aquamentus eval 0.0, 100/100 episodes `failure-left-boss-room`.
- Late-chain regressed to `progress/max=14` (exp4 had 16).

Lands the append-only ledger (`experiment-memory.md`), tracked summary, the `experiment5-*` circuit
definitions in `triforce.yaml` (referenced by run history), and `tests/test_experiment5_config.py`.
The `experiment5-circuit` curriculum is explicitly marked do-not-reuse. Also gitignores `graphify-out/`.

### Dungeon 1 completion master plan (9d1684c)
Living blueprint: verified root-cause of the boss failure (`failure-left-boss-room` priced at −0.25 vs
−20 for every other non-win), a 47-task checkboxed queue across tooling/probes/reward-spec/demos/
curriculum/structural/integration phases, and archaeology of the `origin/original-design` branch that
beat Dungeon 1 (68.3% boss kills, zero flee-outs).

## Verification
- `pytest tests/test_experiment5_config.py` — 2 passed.