### PR TITLE
P1+P2: combat trace diagnostics, bounded evaluations, loud eval failures

### DIFF
--- a/diagnose.py
+++ b/diagnose.py
@@ -22,6 +22,7 @@ Usage:
 import argparse
 import glob as globmod
 import os
+import statistics
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -91,6 +92,13 @@ PROGRESS_MAP = {
 }
 
 STUCK_THRESHOLD = 200  # steps in one room before flagging as stuck
+
+# Action kinds that constitute an "attack" (used by --combat-trace attack summary).
+# Everything except MOVE and the consumable/utility buttons (WHISTLE/FOOD/POTION).
+ATTACK_ACTION_KINDS = frozenset({
+    ActionKind.SWORD, ActionKind.BEAMS, ActionKind.BOMBS,
+    ActionKind.ARROW, ActionKind.WAND, ActionKind.BOOMERANG, ActionKind.CANDLE,
+})
 
 
 class DiagnosticWrapper(gym.Wrapper):
@@ -424,8 +432,34 @@ class PbrsStepRecord:
     enemy_ids: tuple = ()   # enemy type IDs this step
 
 
+@dataclass
+class CombatStepRecord:
+    """Per-step combat detail captured by --combat-trace."""
+    step: int
+    room: int                       # curr.location (int)
+    room_changed: bool
+    action_kind: str                # sc.action.kind.name
+    action_dir: str                 # sc.action.direction.name
+    link_tile: tuple                # (tile.x, tile.y)
+    link_pos: tuple                 # (position.x, position.y)
+    link_health: float
+    link_max_health: int
+    beams_available: bool
+    hits: int                       # sc.hits (number of enemies hit)
+    damage_dealt: int               # sc.damage_dealt
+    health_lost: float              # sc.health_lost (half-hearts)
+    enemies_hit: tuple              # ((enemy_index, damage), ...)
+    enemies: tuple                  # per-enemy snapshot, see _run_combat_episode
+    objective: str                  # objective kind name (or "NONE")
+    next_rooms: tuple               # (str(room), ...)
+    masked_moves: tuple             # cardinal dirs where MOVE is masked
+    allowed_moves: tuple            # cardinal dirs where MOVE is allowed
+    rewards: tuple                  # ((name, value, count), ...)
+    ending: Optional[str] = None
+
+
 def run_pbrs_diagnostic(model_name, scenario_name, model_path,  # pylint: disable=too-many-statements
-                        episodes, tail, output_path):
+                        episodes, tail, output_path, trace_endings=None):
     """Run episodes looking for stuck/timeout endings, then print step-by-step PBRS detail."""
     scenario_def = TrainingScenarioDefinition.get(scenario_name)
     metadata = Network.load_metadata(model_path)
@@ -452,14 +486,15 @@ def run_pbrs_diagnostic(model_name, scenario_name, model_path,  # pylint: disabl
     w(f"Scenario: {scenario_name}")
     w("=" * 90)
 
+    endings_filter = trace_endings if trace_endings else ["stuck", "no-next-room"]
     found_stuck = 0
     for ep_idx in range(episodes):
         result = _run_pbrs_episode(env, network, ep_idx)
         ep_steps, ending, _, room_segments = result
 
-        is_stuck = ending and "stuck" in ending or "no-next-room" in ending
+        is_stuck = _matches_endings(ending, endings_filter)
         print(f"  Episode {ep_idx+1}/{episodes}: steps={ep_steps}, ending={ending}, "
-              f"stuck={'YES' if is_stuck else 'no'}")
+              f"match={'YES' if is_stuck else 'no'}")
 
         if not is_stuck:
             continue
@@ -715,6 +750,268 @@ def _run_pbrs_episode(env, network, _ep_idx):  # pylint: disable=too-many-statem
         room_segments.append((current_room_id, current_room_steps))
 
     return step_num, ending, all_steps, room_segments
