### PR TITLE
Fix skill frontmatter that fails strict YAML parsing

### DIFF
--- a/.agents/skills/triforce-experiment/SKILL.md
+++ b/.agents/skills/triforce-experiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triforce-experiment
-description: Use when running autonomous Triforce training experiments through OMP: choose experiment scope, launch train.py, handle milestone wake reports, decide continue/stop-edit-restart/finish, compare to baselines, and write final summaries.
+description: Use when running autonomous Triforce training experiments through OMP. Covers choosing experiment scope, launching train.py, handling milestone wake reports, deciding continue/stop-edit-restart/finish, comparing to baselines, and writing final summaries.
 ---
 
 # Triforce Experiment Skill

--- a/.agents/skills/triforce-plan-task/SKILL.md
+++ b/.agents/skills/triforce-plan-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triforce-plan-task
-description: Use when asked to work the next item from a Triforce living plan document — "work on the next proposed experiment", "do the next task", "next item from the table", "continue the dungeon 1 plan", "pick up the next blocking task". Drives one plan task end to end: select it, execute it, decide whether the code lands, PR and merge when green, and check the item off either way.
+description: Use when asked to work the next item from a Triforce living plan document, e.g. 'work on the next proposed experiment', 'do the next task', 'next item from the table', 'continue the dungeon 1 plan', or 'pick up the next blocking task'. Drives one plan task end to end. Selects it, executes it, decides whether the code lands, opens a PR and merges when green, then checks the item off either way.
 ---
 
 # Triforce Plan Task Skill

--- a/tests/test_skill_frontmatter.py
+++ b/tests/test_skill_frontmatter.py
@@ -1,0 +1,70 @@
+# pylint: disable=all
+"""Every agent skill must have frontmatter that parses as strict YAML.
+
+Skill loaders differ in strictness. OMP accepts a malformed plain scalar that
+Copilot rejects outright with "mapping values are not allowed in this context",
+which silently drops the whole skill. Both shipped skills hit this via an
+unquoted ': ' inside the description, so this test parses every skill's
+frontmatter the strict way.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = ROOT / ".agents/skills"
+SKILL_FILES = sorted(SKILL_DIR.glob("*/SKILL.md"))
+
+
+def _split_frontmatter(text):
+    """Return the frontmatter block, delimited by the first two '---' lines."""
+    lines = text.split("\n")
+    assert lines[0].strip() == "---", "SKILL.md must open with a '---' frontmatter delimiter"
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[1:i])
+    raise AssertionError("SKILL.md frontmatter is not closed by a '---' line")
+
+
+def test_skills_are_discovered():
+    # Guard against this whole module silently passing on an empty glob.
+    assert SKILL_FILES, f"no SKILL.md files found under {SKILL_DIR}"
+
+
+@pytest.mark.parametrize("path", SKILL_FILES, ids=lambda p: p.parent.name)
+def test_frontmatter_parses_as_strict_yaml(path):
+    frontmatter = _split_frontmatter(path.read_text(encoding="utf-8"))
+    try:
+        parsed = yaml.safe_load(frontmatter)
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        where = f" at line {mark.line + 2}, column {mark.column + 1}" if mark else ""
+        pytest.fail(
+            f"{path.parent.name}/SKILL.md frontmatter is not valid YAML{where}: "
+            f"{getattr(exc, 'problem', exc)}. The usual cause is an unquoted ': ' "
+            f"(colon followed by a space) inside a plain scalar, which YAML reads as "
+            f"a nested mapping. Rephrase to avoid ': ', or quote the whole value."
+        )
+    assert isinstance(parsed, dict), "frontmatter must be a YAML mapping"
+
+
+@pytest.mark.parametrize("path", SKILL_FILES, ids=lambda p: p.parent.name)
+def test_name_and_description_are_present_and_well_formed(path):
+    parsed = yaml.safe_load(_split_frontmatter(path.read_text(encoding="utf-8")))
+
+    name = parsed.get("name")
+    assert isinstance(name, str) and name.strip(), "frontmatter needs a non-empty 'name'"
+    assert name == path.parent.name, (
+        f"frontmatter name {name!r} must match its directory {path.parent.name!r}"
+    )
+
+    description = parsed.get("description")
+    assert isinstance(description, str) and description.strip(), (
+        "frontmatter needs a non-empty 'description'; it drives skill matching"
+    )
+    # A parsed-but-truncated description means YAML swallowed part of the line.
+    assert description.rstrip().endswith((".", "!")), (
+        f"description looks truncated, ending {description[-40:]!r}"
+    )


### PR DESCRIPTION
`triforce-experiment` and `triforce-plan-task` both failed to load in Copilot with
`mapping values are not allowed in this context` at line 2 — the whole skill gets dropped.

## Cause

An unquoted `': '` (colon followed by a space) inside a plain YAML scalar. YAML reads it as a nested
mapping inside the `description` value.

| Skill | Column | Text |
|---|---:|---|
| `triforce-experiment` | 83 | `...training experiments through OMP: choose experiment scope...` |
| `triforce-plan-task` | 274 | `...Drives one plan task end to end: select it, execute it...` |

Reproduced with `yaml.safe_load`, matching the reported columns exactly (the reported "line 2" is line 3
counting the opening `---`).

`triforce-experiment` has carried this since it was written. `triforce-plan-task` was introduced in
#194 — my regression. OMP's loader is lenient and accepted both, which is why neither surfaced until a
strict parser saw them. `triforce-evaluation` was unaffected.

## Fix

Rephrased both descriptions to remove `': '` rather than quoting the values, so the frontmatter is valid
under any parser without depending on quote-escaping rules (both descriptions also contain quote
characters, which makes wrapping them more fragile than rewording). Meaning and trigger phrasing are
unchanged; all three descriptions now parse and none contains `': '`.

## The real defect

Nothing validated the frontmatter. The existing `test_plan_task_skill_contract.py` only asserted
substrings, which a file that never loads still satisfies.

`tests/test_skill_frontmatter.py` now parses **every** `.agents/skills/*/SKILL.md` frontmatter with
`yaml.safe_load` and asserts:

- it is valid YAML and a mapping, with a failure message naming the `': '` cause and the fix
- `name` is non-empty and matches its directory
- `description` is non-empty and not truncated (a partially-swallowed line still parses)
- the skill glob is non-empty, so the module cannot pass vacuously

Verified against a deliberately broken fixture — it fails as intended rather than being decoration.

## Verification

- `SDL_VIDEODRIVER=dummy QT_QPA_PLATFORM=offscreen pytest` → **801 passed, 1 skipped** (794 prior + 7 new)
- `pylint triforce/ triforce_debugger/ debug.py evaluate.py train.py record.py` → **10.00/10**
- All three skills parse; `': '` absent from every description