### PR TITLE
P5: Gate weighted circuits on primary scenario

### DIFF
--- a/docs/experiments/dungeon1-completion-plan.md
+++ b/docs/experiments/dungeon1-completion-plan.md
@@ -104,51 +104,51 @@ Line numbers refresh via: `grep -n '^### ' docs/experiments/dungeon1-completion-
 | [x] | P2 Fix evaluation hang + silent no-artifact evals | P Tooling | 360 |
 | [ ] | P3 Fix restart crash on completed circuits (train.py:1290) | P Tooling | 446 |
 | [ ] | P4 --compare must compare success-rate | P Tooling | 456 |
-| [ ] ⛔ | P5 Weighted-circuit exit criteria gate on primary scenario | P Tooling | 466 |
-| [ ] | P6 Verify worker metric aggregation under --parallel | P Tooling | 476 |
-| [ ] | P0 Land or discard the experiment5 branch leftovers | P Tooling | 487 |
-| [ ] ⛔ | V1 Empirical root-cause confirmation trace | V Probes | 500 |
-| [ ] ⛔ | V2 Scripted boss-kill probe (beams / bombs / melee) | V Probes | 512 |
-| [ ] | V3 DefeatedBoss false-positive check | V Probes | 535 |
-| [ ] | V4 Trace the hint-mask escape route | V Probes | 547 |
-| [ ] | V5 Fireball dodgeability / beam retention measurement | V Probes | 559 |
-| [ ] | V6 Aquamentus RAM fact sheet | V Probes | 569 |
-| [ ] ⛔ | R1 Terminal parity: leaving the boss room = −20 | R Reward spec | 584 |
-| [ ] ⛔ | R2 Boss-damage rewards, stall reset on hits, boss PBRS scale | R Reward spec | 601 |
-| [ ] ⛔ | R3 FIGHT rooms get route next_rooms (exit semantics) | R Reward spec | 628 |
-| [ ] | R4 Recompute and rebalance the boss-room payoff table | R Reward spec | 650 |
-| [ ] | R5 Split micro-scenarios: kill vs victory-lap | R Reward spec | 664 |
-| [ ] | R6 EXPERIMENT: retrain Aquamentus on the fixed spec | R Reward spec | 678 |
-| [ ] | B1 Demo format: non-MOVE actions | B Demos | 705 |
-| [ ] | B2 Multi-demo support in train.py/ml_ppo.py | B Demos | 719 |
-| [ ] | B3 Acquire a boss-kill demonstration | B Demos | 732 |
-| [ ] | B4 EXPERIMENT: BC + demo-regularized PPO on the boss | B Demos | 744 |
-| [ ] | B5 Value-head warmup after BC | B Demos | 761 |
-| [ ] | C1 Boss-HP reverse curriculum (1hp→2hp→4hp→6hp) | C Curriculum | 775 |
-| [ ] | C2 Mid-fight savestate curriculum | C Curriculum | 793 |
-| [ ] | C3 Invulnerability training wheels (per_frame health) | C Curriculum | 802 |
-| [ ] | C4 Start-state diversity for the boss room | C Curriculum | 818 |
-| [ ] | C5 Victory-lap scenario: post-kill → triforce | C Curriculum | 830 |
-| [ ] | C6 Boss-room action masking of useless items | C Curriculum | 844 |
-| [ ] | S1 Per-head entropy floor / adaptive ent_coef | S Structural | 860 |
-| [ ] | S2 Scope MOVE-only demo-BC loss to the direction head | S Structural | 874 |
-| [ ] | S3 EPOCHS 10→4 and expose LEARNING_RATE | S Structural | 886 |
-| [ ] | S4 Optimizer persistence across circuit legs | S Structural | 896 |
-| [ ] | S5 KL-anchor regularization (fallback to demo-BC) | S Structural | 904 |
-| [ ] | S6 Self-imitation on harvested successes | S Structural | 916 |
-| [ ] | S7 Per-leg ent_coef in circuit YAML | S Structural | 929 |
-| [ ] | S8 Entity distance/vector features (observation) | S Structural | 935 |
-| [ ] | I1 EXPERIMENT: late-chain integration | I Integration | 951 |
-| [ ] | I2 EXPERIMENT: full dungeon 1 | I Integration | 970 |
-| [ ] | I3 EXPERIMENT: full game gate | I Integration | 978 |
-| [ ] | X1 Auto-demo harvesting from scripted policies | X Backlog | 989 |
-| [ ] | X2 Auxiliary boss-HP prediction loss | X Backlog | 994 |
-| [ ] | X3 Sustained-threshold exit criteria | X Backlog | 999 |
-| [ ] | X4 Multi-seed replication harness for micro-scenarios | X Backlog | 1004 |
-| [ ] | X5 Beam-alignment shaping (fired-correctly / didn't-fire) | X Backlog | 1009 |
-| [ ] | X6 Update stale docs (combat-engagement, nes-mechanics boss section) | X Backlog | 1016 |
-| [ ] | X7 Positive-clamp audit for multi-reward kill steps | X Backlog | 1022 |
-| [ ] | X8 Fireball danger shaping (danger tiles / wavefront field) | X Backlog | 1028 |
+| [x] | P5 Weighted-circuit exit criteria gate on primary scenario | P Tooling | 466 |
+| [ ] | P6 Verify worker metric aggregation under --parallel | P Tooling | 508 |
+| [ ] | P0 Land or discard the experiment5 branch leftovers | P Tooling | 519 |
+| [ ] ⛔ | V1 Empirical root-cause confirmation trace | V Probes | 532 |
+| [ ] ⛔ | V2 Scripted boss-kill probe (beams / bombs / melee) | V Probes | 544 |
+| [ ] | V3 DefeatedBoss false-positive check | V Probes | 567 |
+| [ ] | V4 Trace the hint-mask escape route | V Probes | 579 |
+| [ ] | V5 Fireball dodgeability / beam retention measurement | V Probes | 591 |
+| [ ] | V6 Aquamentus RAM fact sheet | V Probes | 601 |
+| [ ] ⛔ | R1 Terminal parity: leaving the boss room = −20 | R Reward spec | 616 |
+| [ ] ⛔ | R2 Boss-damage rewards, stall reset on hits, boss PBRS scale | R Reward spec | 633 |
+| [ ] ⛔ | R3 FIGHT rooms get route next_rooms (exit semantics) | R Reward spec | 660 |
+| [ ] | R4 Recompute and rebalance the boss-room payoff table | R Reward spec | 682 |
+| [ ] | R5 Split micro-scenarios: kill vs victory-lap | R Reward spec | 696 |
+| [ ] | R6 EXPERIMENT: retrain Aquamentus on the fixed spec | R Reward spec | 710 |
+| [ ] | B1 Demo format: non-MOVE actions | B Demos | 737 |
+| [ ] | B2 Multi-demo support in train.py/ml_ppo.py | B Demos | 751 |
+| [ ] | B3 Acquire a boss-kill demonstration | B Demos | 764 |
+| [ ] | B4 EXPERIMENT: BC + demo-regularized PPO on the boss | B Demos | 776 |
+| [ ] | B5 Value-head warmup after BC | B Demos | 793 |
+| [ ] | C1 Boss-HP reverse curriculum (1hp→2hp→4hp→6hp) | C Curriculum | 807 |
+| [ ] | C2 Mid-fight savestate curriculum | C Curriculum | 825 |
+| [ ] | C3 Invulnerability training wheels (per_frame health) | C Curriculum | 834 |
+| [ ] | C4 Start-state diversity for the boss room | C Curriculum | 850 |
+| [ ] | C5 Victory-lap scenario: post-kill → triforce | C Curriculum | 862 |
+| [ ] | C6 Boss-room action masking of useless items | C Curriculum | 876 |
+| [ ] | S1 Per-head entropy floor / adaptive ent_coef | S Structural | 892 |
+| [ ] | S2 Scope MOVE-only demo-BC loss to the direction head | S Structural | 906 |
+| [ ] | S3 EPOCHS 10→4 and expose LEARNING_RATE | S Structural | 918 |
+| [ ] | S4 Optimizer persistence across circuit legs | S Structural | 928 |
+| [ ] | S5 KL-anchor regularization (fallback to demo-BC) | S Structural | 936 |
+| [ ] | S6 Self-imitation on harvested successes | S Structural | 948 |
+| [ ] | S7 Per-leg ent_coef in circuit YAML | S Structural | 961 |
+| [ ] | S8 Entity distance/vector features (observation) | S Structural | 967 |
+| [ ] | I1 EXPERIMENT: late-chain integration | I Integration | 983 |
+| [ ] | I2 EXPERIMENT: full dungeon 1 | I Integration | 1002 |
+| [ ] | I3 EXPERIMENT: full game gate | I Integration | 1010 |
+| [ ] | X1 Auto-demo harvesting from scripted policies | X Backlog | 1021 |
+| [ ] | X2 Auxiliary boss-HP prediction loss | X Backlog | 1026 |
+| [ ] | X3 Sustained-threshold exit criteria | X Backlog | 1031 |
+| [ ] | X4 Multi-seed replication harness for micro-scenarios | X Backlog | 1036 |
+| [ ] | X5 Beam-alignment shaping (fired-correctly / didn't-fire) | X Backlog | 1041 |
+| [ ] | X6 Update stale docs (combat-engagement, nes-mechanics boss section) | X Backlog | 1048 |
+| [ ] | X7 Positive-clamp audit for multi-reward kill steps | X Backlog | 1054 |
+| [ ] | X8 Fireball danger shaping (danger tiles / wavefront field) | X Backlog | 1060 |
 
 **Recommended experiment queue (the spine; everything else supports it):**
 1. **EXP6 (probes, no training):** P1+P2 → V1..V6. Deliverable: empirical root-cause verdict + a scripted boss-kill trace.
@@ -471,7 +471,39 @@ only when the primary scenario's criterion is met (or all criteria, if none mark
 test in `tests/`.
 **Acceptance:** a config test proves a weighted circuit with a primary cannot exit on a non-primary
 metric; existing sequential circuits unaffected.
-**Outcome:** _not attempted_
+**Outcome:** ✅ **DONE 2026-08-04.** Commit `1de1f47` adds validated `primary: true` semantics for
+weighted circuit entries and marks `dungeon1-aquamentus-east` as the primary gate for
+`experiment5-boss-transfer`.
+
+Weighted circuits with a primary now pass only that scenario's exit criterion to PPO. Circuits
+without a primary preserve the existing all-configured-criteria behavior. Validation rejects multiple
+primaries, a primary without exit criteria, and `primary` on sequential entries. Parent-level exit
+criteria target the configured primary instead of implicitly targeting the first scenario.
+
+**Numbers:**
+
+| Proof | Result |
+|---|---:|
+| Focused weighted/config tests | 28 passed |
+| Full test suite | 804 passed, 1 skipped, 8 deselected |
+| Pylint | 10.00/10 |
+| Real exp5-checkpoint smoke run | 4,096 weighted trainer steps, exit 0 |
+| Criteria passed to PPO for `experiment5-boss-transfer` | 1: `dungeon1-aquamentus-east/success-rate >= 0.6` |
+| Non-primary criteria passed to PPO | 0 |
+
+Smoke artifact:
+`/home/leculver/.copilot/session-state/11df117b-6401-4911-a29e-0d8dbffd1ce4/files/p5-smoke/experiment5-boss-transfer/0/impala-multihead_all-items.pt`.
+
+**Verdict:** a weighted circuit with `primary: true` cannot exit on a non-primary metric; P5's
+acceptance criteria are met.
+
+**What the next agent must know:**
+1. Add `primary: true` only when one scenario should control completion; omitting it deliberately
+   requires all configured exit criteria.
+2. `experiment5-boss-transfer` now gates on Aquamentus, so a wallmaster-only success can no longer
+   reproduce exp5's false completion.
+3. P5 unblocks future weighted training structurally, but Phase R remains mandatory before R6; this
+   change does not repair the boss reward specification.
 
 ### P6. Verify worker metric aggregation under --parallel
 **Goal:** `docs/recommendations.md` item 2 claims worker MetricTracker data is not aggregated — exit

--- a/tests/test_experiment5_config.py
+++ b/tests/test_experiment5_config.py
@@ -15,6 +15,7 @@ def test_experiment5_weighted_circuit_loads():
         "dungeon1-late-chain",
     ]
     assert [entry.weight for entry in circuit.scenarios] == [10, 80, 10]
+    assert [entry.primary for entry in circuit.scenarios] == [False, True, False]
     assert [entry.exit_criteria.metric for entry in circuit.scenarios] == ["success-rate"] * 3
     assert [entry.exit_criteria.threshold for entry in circuit.scenarios] == [0.8, 0.6, 0.1]
 

--- a/tests/test_weighted_circuits.py
+++ b/tests/test_weighted_circuits.py
@@ -10,6 +10,7 @@ Tests:
 
 import pytest
 
+from train import _get_circuit_exit_criteria
 from triforce.scenario_wrapper import (
     ExitCriteria, TrainingCircuitEntry, TrainingCircuitDefinition,
     WeightedScenarioSelector, TrainingScenarioDefinition,
@@ -52,6 +53,10 @@ class TestExitCriteria:
     def test_circuit_entry_with_weight(self):
         entry = TrainingCircuitEntry(scenario='full-game', weight=70.0)
         assert entry.weight == 70.0
+
+    def test_circuit_entry_with_primary(self):
+        entry = TrainingCircuitEntry(scenario='full-game', weight=70.0, primary=True)
+        assert entry.primary is True
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +113,51 @@ class TestCircuitKind:
         assert first.exit_criteria is not None
         assert first.exit_criteria.metric == 'room-result/correct-exit'
         assert first.exit_criteria.threshold == 0.9
+
+    def test_experiment5_primary_controls_embedded_exit_criteria(self):
+        """A weighted circuit reports and gates on its designated primary scenario."""
+        circuit = TrainingCircuitDefinition.get('experiment5-boss-transfer')
+        parent_entry = TrainingCircuitEntry(circuit=circuit.name)
+
+        criteria, scenario = _get_circuit_exit_criteria(parent_entry, circuit)
+
+        assert scenario == 'dungeon1-aquamentus-east'
+        assert criteria.metric == 'success-rate'
+        assert criteria.threshold == 0.6
+
+    def test_primary_metric_map_excludes_non_primary_criteria(self, monkeypatch, tmp_path):
+        """A non-primary threshold cannot stop a weighted training leg."""
+        circuit = TrainingCircuitDefinition.get('experiment5-boss-transfer')
+        captured = {}
+
+        class FakePpo:
+            optimizer = None
+
+            def train_weighted(self, _network_class, _create_env, _scenario_defs, _weights,
+                               _actions, _iterations, exit_criteria_map, _callback, **_kwargs):
+                captured.update(exit_criteria_map)
+                raise RuntimeError("captured")
+
+        class FakeModelKind:
+            name = 'fake-model'
+            network_class = object
+
+        class FakeActionSpace:
+            name = 'fake-actions'
+            actions = 'fake-actions'
+
+        monkeypatch.setattr(
+            TrainingScenarioDefinition, 'get',
+            staticmethod(lambda name: type('Scenario', (), {'name': name, 'iterations': 100})()))
+
+        from train import _run_weighted_circuit
+
+        with pytest.raises(RuntimeError, match="captured"):
+            _run_weighted_circuit(
+                FakePpo(), circuit, FakeModelKind(), FakeActionSpace(), str(tmp_path),
+                {}, 100, callback=None)
+
+        assert list(captured) == ['dungeon1-aquamentus-east']
 
 
 # ---------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -882,9 +882,12 @@ def _get_circuit_exit_criteria(scenario_entry, sub_circuit_def):
     """
     ec = scenario_entry.exit_criteria
     if ec is not None:
-        return ec, None
+        primary_entry = next((entry for entry in sub_circuit_def.scenarios if entry.primary), None)
+        owner = primary_entry or sub_circuit_def.scenarios[0]
+        return ec, owner.scenario
 
-    for sub_entry in sub_circuit_def.scenarios:
+    ordered_entries = sorted(sub_circuit_def.scenarios, key=lambda entry: not entry.primary)
+    for sub_entry in ordered_entries:
         if sub_entry.exit_criteria:
             return sub_entry.exit_criteria, sub_entry.scenario
     return None, None
@@ -1112,12 +1115,16 @@ def _run_weighted_circuit(ppo, circuit_def, model_kind, action_space_def, checkp
     All scenarios run concurrently with step-count proportional to their weights.
     The WeightedScenarioSelector (via RPC) decides which scenario each worker runs on reset.
     outer_exit_criteria: ExitCriteria from the parent sequential entry. When provided, overrides
-    inner entry exit criteria — applied to the first (primary) scenario.
+    inner entry exit criteria and applies to the designated primary scenario, or the first scenario
+    when no primary is configured.
     """
     # Resolve scenario definitions and weights
     scenario_defs = []
     weights = []
     exit_criteria_map = {}
+
+    primary_entry = next((entry for entry in circuit_def.scenarios if entry.primary), None)
+    criteria_entries = [primary_entry] if primary_entry else circuit_def.scenarios
 
     for entry in circuit_def.scenarios:
         sdef = TrainingScenarioDefinition.get(entry.scenario)
@@ -1125,12 +1132,13 @@ def _run_weighted_circuit(ppo, circuit_def, model_kind, action_space_def, checkp
             raise ValueError(f"Unknown scenario: {entry.scenario}")
         scenario_defs.append(sdef)
         weights.append(entry.weight)
-        if entry.exit_criteria:
+        if entry in criteria_entries and entry.exit_criteria:
             exit_criteria_map[entry.scenario] = entry.exit_criteria
 
-    # Outer exit criteria overrides inner — applied to the first (primary) scenario
+    # Outer exit criteria overrides inner and targets the configured primary scenario.
     if outer_exit_criteria and scenario_defs:
-        exit_criteria_map = {scenario_defs[0].name: outer_exit_criteria}
+        target_entry = primary_entry or circuit_def.scenarios[0]
+        exit_criteria_map = {target_entry.scenario: outer_exit_criteria}
 
     # Determine iteration budget
     if total_budget is not None:

--- a/triforce/scenario_wrapper.py
+++ b/triforce/scenario_wrapper.py
@@ -144,6 +144,7 @@ class TrainingCircuitEntry(BaseModel):
     iterations : Optional[int] = None
     exit_criteria : Optional[ExitCriteria] = Field(None, alias='exit-criteria')
     weight : Optional[float] = None
+    primary : bool = False
 
 class TrainingCircuitDefinition(BaseModel):
     """A training circuit."""
@@ -182,17 +183,29 @@ class TrainingCircuitDefinition(BaseModel):
 
                 # Validate weight fields match circuit kind
                 if circuit.kind == 'weighted':
+                    primary_entries = [entry for entry in circuit.scenarios if entry.primary]
+                    if len(primary_entries) > 1:
+                        raise ValueError(f"Weighted circuit '{circuit.name}' must not have more than "
+                                         "one primary entry")
                     for entry in circuit.scenarios:
                         if entry.weight is None:
                             name = entry.scenario or entry.circuit
                             raise ValueError(f"Weighted circuit '{circuit.name}' entry "
                                              f"'{name}' must have a weight")
+                        if entry.primary and entry.exit_criteria is None:
+                            name = entry.scenario or entry.circuit
+                            raise ValueError(f"Weighted circuit '{circuit.name}' primary entry "
+                                             f"'{name}' must have exit criteria")
                 else:
                     for entry in circuit.scenarios:
                         if entry.weight is not None:
                             name = entry.scenario or entry.circuit
                             raise ValueError(f"Sequential circuit '{circuit.name}' entry "
                                              f"'{name}' must not have a weight")
+                        if entry.primary:
+                            name = entry.scenario or entry.circuit
+                            raise ValueError(f"Sequential circuit '{circuit.name}' entry "
+                                             f"'{name}' must not be primary")
 
                 circuits[circuit.name] = circuit
 

--- a/triforce/triforce.yaml
+++ b/triforce/triforce.yaml
@@ -247,6 +247,7 @@ training-circuits:
       threshold: 0.8
   - scenario: dungeon1-aquamentus-east
     weight: 80
+    primary: true
     exit-criteria:
       metric: success-rate
       threshold: 0.6


### PR DESCRIPTION
Implements plan task P5 from `docs/experiments/dungeon1-completion-plan.md`.

## Changes
- Add validated `primary: true` support to weighted circuit entries.
- Gate weighted-leg completion only on the primary scenario when configured; preserve all-criteria behavior otherwise.
- Target parent overrides and callback reporting at the primary scenario.
- Mark `dungeon1-aquamentus-east` primary in `experiment5-boss-transfer`.
- Record P5 as complete and refresh plan index line numbers.

## Verification
- `pytest tests/test_weighted_circuits.py tests/test_experiment5_config.py -q`: 28 passed.
- Full `pytest -q`: 804 passed, 1 skipped, 8 deselected.
- `pylint triforce/ triforce_debugger/ debug.py evaluate.py train.py record.py`: 10.00/10.
- Real Experiment 5 checkpoint smoke run: 4,096 weighted trainer steps, exit 0.
- Test capture proves PPO receives only `dungeon1-aquamentus-east/success-rate >= 0.6`; non-primary criteria count is 0.

The short smoke run exposed the existing rollout quantum (a requested 1,024-step budget executes 4,096 trainer steps); this PR does not change that unrelated behavior.