+
+
+# ---------------------------------------------------------------------------
+# --combat-trace mode: per-step combat/boss trace
+# ---------------------------------------------------------------------------
+
+def _percentiles(values):
+    """Return (min, p25, p50, p75, max) for a list of numbers, or None if empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        v = ordered[0]
+        return (v, v, v, v, v)
+    q = statistics.quantiles(ordered, n=4, method="inclusive")
+    return (ordered[0], q[0], q[1], q[2], ordered[-1])
+
+
+def _matches_endings(ending, trace_endings):
+    """True if this episode should be traced given the ending substring filter."""
+    if not trace_endings:
+        return True
+    if ending is None:
+        return False
+    return any(sub in ending for sub in trace_endings)
+
+
+def run_combat_diagnostic(model_name, scenario_name, model_path,  # pylint: disable=too-many-statements,too-many-locals,too-many-arguments
+                          episodes, tail, trace_endings, trace_max_episodes, output_path):
+    """Run episodes and print per-step combat detail for those matching --trace-endings."""
+    scenario_def = TrainingScenarioDefinition.get(scenario_name)
+    metadata = Network.load_metadata(model_path)
+    model_kind = ModelKindDefinition.get(metadata["model_kind"] or model_name)
+    action_space_def = ActionSpaceDefinition.get(metadata["action_space_name"] or "basic")
+    multihead = getattr(model_kind.network_class, 'is_multihead', False)
+
+    obs_kind, frame_stack = infer_obs_kind(metadata["obs_space"])
+    env = make_zelda_env(scenario_def, action_space_def.actions,
+                         render_mode=None, multihead=multihead, translation=False,
+                         obs_kind=obs_kind, frame_stack=frame_stack)
+    env = DiagnosticWrapper(env)
+
+    obs_space, act_space = Network.load_spaces(model_path)
+    network = model_kind.network_class(obs_space, act_space)
+    network.load(model_path)
+    network.eval()
+
+    lines = []
+    w = lines.append
+    w("=" * 90)
+    w(f"COMBAT TRACE: {model_name}")
+    w(f"Model: {model_path}")
+    w(f"Scenario: {scenario_name}")
+    w(f"Trace endings: {trace_endings if trace_endings else '(all)'}")
+    w("=" * 90)
+
+    traced = 0
+    for ep_idx in range(episodes):
+        ep_steps, ending, all_steps = _run_combat_episode(env, network, ep_idx)
+        is_traced = _matches_endings(ending, trace_endings)
+        print(f"  Episode {ep_idx+1}/{episodes}: steps={ep_steps}, ending={ending}, "
+              f"traced={'YES' if is_traced else 'no'}")
+
+        if not is_traced:
+            continue
+
+        traced += 1
+        if traced > trace_max_episodes:
+            continue
+
+        _render_combat_episode(w, ep_idx, ending, ep_steps, all_steps, tail)
+
+    env.close()
+
+    if traced == 0:
+        w("\n  No episodes matched the ending filter.")
+    elif traced > trace_max_episodes:
+        w(f"\n(Showing first {trace_max_episodes} traced episodes, "
+          f"{traced - trace_max_episodes} more matched.)")
+
+    w("")
+    w("=" * 90)
+    w("END OF COMBAT TRACE")
+    w("=" * 90)
+
+    report = "\n".join(lines)
+    if output_path:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(report)
+        print(f"\nReport written to: {output_path}")
+    else:
+        print(report)
+
+
+def _render_combat_episode(w, ep_idx, ending, ep_steps, all_steps, tail):  # pylint: disable=too-many-locals
+    """Append the full per-episode combat report block via writer `w`."""
+    w("")
+    w(f"## EPISODE {ep_idx+1} — ended: {ending} ({ep_steps} steps)")
+
+    # Exit attribution: last step that changed room.
+    exit_steps = [s for s in all_steps if s.room_changed]
+    if exit_steps:
+        ex = exit_steps[-1]
+        w(f"  Exit: step {ex.step}  tile {ex.link_tile}  action {ex.action_kind}/{ex.action_dir}  "
+          f"MOVE masked={ex.masked_moves} allowed={ex.allowed_moves}")
+    else:
+        w("  Exit: no room-change exit (ended in boss room)")
+
+    # Attack summary.
+    attack_steps = sum(1 for s in all_steps if s.action_kind in _ATTACK_KIND_NAMES)
+    total_hits = sum(s.hits for s in all_steps)
+    total_damage = sum(s.damage_dealt for s in all_steps)
+    total_health_lost = sum(s.health_lost for s in all_steps)
+    w(f"  Attacks: {attack_steps}/{len(all_steps)} steps  hits={total_hits}  "
+      f"damage_dealt={total_damage}  health_lost={total_health_lost}")
+
+    # Enemies observed: unique type names with the health range seen (boss HP countdown).
+    health_by_name = defaultdict(list)
+    for s in all_steps:
+        for e in s.enemies:
+            health_by_name[e[0]].append(e[2])
+    if health_by_name:
+        parts = [f"{name} hp {min(hs)}..{max(hs)}" for name, hs in sorted(health_by_name.items())]
+        w(f"  Enemies observed: {'; '.join(parts)}")
+    else:
+        w("  Enemies observed: none")
+
+    # Damage timeline.
+    dmg_steps = [s for s in all_steps if s.damage_dealt > 0 or s.health_lost > 0]
+    if dmg_steps:
+        w(f"  Damage timeline ({len(dmg_steps)} events):")
+        for s in dmg_steps:
+            w(f"    step {s.step}: {s.action_kind}/{s.action_dir}  hit={s.enemies_hit}  "
+              f"dmg_dealt={s.damage_dealt}  health_lost={s.health_lost}")
+    else:
+        w("  Damage timeline: none (no hits landed, no health lost)")
+
+    # Distance-to-nearest-enemy percentiles (first enemy is nearest; enemies are distance-sorted).
+    near_dists = [s.enemies[0][4] for s in all_steps if s.enemies]
+    pcts = _percentiles(near_dists)
+    if pcts:
+        w(f"  Nearest-enemy distance: min={pcts[0]:.1f} p25={pcts[1]:.1f} p50={pcts[2]:.1f} "
+          f"p75={pcts[3]:.1f} max={pcts[4]:.1f}  ({len(near_dists)} steps with enemies)")
+    else:
+        w("  Nearest-enemy distance: no enemies observed")
+
+    # Per-step table (last `tail` steps).
+    show = all_steps[-tail:]
+    start_idx = len(all_steps) - len(show)
+    w(f"\n  Last {len(show)} steps (of {len(all_steps)}):")
+    w(f"  {'Step':>5s}  {'Act':>8s} {'Dir':>4s}  {'LinkTile':>10s}  {'HP':>5s} {'Bm':>2s}  "
+      f"{'Ht':>2s} {'Dmg':>3s} {'HL':>4s}  {'Obj':>8s}  {'MaskS':>8s}  Rewards")
+    w(f"  {'-'*5}  {'-'*8} {'-'*4}  {'-'*10}  {'-'*5} {'-'*2}  "
+      f"{'-'*2} {'-'*3} {'-'*4}  {'-'*8}  {'-'*8}  {'-'*30}")
+    for s in show:
+        reward_str = ", ".join(f"{n}={v:+.2f}" for n, v, _ in s.rewards if v != 0)
+        masked = ",".join(s.masked_moves) if s.masked_moves else "-"
+        w(f"  {s.step:5d}  {s.action_kind:>8s} {s.action_dir:>4s}  {str(s.link_tile):>10s}  "
+          f"{s.link_health:5.1f} {('Y' if s.beams_available else 'n'):>2s}  "
+          f"{s.hits:2d} {s.damage_dealt:3d} {s.health_lost:4.1f}  {s.objective:>8s}  "
+          f"{masked:>8s}  {reward_str}")
+    w("")
+    _ = start_idx  # kept for parity with pbrs table; step numbers are absolute
+
+
+# Attack action-kind names (str) for fast per-step membership checks in the report.
+_ATTACK_KIND_NAMES = frozenset(k.name for k in ATTACK_ACTION_KINDS)
+
+
+def _run_combat_episode(env, network, _ep_idx):  # pylint: disable=too-many-locals
+    """Run one episode, capturing per-step combat detail. Returns (steps, ending, all_steps)."""
+    obs, info = env.reset()
+
+    all_steps = []
+    step_num = 0
+    ending = None
+    cardinals = (Direction.N, Direction.S, Direction.W, Direction.E)
+    try:
+        is_valid_action = env.get_wrapper_attr('is_valid_action')
+    except AttributeError:
+        is_valid_action = None
+
+    terminated = truncated = False
+    while not terminated and not truncated:
+        action_mask = info.get('action_mask', None)
+        if action_mask is not None:
+            action_mask = action_mask.unsqueeze(0) if action_mask.dim() == 1 else action_mask
+
+        action = network.get_action(obs, action_mask)
+        action = action.squeeze(0)
+        obs, _, terminated, truncated, info = env.step(action)
+
+        sc = env.last_state_change
+        rewards = env.last_rewards
+        curr = sc.state
+
+        link = curr.link
+        tile = link.tile
+        pos = link.position
+
+        enemies = tuple(
+            (
+                e.id.name if hasattr(e.id, 'name') else str(e.id),
+                e.index,
+                e.health,
+                (e.position.x, e.position.y),
+                round(float(e.distance), 1),
+                e.is_active,
+                e.is_stunned,
+                e.stun_timer,
+                e.is_dying,
+            )
+            for e in curr.enemies
+        )
+
+        objectives = curr.objectives
+        if objectives is not None:
+            obj_kind = objectives.kind.name
+            next_rooms = tuple(str(r) for r in objectives.next_rooms)
+        else:
+            obj_kind = "NONE"
+            next_rooms = ()
+
+        masked_moves = []
+        allowed_moves = []
+        if sc.action_mask is not None and is_valid_action is not None:
+            for d in cardinals:
+                if is_valid_action((ActionKind.MOVE, d), sc.action_mask):
+                    allowed_moves.append(d.name)
+                else:
+                    masked_moves.append(d.name)
+
+        record = CombatStepRecord(
+            step=step_num,
+            room=curr.location,
+            room_changed=sc.changed_location,
+            action_kind=sc.action.kind.name,
+            action_dir=sc.action.direction.name,
+            link_tile=(tile.x, tile.y),
+            link_pos=(pos.x, pos.y),
+            link_health=link.health,
+            link_max_health=link.max_health,
+            beams_available=link.are_beams_available,
+            hits=sc.hits,
+            damage_dealt=sc.damage_dealt,
+            health_lost=sc.health_lost,
+            enemies_hit=tuple(sorted(sc.enemies_hit.items())),
+            enemies=enemies,
+            objective=obj_kind,
+            next_rooms=next_rooms,
+            masked_moves=tuple(masked_moves),
+            allowed_moves=tuple(allowed_moves),
+            rewards=tuple((o.name, o.value, o.count) for o in rewards),
+        )
+        all_steps.append(record)
+        step_num += 1
+
+        if rewards.ending is not None:
+            ending = str(rewards.ending)
+            record.ending = ending
+
+    return step_num, ending, all_steps
 
 
 # ---------------------------------------------------------------------------
@@ -1126,6 +1423,15 @@ def parse_args():
                              "PBRS calculation for the stuck room")
     parser.add_argument("--tail", type=int, default=50,
                         help="Number of trailing steps to show in --infinite-pbrs mode (default: 50)")
+    parser.add_argument("--combat-trace", action="store_true",
+                        help="Run combat/boss trace: per-step action, enemy, hit, reward, "
+                             "objective, and MOVE-mask detail for episodes matching --trace-endings")
+    parser.add_argument("--trace-endings", default=None,
+                        help="Comma-separated ending substrings to trace (e.g. "
+                             "'left-boss-room,death'). --infinite-pbrs default keeps "
+                             "stuck/no-next-room; --combat-trace default traces all endings")
+    parser.add_argument("--trace-max-episodes", type=int, default=5,
+                        help="Max episodes to print full traces for in --combat-trace (default: 5)")
     parser.add_argument("--invariants", action="store_true",
                         help="Run movement/reward invariant checker: detect zero-movement, "
                              "missing wavefronts, empty masks, and zero-PBRS violations")
@@ -1185,9 +1491,14 @@ def main():
 
     model_path = resolve_model_path(args.model_path)
 
-    if args.infinite_pbrs:
+    parsed_endings = [s for s in args.trace_endings.split(",") if s] if args.trace_endings else None
+
+    if args.combat_trace:
+        run_combat_diagnostic(args.model, args.scenario, model_path, args.episodes,
+                              args.tail, parsed_endings or [], args.trace_max_episodes, args.output)
+    elif args.infinite_pbrs:
         run_pbrs_diagnostic(args.model, args.scenario, model_path,
-                            args.episodes, args.tail, args.output)
+                            args.episodes, args.tail, args.output, parsed_endings)
     elif args.invariants:
         run_invariant_checker(args.model, args.scenario, model_path,
                               args.episodes, args.output)

--- a/docs/experiments/dungeon1-completion-plan.md
+++ b/docs/experiments/dungeon1-completion-plan.md
@@ -100,55 +100,55 @@ Line numbers refresh via: `grep -n '^### ' docs/experiments/dungeon1-completion-
 
 | # | Task | Phase | Line |
 |---|------|-------|-----:|
-| [ ] ⛔ | P1 Combat/boss trace mode for diagnose.py | P Tooling | 314 |
-| [ ] ⛔ | P2 Fix evaluation hang + silent no-artifact evals | P Tooling | 335 |
-| [ ] | P3 Fix restart crash on completed circuits (train.py:1290) | P Tooling | 358 |
-| [ ] | P4 --compare must compare success-rate | P Tooling | 368 |
-| [ ] ⛔ | P5 Weighted-circuit exit criteria gate on primary scenario | P Tooling | 378 |
-| [ ] | P6 Verify worker metric aggregation under --parallel | P Tooling | 388 |
-| [ ] | P0 Land or discard the experiment5 branch leftovers | P Tooling | 399 |
-| [ ] ⛔ | V1 Empirical root-cause confirmation trace | V Probes | 412 |
-| [ ] ⛔ | V2 Scripted boss-kill probe (beams / bombs / melee) | V Probes | 424 |
-| [ ] | V3 DefeatedBoss false-positive check | V Probes | 447 |
-| [ ] | V4 Trace the hint-mask escape route | V Probes | 459 |
-| [ ] | V5 Fireball dodgeability / beam retention measurement | V Probes | 471 |
-| [ ] | V6 Aquamentus RAM fact sheet | V Probes | 481 |
-| [ ] ⛔ | R1 Terminal parity: leaving the boss room = −20 | R Reward spec | 496 |
-| [ ] ⛔ | R2 Boss-damage rewards, stall reset on hits, boss PBRS scale | R Reward spec | 513 |
-| [ ] ⛔ | R3 FIGHT rooms get route next_rooms (exit semantics) | R Reward spec | 540 |
-| [ ] | R4 Recompute and rebalance the boss-room payoff table | R Reward spec | 562 |
-| [ ] | R5 Split micro-scenarios: kill vs victory-lap | R Reward spec | 576 |
-| [ ] | R6 EXPERIMENT: retrain Aquamentus on the fixed spec | R Reward spec | 590 |
-| [ ] | B1 Demo format: non-MOVE actions | B Demos | 617 |
-| [ ] | B2 Multi-demo support in train.py/ml_ppo.py | B Demos | 631 |
-| [ ] | B3 Acquire a boss-kill demonstration | B Demos | 644 |
-| [ ] | B4 EXPERIMENT: BC + demo-regularized PPO on the boss | B Demos | 656 |
-| [ ] | B5 Value-head warmup after BC | B Demos | 673 |
-| [ ] | C1 Boss-HP reverse curriculum (1hp→2hp→4hp→6hp) | C Curriculum | 687 |
-| [ ] | C2 Mid-fight savestate curriculum | C Curriculum | 705 |
-| [ ] | C3 Invulnerability training wheels (per_frame health) | C Curriculum | 714 |
-| [ ] | C4 Start-state diversity for the boss room | C Curriculum | 730 |
-| [ ] | C5 Victory-lap scenario: post-kill → triforce | C Curriculum | 742 |
-| [ ] | C6 Boss-room action masking of useless items | C Curriculum | 756 |
-| [ ] | S1 Per-head entropy floor / adaptive ent_coef | S Structural | 772 |
-| [ ] | S2 Scope MOVE-only demo-BC loss to the direction head | S Structural | 786 |
-| [ ] | S3 EPOCHS 10→4 and expose LEARNING_RATE | S Structural | 798 |
-| [ ] | S4 Optimizer persistence across circuit legs | S Structural | 808 |
-| [ ] | S5 KL-anchor regularization (fallback to demo-BC) | S Structural | 816 |
-| [ ] | S6 Self-imitation on harvested successes | S Structural | 828 |
-| [ ] | S7 Per-leg ent_coef in circuit YAML | S Structural | 841 |
-| [ ] | S8 Entity distance/vector features (observation) | S Structural | 847 |
-| [ ] | I1 EXPERIMENT: late-chain integration | I Integration | 863 |
-| [ ] | I2 EXPERIMENT: full dungeon 1 | I Integration | 882 |
-| [ ] | I3 EXPERIMENT: full game gate | I Integration | 890 |
-| [ ] | X1 Auto-demo harvesting from scripted policies | X Backlog | 901 |
-| [ ] | X2 Auxiliary boss-HP prediction loss | X Backlog | 906 |
-| [ ] | X3 Sustained-threshold exit criteria | X Backlog | 911 |
-| [ ] | X4 Multi-seed replication harness for micro-scenarios | X Backlog | 916 |
-| [ ] | X5 Beam-alignment shaping (fired-correctly / didn't-fire) | X Backlog | 921 |
-| [ ] | X6 Update stale docs (combat-engagement, nes-mechanics boss section) | X Backlog | 928 |
-| [ ] | X7 Positive-clamp audit for multi-reward kill steps | X Backlog | 934 |
-| [ ] | X8 Fireball danger shaping (danger tiles / wavefront field) | X Backlog | 940 |
+| [x] | P1 Combat/boss trace mode for diagnose.py | P Tooling | 314 |
+| [x] | P2 Fix evaluation hang + silent no-artifact evals | P Tooling | 360 |
+| [ ] | P3 Fix restart crash on completed circuits (train.py:1290) | P Tooling | 414 |
+| [ ] | P4 --compare must compare success-rate | P Tooling | 424 |
+| [ ] ⛔ | P5 Weighted-circuit exit criteria gate on primary scenario | P Tooling | 434 |
+| [ ] | P6 Verify worker metric aggregation under --parallel | P Tooling | 444 |
+| [ ] | P0 Land or discard the experiment5 branch leftovers | P Tooling | 455 |
+| [ ] ⛔ | V1 Empirical root-cause confirmation trace | V Probes | 468 |
+| [ ] ⛔ | V2 Scripted boss-kill probe (beams / bombs / melee) | V Probes | 480 |
+| [ ] | V3 DefeatedBoss false-positive check | V Probes | 503 |
+| [ ] | V4 Trace the hint-mask escape route | V Probes | 515 |
+| [ ] | V5 Fireball dodgeability / beam retention measurement | V Probes | 527 |
+| [ ] | V6 Aquamentus RAM fact sheet | V Probes | 537 |
+| [ ] ⛔ | R1 Terminal parity: leaving the boss room = −20 | R Reward spec | 552 |
+| [ ] ⛔ | R2 Boss-damage rewards, stall reset on hits, boss PBRS scale | R Reward spec | 569 |
+| [ ] ⛔ | R3 FIGHT rooms get route next_rooms (exit semantics) | R Reward spec | 596 |
+| [ ] | R4 Recompute and rebalance the boss-room payoff table | R Reward spec | 618 |
+| [ ] | R5 Split micro-scenarios: kill vs victory-lap | R Reward spec | 632 |
+| [ ] | R6 EXPERIMENT: retrain Aquamentus on the fixed spec | R Reward spec | 646 |
+| [ ] | B1 Demo format: non-MOVE actions | B Demos | 673 |
+| [ ] | B2 Multi-demo support in train.py/ml_ppo.py | B Demos | 687 |
+| [ ] | B3 Acquire a boss-kill demonstration | B Demos | 700 |
+| [ ] | B4 EXPERIMENT: BC + demo-regularized PPO on the boss | B Demos | 712 |
+| [ ] | B5 Value-head warmup after BC | B Demos | 729 |
+| [ ] | C1 Boss-HP reverse curriculum (1hp→2hp→4hp→6hp) | C Curriculum | 743 |
+| [ ] | C2 Mid-fight savestate curriculum | C Curriculum | 761 |
+| [ ] | C3 Invulnerability training wheels (per_frame health) | C Curriculum | 770 |
+| [ ] | C4 Start-state diversity for the boss room | C Curriculum | 786 |
+| [ ] | C5 Victory-lap scenario: post-kill → triforce | C Curriculum | 798 |
+| [ ] | C6 Boss-room action masking of useless items | C Curriculum | 812 |
+| [ ] | S1 Per-head entropy floor / adaptive ent_coef | S Structural | 828 |
+| [ ] | S2 Scope MOVE-only demo-BC loss to the direction head | S Structural | 842 |
+| [ ] | S3 EPOCHS 10→4 and expose LEARNING_RATE | S Structural | 854 |
+| [ ] | S4 Optimizer persistence across circuit legs | S Structural | 864 |
+| [ ] | S5 KL-anchor regularization (fallback to demo-BC) | S Structural | 872 |
+| [ ] | S6 Self-imitation on harvested successes | S Structural | 884 |
+| [ ] | S7 Per-leg ent_coef in circuit YAML | S Structural | 897 |
+| [ ] | S8 Entity distance/vector features (observation) | S Structural | 903 |
+| [ ] | I1 EXPERIMENT: late-chain integration | I Integration | 919 |
+| [ ] | I2 EXPERIMENT: full dungeon 1 | I Integration | 938 |
+| [ ] | I3 EXPERIMENT: full game gate | I Integration | 946 |
+| [ ] | X1 Auto-demo harvesting from scripted policies | X Backlog | 957 |
+| [ ] | X2 Auxiliary boss-HP prediction loss | X Backlog | 962 |
+| [ ] | X3 Sustained-threshold exit criteria | X Backlog | 967 |
+| [ ] | X4 Multi-seed replication harness for micro-scenarios | X Backlog | 972 |
+| [ ] | X5 Beam-alignment shaping (fired-correctly / didn't-fire) | X Backlog | 977 |
+| [ ] | X6 Update stale docs (combat-engagement, nes-mechanics boss section) | X Backlog | 984 |
+| [ ] | X7 Positive-clamp audit for multi-reward kill steps | X Backlog | 990 |
+| [ ] | X8 Fireball danger shaping (danger tiles / wavefront field) | X Backlog | 996 |
 
 **Recommended experiment queue (the spine; everything else supports it):**
 1. **EXP6 (probes, no training):** P1+P2 → V1..V6. Deliverable: empirical root-cause verdict + a scripted boss-kill trace.
@@ -330,7 +330,32 @@ exit, boss-directed gradient, aggression ratio, alignment shaping), not the raw 
 --model-path training/experiments/experiment5/runs/experiment5-circuit/4/impala-multihead_all-items.pt
 --combat-trace --trace-endings left-boss-room --episodes 10 -o /tmp/boss-trace.txt` produces per-step
 traces for ≥5 episodes with exit attribution.
-**Outcome:** _not attempted_
+**Outcome:** ✅ **DONE 2026-08-04.** Implemented `--combat-trace` in `diagnose.py` (PR #192, commit
+`07d9be5`). `CombatStepRecord` captures per step: action kind/direction, Link tile/position/health/
+beams-available, `hits`/`damage_dealt`/`health_lost`, `enemies_hit` indices, per-enemy snapshot (id,
+index, health, position, distance, is_active, is_stunned, stun_timer, is_dying), objective kind +
+`next_rooms`, MOVE-mask summary, full rewards breakdown. Per-episode report: exit attribution, attack
+summary, enemies-observed w/ HP range, damage timeline, nearest-enemy distance percentiles, `--tail`
+step table. `--trace-endings` replaces the hardcoded filter and is shared with `--infinite-pbrs`
+(default behavior unchanged); `--trace-max-episodes` bounds output (default 5).
+
+Acceptance command run on the exp5 checkpoint (`--episodes 10 --trace-endings left-boss-room`):
+**10/10 episodes traced**, all `failure-left-boss-room`. Every episode: `Attacks: 0/N steps  hits=0
+damage_dealt=0  health_lost=0`, `Enemies observed: Aquamentus hp 6..6`, exit via `MOVE/S`. Episode
+lengths 6–197 steps. This independently reproduces §1.1 (zero `reward-hit` entries) on a 10-episode
+sample — the boss takes **no damage at all**, ever.
+
+**Two things the next agent must know:**
+1. **Implementation gotcha:** gymnasium 1.2.3 dropped implicit `Wrapper.__getattr__` delegation, so
+   the MOVE-mask readout resolves `is_valid_action` via `env.get_wrapper_attr('is_valid_action')`.
+   Any new diagnose mode reaching into `ZeldaActionSpace` must do the same.
+2. **Reading the exit step (matters for V4):** on the room-change step, `link_tile` and `masked_moves`
+   are from the **post-transition** state (e.g. tile `(15, 2)` in the *new* room 1_45). For V4, read
+   the step *before* the room change. Doing so already shows the exit action `MOVE/S` being taken from
+   tile `(15, 19)` = y `0x13` — **below** the `tile.y >= 0x14` hint threshold, so S was never masked
+   there. Traces also show S correctly masked at y=`0x14` (step 60 of one episode: `MaskS = S,W,E`).
+   That is direct support for V4's y-threshold-leak hypothesis; V4 remains open for the full
+   determination but the mechanism is already visible.
 
 ### P2. Fix evaluation hang + silent no-artifact evals ⛔
 **Goal:** we still have NO exp5 late-chain number; the eval ran 124h before SIGKILL, episode rate
@@ -353,7 +378,38 @@ degraded to ~11.5h/episode, and two other plugin evals "completed" without artif
   make both paths loud (warning + nonzero exit), and write the JSON atomically (tmp+rename).
 **Acceptance:** exp4-final and exp5-final both produce `dungeon1-late-chain` eval JSONs (100 eps) in
 bounded time (< 2h); an induced failure (missing MetricTracker) exits nonzero with a clear message.
-**Outcome:** _not attempted_
+**Outcome:** ✅ **DONE 2026-08-04.** PR #192, commit `e2fd96a`. **Hypothesis 1 CONFIRMED** as the
+cause; hypothesis 2 (emulator/FrameSkip wedge) was never reached.
+
+Changes:
+1. **`Timeout` (`end_conditions.py`)** — now resets the no-progress clock only on the **first** entry
+   to each next-room per episode (`__entered_rooms` set, cleared in `clear()`). Genuine forward
+   discovery still resets; re-entering an already-visited room does not, so the `1_45↔1_35` loop
+   accumulates to `no_progress_timeout` and fires `failure-no-progress`. `failure-stuck` untouched.
+2. **`evaluate.py --max-steps`** (default `DEFAULT_MAX_EPISODE_STEPS = 20000`) — cause-agnostic
+   per-episode ceiling; on reach the episode truncates with a distinct **`eval-step-cap`** ending
+   recorded through the normal `MetricTracker` path, so it shows up as `endings/eval-step-cap`.
+3. **`_save_results`** — empty `metrics` or `progress_values is None` now print to stderr and
+   `sys.exit(1)` instead of silently no-op'ing; JSON is written atomically (tmp + `os.replace`).
+4. **Missed callsite fixed:** `train.py:1322` (`--evaluate` post-training path) also calls
+   `evaluate_one_model` and now passes the shared `DEFAULT_MAX_EPISODE_STEPS`. Caught by pylint
+   `E1120`, not by grep — search `train.py` too when changing `evaluate.py` signatures.
+
+Tests: `tests/test_end_conditions_timeout.py` (ping-pong re-entry still times out; fresh discovery
+still resets) and `tests/test_evaluate_save_results.py` (both loud-exit paths). Emulator-free, 4 tests.
+Full suite 783 passed / 1 skipped; pylint 10.00/10.
+
+**Empirical proof the hang is gone:** `dungeon1-late-chain` on exp5-final completed **5 episodes in
+2m21s (~28s/episode), exit 0**, artifact written — versus 124h→SIGKILL before. Endings:
+`failure-no-progress 0.2`, `failure-terminated-death 0.6`, `failure-wallmastered 0.2`. That
+`failure-no-progress` episode is the smoking gun: it is precisely the ending that previously could
+never fire. **`eval-step-cap` never triggered**, so the `Timeout` fix alone resolves the livelock and
+the step cap is pure backstop.
+
+**Remaining measurement (not a code task):** the 100-episode Gate-B readings on exp4-final and
+exp5-final. A 100-ep exp5-final late-chain run was launched at ~28s/ep (≈47 min projected, well inside
+the <2h bound); see §9 for its result. exp4-final still needs its run. Gate B itself
+(success-rate > 0 and progress/max = 17) is I1's business, not P2's.
 
 ### P3. Fix restart crash on completed circuits (train.py:1290)
 **Goal:** `--resume` from a checkpoint whose history already covers the final leg leaves `model=None`
@@ -956,6 +1012,23 @@ _Append dated entries when outcomes change strategy._
   — and recorded 68.3% boss kills with zero flee-outs. Added C6, X5; strengthened R1/R2/R4/S8/X8
   rationale. Port structure, not constants (their shaping was non-potential-based and per-area models
   had no retention constraint).
+- **2026-08-04 (P1+P2 landed, PR #192):** EXP6 tooling done. Two findings that change what the next
+  agent should believe:
+  1. **The eval hang was hypothesis 1, not an emulator wedge.** `Timeout` resetting its no-progress
+     clock on every next-room re-entry was the whole bug. With the first-entry-only fix, late-chain on
+     exp5-final runs ~28s/episode and one of 5 episodes ended `failure-no-progress` — the ending that
+     structurally could not fire before. The `--max-steps` / `eval-step-cap` backstop never triggered.
+     **Consequence:** no emulator-timeout work is needed; treat P2 as closed and trust late-chain
+     numbers from here on. Historical exp5 late-chain "hangs" need no other explanation.
+  2. **The boss takes literally zero damage, confirmed on a 10-episode sample.** `--combat-trace`
+     reports `Attacks: 0/N  hits=0  damage_dealt=0` and `Aquamentus hp 6..6` in 10/10 episodes. This
+     upgrades §1.1's "zero reward-hit entries" from a single-eval reading to a reproducible per-step
+     observation, and it means V1's falsification branch (agent attacks and fails) is **already ruled
+     out** — the spec-bug theory keeps primacy. V1 remains open only to attach realized episode returns
+     to the payoff table.
+  Also visible in the traces, pre-empting V4: the south exit is taken from tile y=`0x13`, one tile
+  above the `tile.y >= 0x14` hint-mask threshold, so hints never mask it. R3 alone will not close that
+  leak.
 
 ---
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -12,6 +12,11 @@ from tqdm import tqdm
 from triforce import ActionSpaceDefinition, ModelKindDefinition, make_zelda_env, Network, \
     TrainingScenarioDefinition, MetricTracker
 
+# Hard per-episode step ceiling for evaluation. Bounds pathological episodes (e.g. a
+# room-to-room ping-pong that never satisfies an end condition) so an eval can never
+# run unbounded. Shared with train.py's post-training --evaluate path.
+DEFAULT_MAX_EPISODE_STEPS = 20000
+
 
 def write_progress_markdown(md_path, progress_values, max_progress, episodes, scenario_name,
                             model_name=None, *, metrics=None):
@@ -225,7 +230,7 @@ def _print_stat_row(filename, steps_trained, metrics: Dict[str, float], metric_c
 
     print(result)
 
-def evaluate_one_model(make_env, network, episodes, progress_callback):
+def evaluate_one_model(make_env, network, episodes, progress_callback, max_steps):
     """Runs a single scenario.  Returns (metrics_dict, progress_values, max_progress)."""
     # pylint: disable=redefined-outer-name,too-many-locals
     env = make_env()
@@ -234,12 +239,19 @@ def evaluate_one_model(make_env, network, episodes, progress_callback):
             obs, info = env.reset()
 
             terminated = truncated = False
+            steps = 0
             while not terminated and not truncated:
                 action_mask = info.get('action_mask', None)
                 action_mask = action_mask.unsqueeze(0) if action_mask is not None else None
                 action = network.get_action(obs, action_mask)
                 action = action.squeeze(0)  # remove batch dim: [1, 2] -> [2] or [1] -> scalar
                 obs, _, terminated, truncated, info = env.step(action)
+                steps += 1
+                if steps >= max_steps and not (terminated or truncated):
+                    tracker = MetricTracker.get_instance()
+                    if tracker is not None:
+                        tracker.end_scenario(False, True, "eval-step-cap")
+                    break
 
             progress_callback()
 
@@ -367,24 +379,33 @@ def main():
 def _save_results(path, metrics, progress_values, max_progress, episodes, scenario):
     """Saves evaluation results: updates model .pt, writes .eval.json and .eval.md."""
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    if metrics:
-        network, _, _ = _load_network_from_path(path)
-        network.metrics = metrics
-        network.episodes_evaluated = episodes
-        network.save(path)
+    if not metrics:
+        print(f"ERROR: evaluation produced no metrics for {path}; not saving results.",
+              file=sys.stderr)
+        sys.exit(1)
+    if progress_values is None:
+        print(f"ERROR: evaluation produced no progress metric for {path}; not saving results.",
+              file=sys.stderr)
+        sys.exit(1)
 
-    if progress_values is not None:
-        json_path = path.rsplit('.', 1)[0] + '.eval.json'
-        eval_data = {
-            'episodes': episodes,
-            'scenario': scenario,
-            'progress_values': progress_values,
-            'max_progress': max_progress,
-            'metrics': metrics,
-        }
-        with open(json_path, 'w', encoding='utf-8') as f:
-            json.dump(eval_data, f, indent=2)
-        convert_eval_json_to_md(json_path)
+    network, _, _ = _load_network_from_path(path)
+    network.metrics = metrics
+    network.episodes_evaluated = episodes
+    network.save(path)
+
+    json_path = path.rsplit('.', 1)[0] + '.eval.json'
+    eval_data = {
+        'episodes': episodes,
+        'scenario': scenario,
+        'progress_values': progress_values,
+        'max_progress': max_progress,
+        'metrics': metrics,
+    }
+    tmp_path = json_path + '.tmp'
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        json.dump(eval_data, f, indent=2)
+    os.replace(tmp_path, json_path)
+    convert_eval_json_to_md(json_path)
 
 
 def _run_sequential(args, scenario_def, to_process, total_episodes):
@@ -406,7 +427,7 @@ def _run_sequential(args, scenario_def, to_process, total_episodes):
                                               frame_stack=args.frame_stack)
 
             metrics, progress_values, max_progress = evaluate_one_model(
-                make_env, network, args.episodes, update_progress)
+                make_env, network, args.episodes, update_progress, args.max_steps)
             _save_results(path, metrics, progress_values, max_progress,
                           args.episodes, args.scenario)
 
@@ -420,6 +441,9 @@ def parse_args():
     parser.add_argument("--episodes", type=int, default=100, help="Number of episodes to test.")
     parser.add_argument("--render", action='store_true', help="Render the game while evaluating the models.")
     parser.add_argument("--limit", type=int, default=-1, help="Limit the number of models to evaluate.")
+    parser.add_argument("--max-steps", type=int, default=DEFAULT_MAX_EPISODE_STEPS,
+                        help="Hard per-episode step cap; on reach, truncate the episode with "
+                             "ending 'eval-step-cap'.")
 
     parser.add_argument('model_path', nargs='?', default=None,
                         help='Path to a .pt model file or directory of .pt files.')

--- a/tests/test_end_conditions_timeout.py
+++ b/tests/test_end_conditions_timeout.py
@@ -1,0 +1,61 @@
+# pylint: disable=all
+"""Tests for Timeout end condition no-progress reset semantics."""
+
+from types import SimpleNamespace
+
+from triforce.end_conditions import Timeout
+
+
+def _sc(prev_loc, curr_loc, next_rooms, pos_prev, pos_curr, hits=1):
+    prev = SimpleNamespace(link=SimpleNamespace(position=pos_prev), full_location=prev_loc,
+                           objectives=SimpleNamespace(next_rooms=set(next_rooms)))
+    curr = SimpleNamespace(link=SimpleNamespace(position=pos_curr), full_location=curr_loc)
+    return SimpleNamespace(previous=prev, state=curr, hits=hits)
+
+
+def test_pingpong_reentry_still_times_out():
+    tc = Timeout()
+    tc.clear()
+    tc.no_progress_timeout = 10
+
+    room_a, room_b = 0x45, 0x35
+    timed_out = False
+    pos = 0
+    # A(in-room) -> A -> B -> A -> B ... each room is the other's next-room.
+    for i in range(200):
+        pos += 1
+        # alternate between an in-room step and a room swap
+        if i % 2 == 0:
+            sc = _sc(room_a, room_a, [room_b], (pos, 0), (pos + 1, 0))
+        else:
+            # swap A<->B; both listed as each other's next-room (re-entry)
+            frm, to = (room_a, room_b) if (i // 2) % 2 == 0 else (room_b, room_a)
+            sc = _sc(frm, to, [to], (pos, 0), (pos + 1, 1))
+        result = tc.is_scenario_ended(sc)
+        if result == (False, True, "failure-no-progress"):
+            timed_out = True
+            break
+
+    assert timed_out, "ping-pong re-entry should eventually time out with failure-no-progress"
+
+
+def test_first_entry_discovery_resets():
+    tc = Timeout()
+    tc.clear()
+    tc.no_progress_timeout = 10
+
+    pos = 0
+    room = 0
+    # Genuine forward discovery: each move enters a brand-new room in the prior room's next_rooms,
+    # with one in-room step between moves. Should never time out within a bounded budget.
+    for i in range(200):
+        pos += 1
+        # in-room step
+        sc = _sc(room, room, [room + 1], (pos, 0), (pos + 1, 0))
+        assert tc.is_scenario_ended(sc) != (False, True, "failure-no-progress")
+        pos += 1
+        # discover new room
+        nxt = room + 1
+        sc = _sc(room, nxt, [nxt], (pos, 0), (pos + 1, 1))
+        assert tc.is_scenario_ended(sc) != (False, True, "failure-no-progress")
+        room = nxt

--- a/tests/test_evaluate_save_results.py
+++ b/tests/test_evaluate_save_results.py
@@ -1,0 +1,20 @@
+# pylint: disable=all
+"""Tests for _save_results loud-failure guards."""
+
+import pytest
+
+from evaluate import _save_results
+
+
+def test_save_results_exits_on_empty_metrics(tmp_path):
+    with pytest.raises(SystemExit) as e:
+        _save_results(str(tmp_path / 'm.pt'), {}, [9] * 100, 11, 100, 'x')
+    assert e.value.code != 0
+    assert not (tmp_path / 'm.eval.json').exists()
+
+
+def test_save_results_exits_on_missing_progress(tmp_path):
+    with pytest.raises(SystemExit) as e:
+        _save_results(str(tmp_path / 'm.pt'), {'success-rate': 0.5}, None, 11, 100, 'x')
+    assert e.value.code != 0
+    assert not (tmp_path / 'm.eval.json').exists()

--- a/train.py
+++ b/train.py
@@ -1303,7 +1303,7 @@ def _run_post_training_eval(model, action_space_def, model_kind, scenario_def, e
     """Runs evaluation episodes after training and prints a progress report."""
     # pylint: disable=import-outside-toplevel
     from rich.progress import Progress
-    from evaluate import evaluate_one_model, print_progress_report
+    from evaluate import DEFAULT_MAX_EPISODE_STEPS, evaluate_one_model, print_progress_report
 
     if console is None:
         console = Console()
@@ -1320,7 +1320,7 @@ def _run_post_training_eval(model, action_space_def, model_kind, scenario_def, e
         def update():
             progress.advance(task)
         _, progress_values, max_progress = evaluate_one_model(
-            create_eval_env, model, episodes, update)
+            create_eval_env, model, episodes, update, DEFAULT_MAX_EPISODE_STEPS)
 
     if progress_values is not None:
         print_progress_report(progress_values, max_progress, episodes, scenario_def.name, metrics=None)

--- a/triforce/end_conditions.py
+++ b/triforce/end_conditions.py
@@ -31,12 +31,14 @@ class Timeout(ZeldaEndCondition):
         super().__init__()
         self.__position_duration = 0
         self.__last_progress = 0
+        self.__entered_rooms = set()
         self.position_timeout = 50
         self.no_progress_timeout = 2000
 
     def clear(self):
         self.__position_duration = 0
         self.__last_progress = 0
+        self.__entered_rooms = set()
 
     def is_scenario_ended(self, state_change : StateChange) -> tuple[bool, bool, str]:
         prev, curr = state_change.previous, state_change.state
@@ -50,7 +52,9 @@ class Timeout(ZeldaEndCondition):
 
         if prev.full_location == curr.full_location:
             self.__last_progress += 1
-        elif curr.full_location in prev.objectives.next_rooms:
+        elif curr.full_location in prev.objectives.next_rooms \
+                and curr.full_location not in self.__entered_rooms:
+            self.__entered_rooms.add(curr.full_location)
             self.__last_progress = 0
 
         if self.__last_progress > self.no_progress_timeout:


### PR DESCRIPTION
Implements tasks **P1** and **P2** from `docs/experiments/dungeon1-completion-plan.md` — both were
blocking (⛔) the EXP6 probe phase.

## P1 — `--combat-trace` mode for `diagnose.py` (commit 1)

The per-step boss-room tracing the experiment5 post-mortem said was missing. General-purpose (any
room, any enemy), following the existing `--infinite-pbrs` pattern.

- `CombatStepRecord` per step: action kind/direction, Link tile/position/health/beams-available,
  `hits`/`damage_dealt`/`health_lost`, `enemies_hit` indices, per-enemy snapshot (id, index, health,
  position, distance, active/stunned/dying), objective kind + `next_rooms`, MOVE action-mask summary,
  full rewards breakdown.
- Per-episode report: exit attribution (step/tile/direction/mask at the room change), attack summary,
  enemies-observed with HP range, damage timeline, nearest-enemy distance percentiles, `--tail` table.
- `--trace-endings` replaces the hardcoded `stuck`/`no-next-room` filter and is shared with
  `--infinite-pbrs`, whose default behavior is unchanged. `--trace-max-episodes` bounds output.

## P2 — bounded evaluations + loud failures (commit 2)

Late-chain evals could run unbounded (one ran 124h before SIGKILL) and some "completed" with no
artifact.

**Root cause:** `Timeout` reset its no-progress clock on *every* entry into a room in
`prev.objectives.next_rooms`, so the `1_45↔1_35` ping-pong in `dungeon1-late-chain` reset the clock
forever and the episode never ended.

- `Timeout` now resets the no-progress clock only on the **first** entry to each next-room per
  episode. Forward discovery still resets; re-entry does not. `failure-stuck` untouched.
- `evaluate.py --max-steps` (default `DEFAULT_MAX_EPISODE_STEPS = 20000`) — cause-agnostic ceiling;
  truncates with a distinct `eval-step-cap` ending recorded through the normal `MetricTracker` path so
  it appears in endings metrics.
- `_save_results` no longer silently no-ops on empty metrics / missing progress metric: stderr +
  nonzero exit, and the JSON is written atomically (tmp + `os.replace`).
- `train.py`'s post-training `--evaluate` path shares the same ceiling.

## Verification

- `pylint triforce/ triforce_debugger/ debug.py evaluate.py train.py record.py diagnose.py` → **10.00/10**
- `pytest tests/ -v` → **783 passed, 1 skipped**
- New: `tests/test_end_conditions_timeout.py` (ping-pong re-entry still times out; fresh discovery
  still resets), `tests/test_evaluate_save_results.py` (both loud-exit paths). Emulator-free.
- **P1 acceptance:** `--combat-trace --trace-endings left-boss-room --episodes 10` on the exp5
  checkpoint → 10/10 traced, every episode `Attacks: 0/N  hits=0  damage_dealt=0`,
  `Aquamentus hp 6..6`, exit via `MOVE/S`.
- **P2 end-to-end:** `dungeon1-late-chain` on exp5-final → 5 episodes in **2m21s** (~28s/ep), exit 0,
  artifact written. Endings: `failure-no-progress 0.2`, `death 0.6`, `wallmastered 0.2`. That
  `failure-no-progress` is the ending that previously could never fire. `eval-step-cap` never
  triggered, so the `Timeout` fix alone resolves the livelock.

## Notes

- `train.py:1322` was a missed callsite of `evaluate_one_model`, caught by pylint `E1120` rather than
  grep — worth remembering when changing `evaluate.py` signatures.
- `eval-step-cap` is deliberately **not** added to any terminal-penalty set; it is an eval-only
  artifact and never a training reward.
- The plan document is updated in commit 3: P1/P2 checked off, index line numbers refreshed, dated
  outcome blocks, and a Decision Log entry.